### PR TITLE
Convert DateDeltaSeries to days and weeks

### DIFF
--- a/databuilder/dsl.py
+++ b/databuilder/dsl.py
@@ -363,6 +363,10 @@ class DateDeltaSeries(PatientSeries):
         start_date, end_date = self.value.arguments[:2]
         return IntSeries(DateDifference(start_date, end_date, units="days"))
 
+    def convert_to_weeks(self):
+        start_date, end_date = self.value.arguments[:2]
+        return IntSeries(DateDifference(start_date, end_date, units="weeks"))
+
 
 class IdSeries(PatientSeries):
     pass

--- a/databuilder/dsl.py
+++ b/databuilder/dsl.py
@@ -351,21 +351,21 @@ class DateSeries(PatientSeries):
 
 
 class DateDeltaSeries(PatientSeries):
-    def convert_to_years(self):
+    def _convert(self, units):
         start_date, end_date = self.value.arguments[:2]
-        return IntSeries(DateDifference(start_date, end_date, units="years"))
+        return IntSeries(DateDifference(start_date, end_date, units=units))
+
+    def convert_to_years(self):
+        return self._convert("years")
 
     def convert_to_months(self):
-        start_date, end_date = self.value.arguments[:2]
-        return IntSeries(DateDifference(start_date, end_date, units="months"))
+        return self._convert("months")
 
     def convert_to_days(self):
-        start_date, end_date = self.value.arguments[:2]
-        return IntSeries(DateDifference(start_date, end_date, units="days"))
+        return self._convert("days")
 
     def convert_to_weeks(self):
-        start_date, end_date = self.value.arguments[:2]
-        return IntSeries(DateDifference(start_date, end_date, units="weeks"))
+        return self._convert("weeks")
 
 
 class IdSeries(PatientSeries):

--- a/databuilder/dsl.py
+++ b/databuilder/dsl.py
@@ -359,6 +359,10 @@ class DateDeltaSeries(PatientSeries):
         start_date, end_date = self.value.arguments[:2]
         return IntSeries(DateDifference(start_date, end_date, units="months"))
 
+    def convert_to_days(self):
+        start_date, end_date = self.value.arguments[:2]
+        return IntSeries(DateDifference(start_date, end_date, units="days"))
+
 
 class IdSeries(PatientSeries):
     pass

--- a/databuilder/query_engines/base_sql.py
+++ b/databuilder/query_engines/base_sql.py
@@ -446,29 +446,26 @@ class BaseSQLQueryEngine(BaseQueryEngine):
         start_date = type_coerce(start_date, sqlalchemy_types.Date())
         end_date = type_coerce(end_date, sqlalchemy_types.Date())
 
-        # We do the arithmetic ourselves, to be portable across dbs.
-        start = (
-            sqlalchemy.func.year(start_date),
-            sqlalchemy.func.month(start_date),
-            sqlalchemy.func.day(start_date),
-        )
-        end = (
-            sqlalchemy.func.year(end_date),
-            sqlalchemy.func.month(end_date),
-            sqlalchemy.func.day(end_date),
-        )
-
         unit_conversions = {
             "years": self._convert_date_diff_to_years,
             "months": self._convert_date_diff_to_months,
             "days": self._convert_date_diff_to_days,
             "weeks": self._convert_date_diff_to_weeks,
         }
-        return unit_conversions[units](start, end)
+        return unit_conversions[units](start_date, end_date)
+
+    @staticmethod
+    def _date_to_parts(date):
+        return (
+            sqlalchemy.func.year(date),
+            sqlalchemy.func.month(date),
+            sqlalchemy.func.day(date),
+        )
 
     def _convert_date_diff_to_years(self, start, end):
