### PR TITLE
fix: Trigger builds of new releases on merge to main

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -3,11 +3,11 @@ name: Build and publish image
 on:
   create:
   workflow_dispatch:
-  # Nb: workflow_run only triggers on the default branch
-  # https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#workflow_run
   workflow_run:
     workflows:
       - CI
+    branches:
+      - main
     status:
       - completed
 

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -3,16 +3,36 @@ name: Build and publish image
 on:
   create:
   workflow_dispatch:
+  # Nb: workflow_run only triggers on the default branch
+  # https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#workflow_run
+  workflow_run:
+    workflows:
+      - CI
+    status:
+      - completed
 
 jobs:
   build-and-publish-docker-image:
-    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     runs-on: ubuntu-latest
     env:
       image: ghcr.io/opensafely-core/databuilder
       ce_image: ghcr.io/opensafely-core/cohortextractor-v2
     steps:
       - uses: actions/checkout@v2
+
+      - name: 'Get Previous tag'
+        id: previoustagref
+        uses: "WyriHaximus/github-action-get-previous-tag@8a0e045f02c0a3a04e1452df58b90fc7e555e950"
+
+      - name:
+        id: previoustagcommit
+        # if we are on a tag, should look like `v0.6.0`
+        # if we are not on a tag, should look like `v0.6.0-24-gbf6352d`
+        run: echo ::set-output name=tag_describe::`git describe --tags`
+
+      - name: Fail if not tagged commit
+        if: ${{ steps.previoustagcommit.outputs.tag_describe != steps.previoustagref.outputs.tag }}
+        run: /bin/false
 
       # This relies on the tag having a version of the form vX.Y.Z
       - name: Build image

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -34,6 +34,11 @@ jobs:
         if: ${{ steps.previoustagcommit.outputs.tag_describe != steps.previoustagref.outputs.tag }}
         run: /bin/false
 
+      # 'Get Previous tag' should only get version tags, but let's verify that
+      - name: Fail if not a version tag
+        if: ${{ startsWith(steps.previoustagref.outputs.tag, 'v') }}
+        run: /bin/false
+
       # This relies on the tag having a version of the form vX.Y.Z
       - name: Build image
         run: |


### PR DESCRIPTION
* A successful CI run on main will trigger the build-and-deploy workflow via the `workflow_run` target
* build-and-deploy can also be triggered by manually tagging & pushing via the `create` target
* We only run build-and-deploy if the most recent version tag points to the current commit
* Ideally we would also do some verification of which package versions have already been built & deployed, but despite lots of digging this does not appear to be possible right now