### PR TITLE
chore: set a prefix on dependabot commit messages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,5 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 20
+    commit-message:
+      prefix: "chore: "


### PR DESCRIPTION
This should mean dependabot PRs don't fail CI because of the semantic commit check.