-        start_year, start_month, start_day = start
-        end_year, end_month, end_day = end
+        # We do the arithmetic ourselves, to be portable across dbs.
+        start_year, start_month, start_day = self._date_to_parts(start)
+        end_year, end_month, end_day = self._date_to_parts(end)
         year_diff = end_year - start_year
         date_diff = sqlalchemy.case(
             (end_month > start_month, year_diff),
@@ -481,8 +478,8 @@ class BaseSQLQueryEngine(BaseQueryEngine):
         return type_coerce(date_diff, sqlalchemy_types.Integer())
 
     def _convert_date_diff_to_months(self, start, end):
-        start_year, start_month, start_day = start
-        end_year, end_month, end_day = end
+        start_year, start_month, start_day = self._date_to_parts(start)
+        end_year, end_month, end_day = self._date_to_parts(end)
         year_diff = end_year - start_year
 
         date_diff = sqlalchemy.case(
@@ -494,50 +491,19 @@ class BaseSQLQueryEngine(BaseQueryEngine):
         )
         return type_coerce(date_diff, sqlalchemy_types.Integer())
 
-    @staticmethod
-    def _julian_days(year, month, day):
-        """
-        convert to julian days (days since 1 January 4713 BCE) in the Gregorian calendar
-        see https://www.tondering.dk/claus/cal/julperiod.php
-        """
-        a = sqlalchemy.func.floor((14 - month) / 12)
-        y = year + 4800 - a
-        m = month + 12 * a - 3
-        return (
-            day
-            + sqlalchemy.func.floor((153 * m + 2) / 5)
-            + 365 * y
-            + sqlalchemy.func.floor(y / 4)
-            - sqlalchemy.func.floor(y / 100)
-            + sqlalchemy.func.floor(y / 400)
-            - 32045
-        )
-
     def _convert_date_diff_to_days(self, start, end):
         """
-        Calculate days diff by converting both dates to julian days and subtracting
+        Calculate difference between dates in days
         """
-        start_year, start_month, start_day = start
-        end_year, end_month, end_day = end
-        date_diff = self._julian_days(end_year, end_month, end_day) - self._julian_days(
-            start_year, start_month, start_day
-        )
-        return type_coerce(date_diff, sqlalchemy_types.Integer())
+        raise NotImplementedError()
 
     def _convert_date_diff_to_weeks(self, start, end):
         """
-        Calculate weeks diff by converting both dates to julian days and subtracting
+        Calculate difference in weeks
+        Datediff calculates weeks by boundaries crossed.  Since we want the duration in total
+        number of whole weeks, use the days calculation to calculate weeks also.
         """
-        start_year, start_month, start_day = start
-        end_year, end_month, end_day = end
-        date_diff = sqlalchemy.func.floor(
-            (
-                self._julian_days(end_year, end_month, end_day)
-                - self._julian_days(start_year, start_month, start_day)
-            )
-            / 7
-        )
-        return type_coerce(date_diff, sqlalchemy_types.Integer())
+        return sqlalchemy.func.floor(self._convert_date_diff_to_days(start, end) / 7)
 
     def round_to_first_of_month(self, date):
         raise NotImplementedError

--- a/databuilder/query_engines/base_sql.py
+++ b/databuilder/query_engines/base_sql.py
@@ -462,6 +462,7 @@ class BaseSQLQueryEngine(BaseQueryEngine):
             "years": self._convert_date_diff_to_years,
             "months": self._convert_date_diff_to_months,
             "days": self._convert_date_diff_to_days,
+            "weeks": self._convert_date_diff_to_weeks,
         }
         return unit_conversions[units](start, end)
 
@@ -520,6 +521,21 @@ class BaseSQLQueryEngine(BaseQueryEngine):
         end_year, end_month, end_day = end
         date_diff = self._julian_days(end_year, end_month, end_day) - self._julian_days(
             start_year, start_month, start_day
+        )
+        return type_coerce(date_diff, sqlalchemy_types.Integer())
+
+    def _convert_date_diff_to_weeks(self, start, end):
+        """
+        Calculate weeks diff by converting both dates to julian days and subtracting
+        """
+        start_year, start_month, start_day = start
+        end_year, end_month, end_day = end
+        date_diff = sqlalchemy.func.floor(
+            (
+                self._julian_days(end_year, end_month, end_day)
+                - self._julian_days(start_year, start_month, start_day)
+            )
+            / 7
         )
         return type_coerce(date_diff, sqlalchemy_types.Integer())
 

--- a/databuilder/query_engines/mssql.py
+++ b/databuilder/query_engines/mssql.py
@@ -78,6 +78,12 @@ class MssqlQueryEngine(BaseSQLQueryEngine):
             with super().execute_query() as results:
                 yield results
 
+    def _convert_date_diff_to_days(self, start, end):
+        """
+        Calculate difference in days
+        """
+        return sqlalchemy.func.datediff(sqlalchemy.text("day"), start, end)
+
     def round_to_first_of_month(self, date):
         date = type_coerce(date, sqlalchemy_types.Date())
 

--- a/databuilder/query_engines/spark.py
+++ b/databuilder/query_engines/spark.py
@@ -59,6 +59,20 @@ class SparkQueryEngine(BaseSQLQueryEngine):
     def get_temp_database(self):
         return self.backend.temporary_database
 
+    def _convert_date_diff_to_days(self, start, end):
+        """
+        Calculate difference in days
+        The sparkSQL datediff function only calculate diff in days, and take the
+        parameters in the order (end, start)
+        """
+        return sqlalchemy.func.datediff(end, start)
+
+    def _convert_date_diff_to_weeks(self, start, end):
+        """
+        Calculate difference in weeks
+        """
+        return sqlalchemy.func.floor(self._convert_date_diff_to_days(start, end) / 7)
+
     def round_to_first_of_month(self, date):
         date = type_coerce(date, sqlalchemy_types.Date())
 

