### PR TITLE
Introduce date arithmetic (subtraction in years) on dateseries

### DIFF
--- a/databuilder/dsl.py
+++ b/databuilder/dsl.py
@@ -52,6 +52,7 @@ from .query_model import (
     BaseTable,
     Codelist,
     Comparator,
+    DateDifference,
     RoundToFirstOfMonth,
     RoundToFirstOfYear,
     Row,
@@ -327,6 +328,22 @@ class DateSeries(PatientSeries):
 
     def round_to_first_of_year(self) -> DateSeries:
         return DateSeries(RoundToFirstOfYear(self.value))
+
+    def __sub__(self, other: str | DateSeries) -> DateDeltaSeries:
+        if isinstance(other, DateSeries):
+            other = other.value
+        return DateDeltaSeries(DateDifference(other, self.value))
+
+    def __rsub__(self, other: str | DateSeries) -> DateDeltaSeries:
+        if isinstance(other, DateSeries):
+            other = other.value
+        return DateDeltaSeries(DateDifference(self.value, other))
+
+
+class DateDeltaSeries(PatientSeries):
+    def convert_to_years(self):
+        start_date, end_date = self.value.arguments[:2]
+        return IntSeries(DateDifference(start_date, end_date, units="years"))
 
 
 class IdSeries(PatientSeries):

--- a/databuilder/dsl.py
+++ b/databuilder/dsl.py
@@ -310,36 +310,32 @@ def _validate_datestring(datestring):
         raise ValueError(
             f"{datestring} is not a valid date; date must in YYYY-MM-DD format"
         )
+    return datestring
 
 
 class DateSeries(PatientSeries):
     @staticmethod
-    def _get_other_for_arithmetic(other):
-        if isinstance(other, DateSeries):
-            other = other.value
-        else:
-            _validate_datestring(other)
-        return other
+    def _get_other_value(other):
+        return (
+            other.value
+            if isinstance(other, DateSeries)
+            else _validate_datestring(other)
+        )
 
     def __gt__(self, other: DateSeries | str) -> BoolSeries:
-        other_value = other.value if isinstance(other, DateSeries) else other
-        return BoolSeries(value=self.value > other_value)
+        return BoolSeries(value=self.value > self._get_other_value(other))
 
     def __ge__(self, other: DateSeries | str) -> BoolSeries:
-        other_value = other.value if isinstance(other, DateSeries) else other
-        return BoolSeries(value=self.value >= other_value)
+        return BoolSeries(value=self.value >= self._get_other_value(other))
 
     def __lt__(self, other: DateSeries | str) -> BoolSeries:
-        other_value = other.value if isinstance(other, DateSeries) else other
-        return BoolSeries(value=self.value < other_value)
+        return BoolSeries(value=self.value < self._get_other_value(other))
 
     def __le__(self, other: DateSeries | str) -> BoolSeries:
-        other_value = other.value if isinstance(other, DateSeries) else other
-        return BoolSeries(value=self.value <= other_value)
+        return BoolSeries(value=self.value <= self._get_other_value(other))
 
     def __ne__(self, other: DateSeries | str) -> BoolSeries:  # type: ignore[override]
-        other_value = other.value if isinstance(other, DateSeries) else other
-        return BoolSeries(value=self.value != other_value)
+        return BoolSeries(value=self.value != self._get_other_value(other))
 
     def round_to_first_of_month(self) -> DateSeries:
         return DateSeries(RoundToFirstOfMonth(self.value))
@@ -348,12 +344,10 @@ class DateSeries(PatientSeries):
         return DateSeries(RoundToFirstOfYear(self.value))
 
     def __sub__(self, other: str | DateSeries) -> DateDeltaSeries:
-        other = self._get_other_for_arithmetic(other)
-        return DateDeltaSeries(DateDifference(other, self.value))
+        return DateDeltaSeries(DateDifference(self._get_other_value(other), self.value))
 
     def __rsub__(self, other: str | DateSeries) -> DateDeltaSeries:
-        other = self._get_other_for_arithmetic(other)
-        return DateDeltaSeries(DateDifference(self.value, other))
+        return DateDeltaSeries(DateDifference(self.value, self._get_other_value(other)))
 
 
 class DateDeltaSeries(PatientSeries):

--- a/databuilder/query_model.py
+++ b/databuilder/query_model.py
@@ -254,8 +254,10 @@ class Table(BaseTable):
             raise NotImplementedError(
                 "This method is only available on the patients table"
             )
-        return DateDifferenceInYears(
-            self.first_by("patient_id").get("date_of_birth"), reference_date
+        return DateDifference(
+            self.first_by("patient_id").get("date_of_birth"),
+            reference_date,
+            units="years",
         )
 
 
@@ -423,10 +425,6 @@ class ValueFromFunction(Value):
 class DateDifference(ValueFromFunction):
     def __init__(self, start, end, units="years"):
         super().__init__(start, end, units)
-
-
-class DateDifferenceInYears(ValueFromFunction):
-    pass
 
 
 class RoundToFirstOfMonth(ValueFromFunction):

--- a/databuilder/query_model.py
+++ b/databuilder/query_model.py
@@ -420,6 +420,11 @@ class ValueFromFunction(Value):
         return tuple(arg for arg in self.arguments if isinstance(arg, QueryNode))
 
 
+class DateDifference(ValueFromFunction):
+    def __init__(self, start, end, units="years"):
+        super().__init__(start, end, units)
+
+
 class DateDifferenceInYears(ValueFromFunction):
     pass
 


### PR DESCRIPTION
This introduces the minimal initial date arithmetic, to replace the `age_as_of` function with a more generic date subtraction, returned in years.