### PR TITLE
Prevent equality comparison between column and codelist

### DIFF
--- a/databuilder/query_language.py
+++ b/databuilder/query_language.py
@@ -154,6 +154,14 @@ class BaseTable(QueryNode):
             # convert a between filter into its two components
             return self.filter(*args, on_or_after=value[0], on_or_before=value[1])
 
+        if operator in ("equals", "not_equals") and isinstance(
+            value, (Codelist, Column)
+        ):
+            raise TypeError(
+                f"You can only use '{operator}' to filter a column by a single value.\n"
+                f"To filter using a {value.__class__.__name__}, use 'is_in/not_in'."
+            )
+
         if operator == "is_in" and not isinstance(value, (Codelist, Column)):
             # convert non-codelist in values to tuple
             value = tuple(value)

--- a/tests/acceptance/test_full_long_covid_study.py
+++ b/tests/acceptance/test_full_long_covid_study.py
@@ -118,7 +118,10 @@ class Cohort:
     # Clinical variables
     # Latest recorded BMI
     _bmi_value = (
-        table("clinical_events").filter(code=bmi_code).latest().get("numeric_value")
+        table("clinical_events")
+        .filter("code", is_in=bmi_code)
+        .latest()
+        .get("numeric_value")
     )
     _bmi_groups = {
         "Obese I (30-34.9)": (_bmi_value >= 30) & (_bmi_value < 35),

--- a/tests/acceptance/test_full_long_covid_study_dsl.py
+++ b/tests/acceptance/test_full_long_covid_study_dsl.py
@@ -217,9 +217,9 @@ def build_cohort():
 # in pyproject.toml
 @pytest.mark.xfail
 @pytest.mark.integration
-def test_cohort(database, setup_backend_database):
+def test_cohort(database):
     cohort = build_cohort()
-    setup_backend_database(
+    database.setup(
         organisation(organisation_id=1, region="South"),
         patient(
             1,

--- a/tests/fixtures/end_to_end_tests_measures/measures_cohort.py
+++ b/tests/fixtures/end_to_end_tests_measures/measures_cohort.py
@@ -6,9 +6,9 @@ class Cohort:
     _registrations = table("practice_registrations")
     population = _registrations.exists()
     practice = _registrations.first_by("patient_id").get("pseudo_id")
-    has_event = _clinical_events.filter(code=codelist(["abc"], system="ctv3")).first_by(
-        "patient_id"
-    )
+    has_event = _clinical_events.filter(
+        "code", is_in=codelist(["abc"], system="ctv3")
+    ).first_by("patient_id")
 
     measures = [
         Measure(

--- a/tests/fixtures/end_to_end_tests_measures/measures_not_specified_cohort.py
+++ b/tests/fixtures/end_to_end_tests_measures/measures_not_specified_cohort.py
@@ -6,6 +6,6 @@ class Cohort:
     _registrations = table("practice_registrations")
     population = _registrations.exists()
     practice = _registrations.first_by("patient_id").get("pseudo_id")
-    has_event = _clinical_events.filter(code=codelist(["abc"], system="ctv3")).first_by(
-        "patient_id"
-    )
+    has_event = _clinical_events.filter(
+        "code", is_in=codelist(["abc"], system="ctv3")
+    ).first_by("patient_id")

--- a/tests/fixtures/end_to_end_tests_measures_with_index_date_range/measures_date_range_cohort.py
+++ b/tests/fixtures/end_to_end_tests_measures_with_index_date_range/measures_date_range_cohort.py
@@ -10,7 +10,7 @@ def cohort(index_date):
         population = _registrations.exists()
         practice = _registrations.first_by("patient_id").get("pseudo_id")
         has_event = _clinical_events.filter(
-            code=codelist(["abc"], system="ctv3")
+            "code", is_in=codelist(["abc"], system="ctv3")
         ).first_by("patient_id")
 
         measures = [

--- a/tests/test_codelists.py
+++ b/tests/test_codelists.py
@@ -58,9 +58,6 @@ def test_codelist_query(engine):
 
 @pytest.mark.integration
 def test_codelist_equals_query(engine):
-    if engine.name == "spark":
-        pytest.xfail()
-
     input_data = [
         patient(1, ctv3_event(code="abc", date="2021-01-01")),
         patient(2, ctv3_event(code="bar", date="2021-01-01")),

--- a/tests/test_codelists.py
+++ b/tests/test_codelists.py
@@ -72,7 +72,12 @@ def test_codelist_equals_query(engine):
     test_codelist = codelist(["abc"], system="ctv3")
 
     class Cohort(OldCohortWithPopulation):
-        code = table("clinical_events").filter(code=test_codelist).latest().get("code")
+        code = (
+            table("clinical_events")
+            .filter("code", is_in=test_codelist)
+            .latest()
+            .get("code")
+        )
 
     result = engine.extract(Cohort)
     assert result == [

--- a/tests/test_query_engine.py
+++ b/tests/test_query_engine.py
@@ -682,8 +682,10 @@ def test_not_in_filter_on_query_values(engine):
             "sum",
             "result",
             [
-                dict(patient_id=1, value=20.6),
-                dict(patient_id=2, value=50.1),
+                # Due to the usual floating point shennanigans we don't always get
+                # _exactly_ the result we're expecting here, depending on the database
+                dict(patient_id=1, value=pytest.approx(20.6)),
+                dict(patient_id=2, value=pytest.approx(50.1)),
                 dict(patient_id=3, value=None),
             ],
         ),

--- a/tests/test_query_engine.py
+++ b/tests/test_query_engine.py
@@ -359,15 +359,7 @@ def test_run_generated_sql_get_single_row_per_patient(
         "test multiple chained filters",
     ],
 )
-def test_simple_filters(engine, data, filtered_table, expected, request):
-    if request.node.callspec.id in [
-        "spark-test single equals filter",
-        "spark-test multiple equals filter",
-        "spark-test not equals filter",
-        "spark-test multiple chained filters",
-    ]:
-        pytest.xfail()
-
+def test_simple_filters(engine, data, filtered_table, expected):
     engine.setup(data)
 
     class Cohort:
@@ -565,9 +557,6 @@ def test_date_in_range_filter(engine):
 
 
 def test_in_filter_on_query_values(engine):
-    if engine.name == "spark":
-        pytest.xfail()
-
     # set up input data for 2 patients, with positive test dates and clinical event results
     input_data = [
         patient(
@@ -702,9 +691,6 @@ def test_not_in_filter_on_query_values(engine):
     ids=[],
 )
 def test_aggregation(engine, aggregation, column, expected):
-    if engine.name == "spark":
-        pytest.xfail()
-
     input_data = [
         patient(
             1,
@@ -898,9 +884,6 @@ def test_categorise_nested_comparisons(engine):
 
 def test_categorise_on_truthiness(engine):
     """Test truthiness of a Value from an exists aggregation"""
-    if engine.name == "spark":
-        pytest.xfail()
-
     input_data = [
         patient(1, ctv3_event("abc")),
         patient(2, ctv3_event("xyz")),
@@ -1256,9 +1239,6 @@ def test_fetching_results_using_temporary_database(engine):
 
 
 def test_dsl_code_comparisons(cohort_with_population, engine):
-    if engine.name == "spark":
-        pytest.xfail()
-
     input_data = [
         patient(1, ctv3_event("abc")),
         patient(2, ctv3_event("abc")),
@@ -1297,9 +1277,6 @@ def test_dsl_date_comparisons(cohort_with_population, engine):
     here to let us make boolean values against which to match the PatientSeries
     values.
     """
-    if engine.name == "spark":
-        pytest.xfail()
-
     input_data = [
         patient(1, ctv3_event("abc", "2019-12-31")),
         patient(2, ctv3_event("abc", "2020-02-29")),

--- a/tests/test_query_engine_dsl.py
+++ b/tests/test_query_engine_dsl.py
@@ -9,9 +9,6 @@ pytestmark = pytest.mark.integration
 
 
 def test_categorise_simple_comparisons(engine, cohort_with_population):
-    if engine.name == "spark":
-        pytest.xfail()
-
     input_data = [patient(1, height=180), patient(2, height=200.5), patient(3)]
     engine.setup(input_data)
 

--- a/tests/test_query_language.py
+++ b/tests/test_query_language.py
@@ -16,6 +16,23 @@ from databuilder.query_utils import get_column_definitions
 from .lib.util import OldCohortWithPopulation, make_codelist
 
 
+def test_cannot_use_equals_with_codelist_or_columns():
+    test_codelist = make_codelist("abc")
+    all_codes = table("clinical_events").get("codes")
+
+    msg_eq = "You can only use 'equals' to filter a column by a single value"
+    with pytest.raises(TypeError, match=msg_eq):
+        table("clinical_events").filter(code=test_codelist)
+    with pytest.raises(TypeError, match=msg_eq):
+        table("clinical_events").filter(code=all_codes)
+
+    msg_ne = "You can only use 'not_equals' to filter a column by a single value"
+    with pytest.raises(TypeError, match=msg_ne):
+        table("clinical_events").filter("code", not_equals=test_codelist)
+    with pytest.raises(TypeError, match=msg_ne):
+        table("clinical_events").filter("code", not_equals=all_codes)
+
+
 def test_comparator_logical_comparisons_not_handled_directly():
     msg = "Invalid operation; cannot perform logical operations on a Comparator"
 

--- a/tests/test_validate_dummy_data.py
+++ b/tests/test_validate_dummy_data.py
@@ -19,7 +19,7 @@ fixtures_path = Path(__file__).parent / "fixtures" / "dummy_data"
 class Cohort:
     population = table("practice_registations").exists()
     sex = table("patients").latest().get("sex")
-    _code = table("clinical_events").filter(code__in=cl)
+    _code = table("clinical_events").filter("code", is_in=cl)
     has_event = _code.exists()
     event_date = _code.latest().get("date")
     event_count = _code.count("code")
@@ -93,7 +93,7 @@ def test_validate_dummy_data_with_categories(
 ):
     class CohortWithCategories:
         population = table("practice_registations").exists()
-        _code = table("clinical_events").filter(code__in=cl)
+        _code = table("clinical_events").filter("code", is_in=cl)
         event_date = _code.latest().get("date")
         _categories = {
             1: event_date == "2021-01-01",


### PR DESCRIPTION
This turned out to be the source of the SQL errors in #250. This PR adds a check to prevent doing this and updates all the test cases to use `is_in` instead of `equals`.

Closes #250