### PR TITLE
Fix container names and update Justfile

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -124,13 +124,13 @@ build-databuilder:
     [[ -v CI ]] && echo "::endgroup::" || echo ""
 
 
-# tear down the persistent databuilder-mssql docker container and network
-remove-persistent-database:
+# tear down the persistent docker containers we create to run tests again
+remove-database-containers:
     docker rm --force databuilder-mssql
-    docker network rm databuilder-network
+    docker rm --force databuilder-spark
 
-# open an interactive SQL Server shell running against the persistent database
-connect-to-persistent-database:
+# open an interactive SQL Server shell running against MSSQL
+connect-to-mssql:
     docker exec -it databuilder-mssql /opt/mssql-tools/bin/sqlcmd -S localhost -U SA -P 'Your_password123!'
 
 # Full set of tests run by CI

--- a/tests/lib/databases.py
+++ b/tests/lib/databases.py
@@ -132,7 +132,7 @@ def wait_for_database(database, timeout=10):
 def make_database(containers):
     password = "Your_password123!"
 
-    container_name = "cohort-extractor-mssql"
+    container_name = "databuilder-mssql"
     mssql_port = 1433
 
     if not containers.is_running(container_name):  # pragma: no cover
@@ -181,7 +181,7 @@ def make_spark_database(containers):
 
 
 def make_spark_container_database(containers):
-    container_name = "cohort-extractor-spark"
+    container_name = "databuilder-spark"
     # This is the default anyway, but better to be explicit
     spark_port = 10001
 


### PR DESCRIPTION
**Note:** this change will leave you with stale containers locally which you'll have to manually remove with:
```
docker rm -f cohort-extractor-mssql cohort-extractor-spark
```

Changes are:
 * Use `databuilder-` instead of `cohort-extractor-` as container prefix.
 * We no longer create a docker network, so don't try to remove it.
 * We do create a Spark container so need to remove that too.
 * We no longer have ephemeral containers so doesn't make much sense to
   refer to these as persistent containers.
 * We have more than one database, so the command name should show which
   one we're connecting to.