### PR TITLE
Update Patients table stub

### DIFF
--- a/databuilder/concepts/tables.py
+++ b/databuilder/concepts/tables.py
@@ -27,7 +27,7 @@ class Patients(PatientFrame):
     date_of_birth = DateColumn("date_of_birth")
 
     def __init__(self):
-        super().__init__(Table("patients"))
+        super().__init__(Table("patients").first_by("patient_id"))
 
 
 class PracticeRegistrations(EventFrame):

--- a/tests/lib/mock_backend.py
+++ b/tests/lib/mock_backend.py
@@ -2,7 +2,10 @@ import sqlalchemy
 import sqlalchemy.orm
 
 from databuilder.backends.base import BaseBackend, Column, MappedTable, QueryTable
+from databuilder.dsl import Column as DSLColumn
+from databuilder.dsl import DateColumn, IdColumn, IntColumn, PatientFrame
 from databuilder.query_engines.mssql import MssqlQueryEngine
+from databuilder.query_language import Table
 
 
 def backend_factory(query_engine_cls):
@@ -139,3 +142,17 @@ def patient(patient_id, *entities, height=None, dob=None, sex="M"):
     for entity in entities:
         entity.PatientId = patient_id
     return [Patients(PatientId=patient_id, Height=height, DateOfBirth=dob), *entities]
+
+
+class MockPatients(PatientFrame):
+    """
+    A PatientFrame instance that can be used with mock backends
+    """
+
+    patient_id = IdColumn("patient_id")
+    height = IntColumn("height")
+    date_of_birth = DateColumn("date_of_birth")
+    sex = DSLColumn("sex")
+
+    def __init__(self):
+        super().__init__(Table("patients").first_by("patient_id"))


### PR DESCRIPTION
This updates the Patients table stub so it's initialised with the `Row` that it expects.  This will need to change later, but for now it lets us use the patients table in tests with the new DSL.

Also adds a mock Patients table that can be used with the mock backend patients table, and a starting rewritten query engine test