### PR TITLE
ci: Publish a databuilder image

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -9,6 +9,7 @@ jobs:
     if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     runs-on: ubuntu-latest
     env:
+      image: ghcr.io/opensafely-core/databuilder
       ce_image: ghcr.io/opensafely-core/cohortextractor-v2
     steps:
       - uses: actions/checkout@v2
@@ -18,14 +19,16 @@ jobs:
         run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
 
       - name: Build image
-        run: docker build . --file Dockerfile --tag ${{ env.ce_image }}:latest
+        run: docker build . --file Dockerfile --tag ${{ env.image }}:latest --tag ${{ env.ce_image }}:latest
 
       - name: Log into GitHub Container Registry
         run: docker login https://ghcr.io -u ${{ github.actor }} --password ${{ secrets.DOCKER_RW_TOKEN }}
 
-      - name: Push image to GitHub Container Registry
+      - name: Push images to GitHub Container Registry
         env:
           VERSION: ${{ steps.tags.outputs.tag }}
         run: |
+          docker tag ${{ env.image }} ${{ env.image }}:$VERSION
           docker tag ${{ env.ce_image }} ${{ env.ce_image }}:$VERSION
+          docker push ${{ env.image }}:$VERSION
           docker push ${{ env.ce_image }}:$VERSION

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -14,21 +14,21 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Get current git tag
-        id: tags
-        run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
-
+      # This relies on the tag having a version of the form vX.Y.Z
       - name: Build image
-        run: docker build . --file Dockerfile --tag ${{ env.image }}:latest --tag ${{ env.ce_image }}:latest
+        run: |
+          PATCH="${GITHUB_REF#refs/*/}"
+          MAJOR="${PATCH%%.*}"
+          MINOR="${PATCH%.*}"
+          docker build . --file Dockerfile \
+            --tag ${{ env.image }}:$MAJOR --tag ${{ env.ce_image }}:$MAJOR \
+            --tag ${{ env.image }}:$MINOR --tag ${{ env.ce_image }}:$MINOR \
+            --tag ${{ env.image }}:$PATCH --tag ${{ env.ce_image }}:$PATCH
 
       - name: Log into GitHub Container Registry
         run: docker login https://ghcr.io -u ${{ github.actor }} --password ${{ secrets.DOCKER_RW_TOKEN }}
 
       - name: Push images to GitHub Container Registry
-        env:
-          VERSION: ${{ steps.tags.outputs.tag }}
         run: |
-          docker tag ${{ env.image }} ${{ env.image }}:$VERSION
-          docker tag ${{ env.ce_image }} ${{ env.ce_image }}:$VERSION
-          docker push ${{ env.image }}:$VERSION
-          docker push ${{ env.ce_image }}:$VERSION
+          docker push --all-tags ${{ env.image }}
+          docker push --all-tags ${{ env.ce_image }}

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -9,7 +9,7 @@ jobs:
     if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     runs-on: ubuntu-latest
     env:
-      image: ghcr.io/opensafely-core/cohortextractor-v2
+      ce_image: ghcr.io/opensafely-core/cohortextractor-v2
     steps:
       - uses: actions/checkout@v2
 
@@ -18,7 +18,7 @@ jobs:
         run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
 
       - name: Build image
-        run: docker build . --file Dockerfile --tag ${{ env.image }}:latest
+        run: docker build . --file Dockerfile --tag ${{ env.ce_image }}:latest
 
       - name: Log into GitHub Container Registry
         run: docker login https://ghcr.io -u ${{ github.actor }} --password ${{ secrets.DOCKER_RW_TOKEN }}
@@ -27,5 +27,5 @@ jobs:
         env:
           VERSION: ${{ steps.tags.outputs.tag }}
         run: |
-          docker tag ${{ env.image }} ${{ env.image }}:$VERSION
-          docker push ${{ env.image }}:$VERSION
+          docker tag ${{ env.ce_image }} ${{ env.ce_image }}:$VERSION
+          docker push ${{ env.ce_image }}:$VERSION

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -20,6 +20,11 @@ jobs:
           PATCH="${GITHUB_REF#refs/*/}"
           MAJOR="${PATCH%%.*}"
           MINOR="${PATCH%.*}"
+
+          echo "MAJOR=$MAJOR"
+          echo "MINOR=$MINOR"
+          echo "PATCH=$PATCH"
+
           docker build . --file Dockerfile \
             --tag ${{ env.image }}:$MAJOR --tag ${{ env.ce_image }}:$MAJOR \
             --tag ${{ env.image }}:$MINOR --tag ${{ env.ce_image }}:$MINOR \


### PR DESCRIPTION
For now, this retains the existing cohortextractor-v2 image while publishing a databuilder image.

We also publish both images with a `vX`, `vX.Y` and `vX.Y.Z` for a Git tag of `vX.Y.Z`

The databuilder image won't yet be usable anywhere because job-runner and opensafely-cli (which vendors job-runner) need updating to permit the new image name. See https://github.com/opensafely-core/job-runner/pull/324