--- a/databuilder/query_engines/spark.py
+++ b/databuilder/query_engines/spark.py
@@ -67,12 +67,6 @@ class SparkQueryEngine(BaseSQLQueryEngine):
         """
         return sqlalchemy.func.datediff(end, start)
 
-    def _convert_date_diff_to_weeks(self, start, end):
-        """
-        Calculate difference in weeks
-        """
-        return sqlalchemy.func.floor(self._convert_date_diff_to_days(start, end) / 7)
-
     def round_to_first_of_month(self, date):
         date = type_coerce(date, sqlalchemy_types.Date())
 

--- a/tests/test_query_engine_dsl.py
+++ b/tests/test_query_engine_dsl.py
@@ -309,7 +309,7 @@ def test_date_arithmetic_conversions(engine, cohort_with_population):
     "current_date,age_data",
     [
         (
-            "2021-09-02",  # end month > 2
+            "2021-09-02",
             {
                 1: dict(dob="2021-09-01", age=1),  # 1 day
                 2: dict(dob="2021-01-15", age=230),
@@ -320,7 +320,7 @@ def test_date_arithmetic_conversions(engine, cohort_with_population):
             },
         ),
         (
-            "2020-01-10",  # end month < 2
+            "2020-01-10",
             {
                 1: dict(dob="2020-01-01", age=9),
                 2: dict(dob="2019-12-20", age=21),  # across year boundary
@@ -330,7 +330,7 @@ def test_date_arithmetic_conversions(engine, cohort_with_population):
             },
         ),
         (
-            "1922-02-01",  # end month == 2
+            "1922-02-01",
             {
                 1: dict(dob="1921-02-01", age=365),  # 1 yr, start month == 2
                 2: dict(
@@ -369,7 +369,7 @@ def test_date_arithmetic_convert_to_days(
 
 def test_date_arithmetic_convert_to_weeks(engine, cohort_with_population):
     input_data = [
-        # all dobs are subtracted from 2021-03-01, rounded down
+        # all dobs are subtracted from 2021-03-02, rounded down
         patient(1, dob="2021-02-26"),  # 5 days
         patient(2, dob="2021-02-16"),  # exactly 2 weeks
         patient(3, dob="2021-02-03"),  # 3 weeks, 6 days

--- a/tests/test_query_engine_dsl.py
+++ b/tests/test_query_engine_dsl.py
@@ -303,3 +303,65 @@ def test_date_arithmetic_conversions(engine, cohort_with_population):
         {"patient_id": 8, "age_in_years": 9, "age_in_months": 119},
         {"patient_id": 9, "age_in_years": 9, "age_in_months": 118},
     ]
+
+
+@pytest.mark.parametrize(
+    "current_date,age_data",
+    [
+        (
+            "2021-09-02",  # end month > 2
+            {
+                1: dict(dob="2021-09-01", age=1),  # 1 day
+                2: dict(dob="2021-01-15", age=230),
+                # 16 in Jan, 28 in Feb, 31 Mar/May/Jul/Aug, 30 Apr/Jun, 2 in Sep; start month <2
+                3: dict(
+                    dob="2019-09-02", age=731
+                ),  # one leap year and one non-leap year
+            },
+        ),
+        (
+            "2020-01-10",  # end month < 2
+            {
+                1: dict(dob="2020-01-01", age=9),
+                2: dict(dob="2019-12-20", age=21),  # across year boundary
+                3: dict(
+                    dob="1999-01-10", age=7670
+                ),  # 16 non leap yrs, 5 leap yrs (2000/4/8/12/16)
+            },
+        ),
+        (
+            "1922-02-01",  # end month == 2
+            {
+                1: dict(dob="1921-02-01", age=365),  # 1 yr, start month == 2
+                2: dict(
+                    dob="1921-08-20", age=165
+                ),  # 11 days Aug, 30 Sep/Nov, 31 Oct/Dec/Jan, 1 Feb
+                3: dict(
+                    dob="1899-01-31", age=8401
+                ),  # 18 non leap, 5 leap yrs (1904/8/12/16/20) + 1 day; (1900 != leap)
+            },
+        ),
+    ],
+)
+def test_date_arithmetic_convert_to_days(
+    engine, cohort_with_population, current_date, age_data
+):
+    input_data = [
+        # all dobs are subtracted from current_date, rounded down
+        patient(patient_id, dob=patient_data["dob"])
+        for patient_id, patient_data in age_data.items()
+    ]
+    engine.setup(input_data)
+
+    patients = tables.patients
+    data_definition = cohort_with_population
+    dob = patients.select_column(patients.date_of_birth)  # DateSeries
+    age = current_date - dob
+
+    data_definition.age_in_days = age.convert_to_days()
+
+    result = engine.extract(data_definition)
+    assert result == [
+        {"patient_id": patient_id, "age_in_days": patient_data["age"]}
+        for patient_id, patient_data in age_data.items()
+    ]


### PR DESCRIPTION
[sc-418]
Calculate differences between dates in days and weeks.

This uses the database-specific `datediff` function (which differs in use between spark and mssql) to calculate the days difference between dates.  It uses the same days difference calculation to calculate the number of full weeks between the two dates.  `datediff` with an interval of "week" (which is only possible in the mssql version of datediff) calculates boundaries crossed rather than full weeks.  

Initially (see the first commit in this PR) I used Julian days to do the date difference calculations in days in a way that could be database agnostic.  This worked, and would mean that we could do the calculations the same way across dbs without using custom db methods, as we do for years and months.  However, it makes for very complex (and I'd assume inefficient) SQL and I think it's better to use the functions available in the dbs backing individual query engines.  If in some future engine we have a db with no `datediff` equivalent, we could reconsider the julian days version.