### PR TITLE
Increase coverage

### DIFF
--- a/databuilder/query_language.py
+++ b/databuilder/query_language.py
@@ -379,16 +379,14 @@ def categorise(mapping, default=None):
 
 @dataclass(frozen=True, eq=False, order=False)
 class ValueFromCategory(Value):
-    definitions: Any
-    default: Any
+    definitions: dict
+    default: str | int | float | None
 
     def _get_referenced_nodes(self):
         nodes = ()
         for value in self.definitions.values():
             if isinstance(value, QueryNode):
                 nodes += (value,)
-        if isinstance(self.default, QueryNode):
-            nodes += (self.default,)
         return nodes
 
 

--- a/databuilder/query_language.py
+++ b/databuilder/query_language.py
@@ -385,8 +385,8 @@ class ValueFromCategory(Value):
     def _get_referenced_nodes(self):
         nodes = ()
         for value in self.definitions.values():
-            if isinstance(value, QueryNode):
-                nodes += (value,)
+            assert isinstance(value, QueryNode)
+            nodes += (value,)
         return nodes
 
 

--- a/databuilder/query_language.py
+++ b/databuilder/query_language.py
@@ -60,8 +60,8 @@ class Comparator(QueryNode):
 
     def _get_referenced_nodes(self):
         nodes = ()
-        if isinstance(self.lhs, QueryNode):
-            nodes += (self.lhs,)
+        assert isinstance(self.lhs, QueryNode)
+        nodes += (self.lhs,)
         if isinstance(self.rhs, QueryNode):
             nodes += (self.rhs,)
         return nodes

--- a/databuilder/validate_dummy_data.py
+++ b/databuilder/validate_dummy_data.py
@@ -108,9 +108,8 @@ def get_csv_validator(query_node):
         """Ensure that a category value is one of the expected categories, or the default"""
         # The default must be either None, or of the same type as the categories
         category_type = type(categories[0])
-        if value is not None:
-            value = category_type(value)
-
+        # None values are skipped in validate_column_values() above, so no need to check for None here
+        value = category_type(value)
         if not (value == default_category or value in categories):
             raise ValueError
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ omit = [
 ]
 
 [tool.coverage.report]
-fail_under = 99.4
+fail_under = 99.7
 skip_covered = true
 exclude_lines = [
     # this is the default, but has to be included explicitly now we specify exclude_lines

--- a/tests/lib/databases.py
+++ b/tests/lib/databases.py
@@ -109,10 +109,6 @@ class DbDetails:
         session.commit()
 
 
-def null_database():
-    return DbDetails(None, None, None, None, None, None)
-
-
 def wait_for_database(database, timeout=10):
     engine = database.engine()
 

--- a/tests/lib/databricks_schema.py
+++ b/tests/lib/databricks_schema.py
@@ -72,7 +72,8 @@ def _get_schemas(base):
     for mapper in base.registry.mappers:
         table_args = getattr(mapper.class_, "__table_args__", {})
         schema = table_args.get("schema")
-        if schema:
+        # currently all test tables are set up with an explicit schema
+        if schema:  # pragma: no cover
             schemas.add(schema)
     return schemas
 

--- a/tests/test_codelists.py
+++ b/tests/test_codelists.py
@@ -225,3 +225,16 @@ def test_codelist_query_with_codelist_from_csv(engine, codelist_csv):
         {"patient_id": 2, "code": None},
         {"patient_id": 3, "code": None},
     ]
+
+
+def test_codelist_repr():
+    codes = [ch for ch in "abcdefghijklmnopqrstuvwxyz"]
+    codelist1 = codelist(codes[:5], system="ctv3")
+    assert repr(codelist1) == "Codelist(system=ctv3, codes=('a', 'b', 'c', 'd', 'e'))"
+
+    codelist2 = codelist(codes[:6], system="ctv3")
+    codelist3 = codelist(codes, system="ctv3")
+    for cl in [codelist2, codelist3]:
+        assert (
+            repr(cl) == "Codelist(system=ctv3, codes=('a', 'b', 'c', 'd', 'e', '...'))"
+        )

--- a/tests/test_dsl.py
+++ b/tests/test_dsl.py
@@ -313,6 +313,19 @@ def test_population_required():
     get_column_definitions(data_definition)
 
 
+def test_patient_series_repr():
+    registrations = tables.registrations
+    series = (
+        registrations.sort_by(registrations.date_end)
+        .first_for_patient()
+        .select_column(registrations.date_start)
+    )
+    assert (
+        repr(series)
+        == "PatientSeries(value=ValueFromRow(source=Row(source=Table(name='practice_registrations'), sort_columns=('date_end',), descending=False), column='date_start'))"
+    )
+
+
 def assert_cohorts_equivalent(dsl_cohort, qm_cohort):
     """Verify that a cohort defined via Query Model objects has the same columns as a
     cohort defined via the DSL.

--- a/tests/test_dsl.py
+++ b/tests/test_dsl.py
@@ -303,6 +303,16 @@ def test_add_variable():
     assert_cohorts_equivalent(cohort1, cohort2)
 
 
+def test_population_required():
+    data_definition = Cohort()
+
+    with pytest.raises(ValueError, match="must define a 'population' variable"):
+        get_column_definitions(data_definition)
+
+    data_definition.set_population(tables.registrations.exists_for_patient())
+    get_column_definitions(data_definition)
+
+
 def assert_cohorts_equivalent(dsl_cohort, qm_cohort):
     """Verify that a cohort defined via Query Model objects has the same columns as a
     cohort defined via the DSL.

--- a/tests/test_functools_utils.py
+++ b/tests/test_functools_utils.py
@@ -1,5 +1,7 @@
 from typing import Union
 
+import pytest
+
 from databuilder.functools_utils import singledispatchmethod_with_unions
 
 
@@ -30,3 +32,6 @@ def test_singledispatchmethod_with_unions():
     assert test_obj.method(A()) == "a_or_b"
     assert test_obj.method(B()) == "a_or_b"
     assert test_obj.method(C()) == "c"
+    # can only call the decorated method with an expected type
+    with pytest.raises(TypeError):
+        test_obj.method(1)

--- a/tests/test_query_engine_dsl.py
+++ b/tests/test_query_engine_dsl.py
@@ -28,3 +28,26 @@ def test_categorise_simple_comparisons(engine, cohort_with_population):
         dict(patient_id=2, height_group="tall"),
         dict(patient_id=3, height_group="missing"),
     ]
+
+
+def test_comparator_order(engine, cohort_with_population):
+    """Test that comparison operators work on both sides of the comparator"""
+    input_data = [patient(1, height=180), patient(2, height=200.5), patient(3)]
+    engine.setup(input_data)
+
+    patients = MockPatients()
+    height = patients.select_column(patients.height)
+    height_categories = {
+        "tall": 190 < height,
+        "short": 190 >= height,
+    }
+    height_group = categorise(height_categories, default="missing")
+    cohort = cohort_with_population
+    cohort.height_group = height_group
+
+    result = engine.extract(cohort)
+    assert result == [
+        dict(patient_id=1, height_group="short"),
+        dict(patient_id=2, height_group="tall"),
+        dict(patient_id=3, height_group="missing"),
+    ]

--- a/tests/test_validate_dummy_data.py
+++ b/tests/test_validate_dummy_data.py
@@ -3,6 +3,8 @@ from pathlib import Path
 import pytest
 
 from databuilder import categorise, codelist, table
+from databuilder.concepts import tables
+from databuilder.dsl import categorise as new_dsl_categorise
 from databuilder.validate_dummy_data import (
     SUPPORTED_FILE_FORMATS,
     DummyDataValidationError,
@@ -101,9 +103,9 @@ def test_validate_dummy_data_with_categories(
         category = categorise(_categories, default=default_value)
 
     rows = zip(
-        ["patient_id", "11", "22", "33"],
-        ["event_date", "2021-01-01", "2021-01-01", "2021-01-01"],
-        ["category", 1, default_value, "foo"],
+        ["patient_id", "11", "22", "33", "44"],
+        ["event_date", "2021-01-01", "2021-01-01", "2021-01-01", "2021-01-01"],
+        ["category", None, 1, default_value, "foo"],
     )
 
     dummy_data_file = Path(tmpdir) / "dummy-data.csv"
@@ -113,3 +115,56 @@ def test_validate_dummy_data_with_categories(
         match=f"Invalid value `'{first_invalid_value}'` for category",
     ):
         validate_dummy_data(CohortWithCategories, dummy_data_file, Path("output.csv"))
+
+
+def test_valid_dummy_data_with_categories_dsl(tmpdir, cohort_with_population):
+    data_definition = cohort_with_population
+    events = tables.clinical_events
+    event_date = (
+        events.sort_by(events.date).last_for_patient().select_column(events.date)
+    )
+    categories = {1: event_date == "2021-01-01"}
+    data_definition.event_date = event_date
+    data_definition.category = new_dsl_categorise(categories, default=-9)
+
+    rows = zip(
+        ["patient_id", "11", "22", "33"],
+        ["event_date", "2021-01-01", "2021-01-01", "2021-01-01"],
+        ["category", None, 1, -9],
+    )
+
+    dummy_data_file = Path(tmpdir) / "dummy-data.csv"
+    write_rows_to_csv(rows, dummy_data_file)
+    assert (
+        validate_dummy_data(data_definition, dummy_data_file, Path("output.csv"))
+        is None
+    )
+
+
+def test_validate_categories_values_must_be_valid_category(
+    tmpdir, cohort_with_population
+):
+    data_definition = cohort_with_population
+    events = tables.clinical_events
+    event_date = (
+        events.sort_by(events.date).last_for_patient().select_column(events.date)
+    )
+    categories = {"has event": event_date == "2021-01-01"}
+    data_definition.event_date = event_date
+    data_definition.category = new_dsl_categorise(categories, default="missing")
+
+    rows = zip(
+        ["patient_id", "11", "22", "33", "44"],
+        ["event_date", "2021-01-01", "2021-01-01", None, None],
+        ["category", None, "has event", "missing", "no event"],
+    )
+
+    dummy_data_file = Path(tmpdir) / "dummy-data.csv"
+    write_rows_to_csv(rows, dummy_data_file)
+
+    # All category values are valid type; only defined categories or the default are allowed
+    with pytest.raises(
+        DummyDataValidationError,
+        match="Invalid value `'no event'` for category",
+    ):
+        validate_dummy_data(data_definition, dummy_data_file, Path("output.csv"))


### PR DESCRIPTION
Add tests and remove some unused code for the easy wins to increase coverage.  Coverage is now up to 99.73%, and the remaining uncovered code is mostly in query engines - I think some of those are probably OK to mark as no-cover, but leaving them for people who know more about it than I do
```
Name                                         Stmts   Miss Branch BrPart  Cover   Missing
----------------------------------------------------------------------------------------
databuilder/query_engines/base_sql.py          231      2     62      0    99%   108, 235
databuilder/query_engines/mssql_dialect.py      33      1      8      1    95%   22
databuilder/query_engines/mssql_lib.py         140      5     28      3    95%   222->exit, 249, 297, 313-315
databuilder/query_engines/spark_dialect.py      50      0      2      1    98%   248->250
tests/lib/databases.py                          79      1     12      0    99%   75
----------------------------------------------------------------------------------------
TOTAL                                         4524      9    622      5    99%
```