### PR TITLE
Add and subtract datedeltas to/from DateSeries

### DIFF
--- a/databuilder/dsl.py
+++ b/databuilder/dsl.py
@@ -405,11 +405,11 @@ class DateDeltaSeries(PatientSeries):
     def convert_to_weeks(self):
         return self._convert("weeks")
 
-    def __rsub__(self, other: str) -> DateDeltaSeries:
+    def __rsub__(self, other: str) -> DateSeries:
         datestring = _validate_datestring(other)
         # This allows subtraction of a DateDeltaSeries from a date string
         # e.g. 2020-10-01
-        return DateDeltaSeries(DateSubtraction(datestring, self.convert_to_days()))
+        return DateSeries(DateSubtraction(datestring, self.convert_to_days()))
 
 
 class IdSeries(PatientSeries):

--- a/databuilder/dsl.py
+++ b/databuilder/dsl.py
@@ -388,7 +388,8 @@ class DateSeries(PatientSeries):
         return DateSeries(DateAddition(self.value, other_value))
 
     def __radd__(self, other: DateDeltaSeries | int) -> DateSeries:
-        return self + other
+        other_value = self._get_other_datedelta_value(other, "add")
+        return DateSeries(DateAddition(other_value, self.value))
 
 
 class DateDeltaSeries(PatientSeries):
@@ -422,7 +423,9 @@ class DateDeltaSeries(PatientSeries):
             return datedelta.convert_to_days()
         return datedelta
 
-    def __add__(self, other: DateDeltaSeries | int) -> DateDeltaSeries:
+    def __add__(
+        self, other: DateDeltaSeries | DateSeries | int
+    ) -> DateDeltaSeries | DateSeries:
         # Adding a DateSeries to a DateDeltaSeries should use DateSeries.__add__ to
         # return a new DateSeries
         if isinstance(other, DateSeries):
@@ -431,7 +434,7 @@ class DateDeltaSeries(PatientSeries):
             DateDeltaAddition(self._delta_in_days(self), self._delta_in_days(other))
         )
 
-    def __radd__(self, other: DateDeltaSeries | int) -> DateDeltaSeries:
+    def __radd__(self, other: DateSeries | int) -> DateDeltaSeries | DateSeries:
         return self + other
 
     def __sub__(self, other: DateDeltaSeries | int) -> DateDeltaSeries:
@@ -439,7 +442,9 @@ class DateDeltaSeries(PatientSeries):
             DateDeltaSubtraction(self._delta_in_days(self), self._delta_in_days(other))
         )
 
-    def __rsub__(self, other: str | DateDeltaSeries | int) -> DateSeries:
+    def __rsub__(
+        self, other: str | DateDeltaSeries | int
+    ) -> DateSeries | DateDeltaSeries:
         if isinstance(other, str):
             datestring = _validate_datestring(other)
             # This allows subtraction of a DateDeltaSeries from a date string

--- a/databuilder/dsl.py
+++ b/databuilder/dsl.py
@@ -350,7 +350,9 @@ class DateSeries(PatientSeries):
     @staticmethod
     def _get_other_datedelta_value(delta_value, operation):
         """Ensure we have either a simple int, or an IntSeries representing a date difference in days"""
-        if isinstance(delta_value, DateDeltaSeries):
+        if isinstance(delta_value, DateDeltaSeries) and isinstance(
+            delta_value.value, DateDifference
+        ):
             return delta_value.convert_to_days()
         elif isinstance(delta_value, int):
             return delta_value
@@ -386,10 +388,6 @@ class DateSeries(PatientSeries):
     def __add__(self, other: DateDeltaSeries | int) -> DateSeries:
         other_value = self._get_other_datedelta_value(other, "add")
         return DateSeries(DateAddition(self.value, other_value))
-
-    def __radd__(self, other: DateDeltaSeries | int) -> DateSeries:
-        other_value = self._get_other_datedelta_value(other, "add")
-        return DateSeries(DateAddition(other_value, self.value))
 
 
 class DateDeltaSeries(PatientSeries):

--- a/databuilder/dsl.py
+++ b/databuilder/dsl.py
@@ -389,6 +389,10 @@ class DateSeries(PatientSeries):
         other_value = self._get_other_datedelta_value(other, "add")
         return DateSeries(DateAddition(self.value, other_value))
 
+    def __radd__(self, other: int) -> DateSeries:
+        # Note that other cannot be a DateDeltaSeries, as this is handled by DateDeltaSeries.__add__
+        return self + other
+
 
 class DateDeltaSeries(PatientSeries):
     def _convert(self, units):
@@ -432,7 +436,8 @@ class DateDeltaSeries(PatientSeries):
             DateDeltaAddition(self._delta_in_days(self), self._delta_in_days(other))
         )
 
-    def __radd__(self, other: DateSeries | int) -> DateDeltaSeries | DateSeries:
+    def __radd__(self, other: int) -> DateDeltaSeries | DateSeries:
+        # Note that other cannot be a DateSeries, as this is handled by DateSeries.__add__
         return self + other
 
     def __sub__(self, other: DateDeltaSeries | int) -> DateDeltaSeries:
@@ -443,6 +448,7 @@ class DateDeltaSeries(PatientSeries):
     def __rsub__(
         self, other: str | DateDeltaSeries | int
     ) -> DateSeries | DateDeltaSeries:
+        # Note that other cannot be a DateSeries, as this is handled by DateSeries.__sub__
         if isinstance(other, str):
             datestring = _validate_datestring(other)
             # This allows subtraction of a DateDeltaSeries from a date string

--- a/databuilder/query_engines/base_sql.py
+++ b/databuilder/query_engines/base_sql.py
@@ -68,6 +68,7 @@ from ..query_model import (
     Column,
     Comparator,
     DateAddition,
+    DateDeltaAddition,
     DateDifference,
     DateSubtraction,
     FilteredTable,
@@ -434,6 +435,7 @@ class BaseSQLQueryEngine(BaseQueryEngine):
             DateDifference: self.date_difference,
             DateAddition: self.date_add,
             DateSubtraction: self.date_subtract,
+            DateDeltaAddition: self.date_delta_add,
             RoundToFirstOfMonth: self.round_to_first_of_month,
             RoundToFirstOfYear: self.round_to_first_of_year,
         }
@@ -529,6 +531,11 @@ class BaseSQLQueryEngine(BaseQueryEngine):
         number_of_days: an IntSeries with a DateDifference value in days or an integer representing a numer of days
         """
         raise NotImplementedError()
+
+    def date_delta_add(self, delta1, delta2):
+        delta1 = self._get_number_of_days_for_query(delta1)
+        delta2 = self._get_number_of_days_for_query(delta2)
+        return type_coerce((delta1 + delta2), sqlalchemy_types.Integer())
 
     def round_to_first_of_month(self, date):
         raise NotImplementedError

--- a/databuilder/query_engines/base_sql.py
+++ b/databuilder/query_engines/base_sql.py
@@ -67,6 +67,7 @@ from ..query_model import (
     Codelist,
     Column,
     Comparator,
+    DateAddition,
     DateDifference,
     FilteredTable,
     QueryNode,
@@ -430,6 +431,7 @@ class BaseSQLQueryEngine(BaseQueryEngine):
         # for this because it doesn't play nicely with subclassing.
         class_method_map = {
             DateDifference: self.date_difference,
+            DateAddition: self.date_add,
             RoundToFirstOfMonth: self.round_to_first_of_month,
             RoundToFirstOfYear: self.round_to_first_of_year,
         }
@@ -504,6 +506,21 @@ class BaseSQLQueryEngine(BaseQueryEngine):
         number of whole weeks, use the days calculation to calculate weeks also.
         """
         return sqlalchemy.func.floor(self._convert_date_diff_to_days(start, end) / 7)
+
+    def _get_number_of_days_for_query(self, number_of_days):
+        if not isinstance(number_of_days, int):
+            number_of_days = self.get_element_from_value_from_function(
+                number_of_days.value
+            )
+        return number_of_days
+
+    def date_add(self, start_date, number_of_days):
+        """
+        Add a number of days to a date.
+        delta: a DateDeltaSeries or an integer representing a numer of days
+
+        """
+        raise NotImplementedError()
 
     def round_to_first_of_month(self, date):
         raise NotImplementedError

--- a/databuilder/query_engines/base_sql.py
+++ b/databuilder/query_engines/base_sql.py
@@ -69,6 +69,7 @@ from ..query_model import (
     Comparator,
     DateAddition,
     DateDeltaAddition,
+    DateDeltaSubtraction,
     DateDifference,
     DateSubtraction,
     FilteredTable,
@@ -436,6 +437,7 @@ class BaseSQLQueryEngine(BaseQueryEngine):
             DateAddition: self.date_add,
             DateSubtraction: self.date_subtract,
             DateDeltaAddition: self.date_delta_add,
+            DateDeltaSubtraction: self.date_delta_subtract,
             RoundToFirstOfMonth: self.round_to_first_of_month,
             RoundToFirstOfYear: self.round_to_first_of_year,
         }
@@ -536,6 +538,11 @@ class BaseSQLQueryEngine(BaseQueryEngine):
         delta1 = self._get_number_of_days_for_query(delta1)
         delta2 = self._get_number_of_days_for_query(delta2)
         return type_coerce((delta1 + delta2), sqlalchemy_types.Integer())
+
+    def date_delta_subtract(self, delta1, delta2):
+        delta1 = self._get_number_of_days_for_query(delta1)
+        delta2 = self._get_number_of_days_for_query(delta2)
+        return type_coerce((delta1 - delta2), sqlalchemy_types.Integer())
 
     def round_to_first_of_month(self, date):
         raise NotImplementedError

--- a/databuilder/query_engines/base_sql.py
+++ b/databuilder/query_engines/base_sql.py
@@ -69,6 +69,7 @@ from ..query_model import (
     Comparator,
     DateAddition,
     DateDifference,
+    DateSubtraction,
     FilteredTable,
     QueryNode,
     RoundToFirstOfMonth,
@@ -432,6 +433,7 @@ class BaseSQLQueryEngine(BaseQueryEngine):
         class_method_map = {
             DateDifference: self.date_difference,
             DateAddition: self.date_add,
+            DateSubtraction: self.date_subtract,
             RoundToFirstOfMonth: self.round_to_first_of_month,
             RoundToFirstOfYear: self.round_to_first_of_year,
         }
@@ -517,8 +519,14 @@ class BaseSQLQueryEngine(BaseQueryEngine):
     def date_add(self, start_date, number_of_days):
         """
         Add a number of days to a date.
-        delta: a DateDeltaSeries or an integer representing a numer of days
+        number_of_days: an IntSeries with a DateDifference value in days or an integer representing a numer of days
+        """
+        raise NotImplementedError()
 
+    def date_subtract(self, start_date, number_of_days):
+        """
+        Add a number of days to a date.
+        number_of_days: an IntSeries with a DateDifference value in days or an integer representing a numer of days
         """
         raise NotImplementedError()
 

--- a/databuilder/query_engines/mssql.py
+++ b/databuilder/query_engines/mssql.py
@@ -88,13 +88,24 @@ class MssqlQueryEngine(BaseSQLQueryEngine):
         """
         Add a number of days to a date, using the `dateadd` function
         """
-        if not isinstance(number_of_days, int):
-            number_of_days = self.get_element_from_value_from_function(
-                number_of_days.value
-            )
+        number_of_days = self._get_number_of_days_for_query(number_of_days)
         start_date = type_coerce(start_date, sqlalchemy_types.Date())
-        return sqlalchemy.func.dateadd(
-            sqlalchemy.text("day"), number_of_days, start_date
+        return type_coerce(
+            sqlalchemy.func.dateadd(sqlalchemy.text("day"), number_of_days, start_date),
+            sqlalchemy_types.Date(),
+        )
+
+    def date_subtract(self, start_date, number_of_days):
+        """
+        Subtract a number of days from a date, using the `dateadd` function
+        """
+        number_of_days = self._get_number_of_days_for_query(number_of_days)
+        start_date = type_coerce(start_date, sqlalchemy_types.Date())
+        return type_coerce(
+            sqlalchemy.func.dateadd(
+                sqlalchemy.text("day"), number_of_days * -1, start_date
+            ),
+            sqlalchemy_types.Date(),
         )
 
     def round_to_first_of_month(self, date):

--- a/databuilder/query_engines/mssql.py
+++ b/databuilder/query_engines/mssql.py
@@ -84,24 +84,27 @@ class MssqlQueryEngine(BaseSQLQueryEngine):
         """
         return sqlalchemy.func.datediff(sqlalchemy.text("day"), start, end)
 
-    def round_to_first_of_month(self, date):
-        date = type_coerce(date, sqlalchemy_types.Date())
-
-        first_of_month = sqlalchemy.func.datefromparts(
-            sqlalchemy.func.year(date),
-            sqlalchemy.func.month(date),
-            1,
+    def date_add(self, start_date, number_of_days):
+        """
+        Add a number of days to a date, using the `dateadd` function
+        """
+        if not isinstance(number_of_days, int):
+            number_of_days = self.get_element_from_value_from_function(
+                number_of_days.value
+            )
+        start_date = type_coerce(start_date, sqlalchemy_types.Date())
+        return sqlalchemy.func.dateadd(
+            sqlalchemy.text("day"), number_of_days, start_date
         )
 
+    def round_to_first_of_month(self, date):
+        date = type_coerce(date, sqlalchemy_types.Date())
+        first_of_month = sqlalchemy.func.datefromparts(
+            sqlalchemy.func.year(date), sqlalchemy.func.month(date), 1
+        )
         return type_coerce(first_of_month, sqlalchemy_types.Date())
 
     def round_to_first_of_year(self, date):
         date = type_coerce(date, sqlalchemy_types.Date())
-
-        first_of_year = sqlalchemy.func.datefromparts(
-            sqlalchemy.func.year(date),
-            1,
-            1,
-        )
-
+        first_of_year = sqlalchemy.func.datefromparts(sqlalchemy.func.year(date), 1, 1)
         return type_coerce(first_of_year, sqlalchemy_types.Date())

--- a/databuilder/query_engines/spark.py
+++ b/databuilder/query_engines/spark.py
@@ -72,13 +72,21 @@ class SparkQueryEngine(BaseSQLQueryEngine):
         Add a number of days to a date, using the `dateadd` function
         The sparkSQL date_add function only allows adding days
         """
-        if not isinstance(number_of_days, int):
-            number_of_days = self.get_element_from_value_from_function(
-                number_of_days.value
-            )
+        number_of_days = self._get_number_of_days_for_query(number_of_days)
         start_date = type_coerce(start_date, sqlalchemy_types.Date())
         return type_coerce(
             sqlalchemy.func.date_add(start_date, number_of_days),
+            sqlalchemy_types.Date(),
+        )
+
+    def date_subtract(self, start_date, number_of_days):
+        """
+        Subtract a number of days from a date, using the `date_add` function
+        """
+        number_of_days = self._get_number_of_days_for_query(number_of_days)
+        start_date = type_coerce(start_date, sqlalchemy_types.Date())
+        return type_coerce(
+            sqlalchemy.func.date_add(start_date, number_of_days * -1),
             sqlalchemy_types.Date(),
         )
 

--- a/databuilder/query_engines/spark.py
+++ b/databuilder/query_engines/spark.py
@@ -67,6 +67,21 @@ class SparkQueryEngine(BaseSQLQueryEngine):
         """
         return sqlalchemy.func.datediff(end, start)
 
+    def date_add(self, start_date, number_of_days):
+        """
+        Add a number of days to a date, using the `dateadd` function
+        The sparkSQL date_add function only allows adding days
+        """
+        if not isinstance(number_of_days, int):
+            number_of_days = self.get_element_from_value_from_function(
+                number_of_days.value
+            )
+        start_date = type_coerce(start_date, sqlalchemy_types.Date())
+        return type_coerce(
+            sqlalchemy.func.date_add(start_date, number_of_days),
+            sqlalchemy_types.Date(),
+        )
+
     def round_to_first_of_month(self, date):
         date = type_coerce(date, sqlalchemy_types.Date())
 

--- a/databuilder/query_model.py
+++ b/databuilder/query_model.py
@@ -432,6 +432,10 @@ class DateAddition(ValueFromFunction):
     pass
 
 
+class DateDeltaAddition(ValueFromFunction):
+    pass
+
+
 class DateSubtraction(ValueFromFunction):
     pass
 

--- a/databuilder/query_model.py
+++ b/databuilder/query_model.py
@@ -432,6 +432,10 @@ class DateAddition(ValueFromFunction):
     pass
 
 
+class DateSubtraction(ValueFromFunction):
+    pass
+
+
 class RoundToFirstOfMonth(ValueFromFunction):
     pass
 

--- a/databuilder/query_model.py
+++ b/databuilder/query_model.py
@@ -425,6 +425,11 @@ class ValueFromFunction(Value):
 class DateDifference(ValueFromFunction):
     def __init__(self, start, end, units="years"):
         super().__init__(start, end, units)
+        self.units = units
+
+
+class DateAddition(ValueFromFunction):
+    pass
 
 
 class RoundToFirstOfMonth(ValueFromFunction):

--- a/databuilder/query_model.py
+++ b/databuilder/query_model.py
@@ -440,6 +440,10 @@ class DateSubtraction(ValueFromFunction):
     pass
 
 
+class DateDeltaSubtraction(ValueFromFunction):
+    pass
+
+
 class RoundToFirstOfMonth(ValueFromFunction):
     pass
 

--- a/tests/test_dsl.py
+++ b/tests/test_dsl.py
@@ -755,10 +755,10 @@ def test_dateseries_radd_integer():
     # Adding an integer to a DateSeries returns another DateSeries
     assert isinstance(output, DateSeries)
     assert isinstance(output.value, DateAddition)
-    series_arg, delta_arg = output.value.arguments
+    delta_arg, series_arg = output.value.arguments
 
-    assert series_arg.column == series.value.column
     assert delta_arg == 10
+    assert series_arg.column == series.value.column
 
 
 @pytest.mark.parametrize(

--- a/tests/test_dsl.py
+++ b/tests/test_dsl.py
@@ -17,6 +17,7 @@ from databuilder.dsl import (
 from databuilder.query_model import (
     Comparator,
     DateAddition,
+    DateDeltaAddition,
     DateDifference,
     DateSubtraction,
     RoundToFirstOfMonth,
@@ -825,3 +826,47 @@ def test_datedeltaseries_rsub_datestring():
     assert isinstance(delta_arg, IntSeries)
     assert isinstance(delta_arg.value, DateDifference)
     assert delta_arg.value.arguments == ("2021-10-01", "2021-11-01", "days")
+
+
+def test_add_datedeltaseries_together():
+    datedelta1 = DateDeltaSeries(DateDifference("2021-10-01", "2021-11-01"))
+    datedelta2 = DateDeltaSeries(DateDifference("2021-01-01", "2021-02-01"))
+    output = datedelta1 + datedelta2
+
+    # Adding DateDeltaSeries together returns another DateDeltaSeries
+    assert isinstance(output, DateDeltaSeries)
+    assert isinstance(output.value, DateDeltaAddition)
+    delta1_arg, delta2_arg = output.value.arguments
+
+    assert isinstance(delta1_arg, IntSeries)
+    assert isinstance(delta2_arg, IntSeries)
+    assert delta1_arg.value.arguments == ("2021-10-01", "2021-11-01", "days")
+    assert delta2_arg.value.arguments == ("2021-01-01", "2021-02-01", "days")
+
+
+def test_add_datedeltaseries_and_integer():
+    datedelta = DateDeltaSeries(DateDifference("2021-10-01", "2021-11-01"))
+    output = datedelta + 20
+
+    # Adding DateDeltaSeries and integer returns another DateDeltaSeries
+    assert isinstance(output, DateDeltaSeries)
+    assert isinstance(output.value, DateDeltaAddition)
+    delta1_arg, delta2_arg = output.value.arguments
+
+    assert isinstance(delta1_arg, IntSeries)
+    assert delta1_arg.value.arguments == ("2021-10-01", "2021-11-01", "days")
+    assert delta2_arg == 20
+
+
+def test_radd_datedeltaseries_and_integer():
+    datedelta = DateDeltaSeries(DateDifference("2021-10-01", "2021-11-01"))
+    output = 20 + datedelta
+
+    # Adding DateDeltaSeries and integer returns another DateDeltaSeries
+    assert isinstance(output, DateDeltaSeries)
+    assert isinstance(output.value, DateDeltaAddition)
+    delta1_arg, delta2_arg = output.value.arguments
+
+    assert isinstance(delta1_arg, IntSeries)
+    assert delta1_arg.value.arguments == ("2021-10-01", "2021-11-01", "days")
+    assert delta2_arg == 20

--- a/tests/test_dsl.py
+++ b/tests/test_dsl.py
@@ -534,7 +534,7 @@ def test_dateseries_rsub():
 @pytest.mark.parametrize(
     "left,right",
     [
-        (DateSeries(ValueFromRow(source=None, column="date")), 2021),
+        (DateSeries(ValueFromRow(source=None, column="date")), "2021"),
         ("2021-02-31", DateSeries(ValueFromRow(source=None, column="date"))),
         (DateSeries(ValueFromRow(source=None, column="date")), "1-2-1999"),
         (DateSeries(ValueFromRow(source=None, column="date")), "Foo"),
@@ -545,6 +545,19 @@ def test_dateseries_sub_with_invalid_datestrings(left, right):
         ValueError, match=".+ is not a valid date; date must in YYYY-MM-DD format"
     ):
         left - right
+
+
+@pytest.mark.parametrize(
+    "other_value,exception,error_match",
+    [
+        (10, TypeError, "Can't subtract DateSeries from int"),
+        ("Foo", ValueError, "Foo is not a valid date"),
+    ],
+)
+def test_dateseries_rsub_errors(other_value, exception, error_match):
+    series = DateSeries(ValueFromRow(source=None, column="date"))
+    with pytest.raises(exception, match=error_match):
+        other_value - series
 
 
 def test_intseries_gt(int_series):

--- a/tests/test_dsl.py
+++ b/tests/test_dsl.py
@@ -748,6 +748,19 @@ def test_datedelta_add_dateseries():
     assert delta_arg.value.arguments == ("2021-10-01", "2021-11-01", "days")
 
 
+def test_dateseries_radd_integer():
+    series = DateSeries(ValueFromRow(source=None, column="date"))
+    output = 10 + series
+
+    # Adding an integer to a DateSeries returns another DateSeries
+    assert isinstance(output, DateSeries)
+    assert isinstance(output.value, DateAddition)
+    series_arg, delta_arg = output.value.arguments
+
+    assert series_arg.column == series.value.column
+    assert delta_arg == 10
+
+
 @pytest.mark.parametrize(
     "delta_value,error",
     [
@@ -866,6 +879,22 @@ def test_add_datedeltaseries_and_integer():
     assert isinstance(delta1_arg, IntSeries)
     assert delta1_arg.value.arguments == ("2021-10-01", "2021-11-01", "days")
     assert delta2_arg == 20
+
+
+def test_add_datedeltaseries_and_dateseries():
+    series = DateSeries(ValueFromRow(source=None, column="date"))
+    datedelta = DateDeltaSeries(DateDifference("2021-10-01", "2021-11-01"))
+    output = datedelta + series
+
+    # Adding DateDeltaSeries and DateSeries returns a DateSeries
+    assert isinstance(output, DateSeries)
+    assert isinstance(output.value, DateAddition)
+    series_arg, delta_arg = output.value.arguments
+
+    assert series_arg.column == series.value.column
+    assert isinstance(delta_arg, IntSeries)
+    assert isinstance(delta_arg.value, DateDifference)
+    assert delta_arg.value.arguments == ("2021-10-01", "2021-11-01", "days")
 
 
 def test_radd_datedeltaseries_and_integer():

--- a/tests/test_dsl.py
+++ b/tests/test_dsl.py
@@ -730,7 +730,7 @@ def test_dateseries_add_integer():
     assert delta_arg == 10
 
 
-def test_dateseries_radd_datedelta():
+def test_datedelta_add_dateseries():
     series = DateSeries(ValueFromRow(source=None, column="date"))
     datedelta = DateDeltaSeries(DateDifference("2021-10-01", "2021-11-01"))
     output = datedelta + series
@@ -746,19 +746,6 @@ def test_dateseries_radd_datedelta():
     assert isinstance(delta_arg, IntSeries)
     assert isinstance(delta_arg.value, DateDifference)
     assert delta_arg.value.arguments == ("2021-10-01", "2021-11-01", "days")
-
-
-def test_dateseries_radd_integer():
-    series = DateSeries(ValueFromRow(source=None, column="date"))
-    output = 10 + series
-
-    # Adding an integer to a DateSeries returns another DateSeries
-    assert isinstance(output, DateSeries)
-    assert isinstance(output.value, DateAddition)
-    delta_arg, series_arg = output.value.arguments
-
-    assert delta_arg == 10
-    assert series_arg.column == series.value.column
 
 
 @pytest.mark.parametrize(

--- a/tests/test_dsl.py
+++ b/tests/test_dsl.py
@@ -701,26 +701,14 @@ def test_datedeltaseries_convert_to_weeks(cohort_with_population):
         (
             (
                 DateSeries(ValueFromRow(source=None, column="date")) - "2021-10-01"
-            ).convert_to_weeks(),
-            "Can't add weeks",
-        ),
-        (
-            (
-                DateSeries(ValueFromRow(source=None, column="date")) - "2021-10-01"
-            ).convert_to_months(),
-            "Can't add months",
-        ),
-        (
-            (
-                DateSeries(ValueFromRow(source=None, column="date")) - "2021-10-01"
-            ).convert_to_years(),
-            "Can't add years",
+            ).convert_to_days(),
+            re.escape("Can only add integer or DateDeltaSeries (got <IntSeries>)"),
         ),
         (
             IntSeries(ValueFromRow(source=None, column="numeric_value")),
-            "Can't add IntSeries with value <ValueFromRow>",
+            re.escape("Can only add integer or DateDeltaSeries (got <IntSeries>)"),
         ),
-        ("foo", "Can't add <str>"),
+        ("foo", re.escape("Can only add integer or DateDeltaSeries (got <str>)")),
     ],
 )
 def test_dateseries_add_validation(cohort_with_population, delta_value, error):

--- a/tests/test_query_engine_dsl.py
+++ b/tests/test_query_engine_dsl.py
@@ -510,3 +510,40 @@ def test_date_arithmetic_radd(engine, cohort_with_population):
             "dob_plus_10": date(1987, 9, 20),
         },
     ]
+
+
+def test_date_arithmetic_subtract_datedelta(engine, cohort_with_population):
+    input_data = [
+        patient(1, dob="1990-08-10"),
+        patient(2, dob="1987-09-10"),
+    ]
+    engine.setup(input_data)
+
+    patients = tables.patients
+    data_definition = cohort_with_population
+    reference_date = "1990-09-10"
+    dob = patients.select_column(patients.date_of_birth)  # DateSeries
+
+    age = reference_date - dob
+    data_definition.age_in_days = age.convert_to_days()
+    data_definition.dob_minus_age = dob - age
+    data_definition.dob_minus_10 = dob - 10
+    data_definition.ref_minus_age = reference_date - age
+
+    result = engine.extract(data_definition)
+    assert result == [
+        {
+            "patient_id": 1,
+            "age_in_days": 31,
+            "dob_minus_age": date(1990, 7, 10),
+            "dob_minus_10": date(1990, 7, 31),
+            "ref_minus_age": date(1990, 8, 10),
+        },
+        {
+            "patient_id": 2,
+            "age_in_days": 1096,
+            "dob_minus_age": date(1984, 9, 9),
+            "dob_minus_10": date(1987, 8, 31),
+            "ref_minus_age": date(1987, 9, 10),
+        },
+    ]

--- a/tests/test_query_engine_dsl.py
+++ b/tests/test_query_engine_dsl.py
@@ -418,64 +418,6 @@ def test_date_arithmetic_add_datedeltaseries(engine, cohort_with_population):
     ]
 
 
-def test_date_arithmetic_add_intseries(engine, cohort_with_population):
-    input_data = [
-        patient(1, dob="1990-08-10"),
-        patient(2, dob="1987-09-10"),
-    ]
-    engine.setup(input_data)
-
-    patients = tables.patients
-    data_definition = cohort_with_population
-    reference_date = "1990-09-10"
-    dob = patients.select_column(patients.date_of_birth)  # -> DateSeries
-
-    age = reference_date - dob
-    age_in_days = age.convert_to_days()  # -> IntSeries
-    # adding age converted to days gives the same result (always adds days)
-    data_definition.age_in_days = age_in_days
-    data_definition.dob_plus_age_in_days = dob + age_in_days
-
-    result = engine.extract(data_definition)
-    assert result == [
-        {"patient_id": 1, "age_in_days": 31, "dob_plus_age_in_days": date(1990, 9, 10)},
-        {
-            "patient_id": 2,
-            "age_in_days": 1096,
-            "dob_plus_age_in_days": date(1990, 9, 10),
-        },
-    ]
-
-
-def test_date_arithmetic_add_days_diff_intseries(engine, cohort_with_population):
-    input_data = [
-        patient(1, dob="1990-08-10"),
-        patient(2, dob="1987-09-10"),
-    ]
-    engine.setup(input_data)
-
-    patients = tables.patients
-    data_definition = cohort_with_population
-    reference_date = "1990-09-10"
-    dob = patients.select_column(patients.date_of_birth)  # -> DateSeries
-
-    age = reference_date - dob
-    age_in_days = age.convert_to_days()  # -> IntSeries
-    # adding age converted to days gives the same result (always adds days)
-    data_definition.age_in_days = age_in_days
-    data_definition.dob_plus_age_in_days = dob + age_in_days
-
-    result = engine.extract(data_definition)
-    assert result == [
-        {"patient_id": 1, "age_in_days": 31, "dob_plus_age_in_days": date(1990, 9, 10)},
-        {
-            "patient_id": 2,
-            "age_in_days": 1096,
-            "dob_plus_age_in_days": date(1990, 9, 10),
-        },
-    ]
-
-
 def test_date_arithmetic_radd(engine, cohort_with_population):
     input_data = [
         patient(1, dob="1990-08-10"),

--- a/tests/test_query_engine_dsl.py
+++ b/tests/test_query_engine_dsl.py
@@ -1,4 +1,4 @@
-from datetime import date
+from datetime import date, timedelta
 
 import pytest
 
@@ -396,15 +396,18 @@ def test_date_arithmetic_convert_to_weeks(engine, cohort_with_population):
 
 
 def test_date_arithmetic_add_datedeltaseries(engine, cohort_with_population):
+    patient1_dob = date(1990, 8, 10)
+    patient2_dob = date(1987, 9, 10)
+    reference_date_obj = date(1990, 9, 10)
     input_data = [
-        patient(1, dob="1990-08-10"),
-        patient(2, dob="1987-09-10"),
+        patient(1, dob=str(patient1_dob)),
+        patient(2, dob=str(patient2_dob)),
     ]
     engine.setup(input_data)
 
     patients = tables.patients
     data_definition = cohort_with_population
-    reference_date = "1990-09-10"
+    reference_date = str(reference_date_obj)
     dob = patients.select_column(patients.date_of_birth)  # -> DateSeries
 
     age = reference_date - dob  # -> DateDeltaSeries
@@ -412,22 +415,33 @@ def test_date_arithmetic_add_datedeltaseries(engine, cohort_with_population):
     data_definition.dob_plus_age = dob + age
 
     result = engine.extract(data_definition)
+
+    def _age(dob_obj):
+        return reference_date_obj - dob_obj
+
     assert result == [
-        {"patient_id": 1, "age_in_days": 31, "dob_plus_age": date(1990, 9, 10)},
-        {"patient_id": 2, "age_in_days": 1096, "dob_plus_age": date(1990, 9, 10)},
+        {
+            "patient_id": patient_id,
+            "age_in_days": _age(patient_dob).days,
+            "dob_plus_age": patient_dob + _age(patient_dob),
+        }
+        for patient_id, patient_dob in [(1, patient1_dob), (2, patient2_dob)]
     ]
 
 
 def test_date_arithmetic_subtract_datedelta(engine, cohort_with_population):
+    patient1_dob = date(1990, 8, 10)
+    patient2_dob = date(1987, 9, 10)
+    reference_date_obj = date(1990, 9, 10)
     input_data = [
-        patient(1, dob="1990-08-10"),
-        patient(2, dob="1987-09-10"),
+        patient(1, dob=str(patient1_dob)),
+        patient(2, dob=str(patient2_dob)),
     ]
     engine.setup(input_data)
 
     patients = tables.patients
     data_definition = cohort_with_population
-    reference_date = "1990-09-10"
+    reference_date = str(reference_date_obj)
     dob = patients.select_column(patients.date_of_birth)  # DateSeries
 
     age = reference_date - dob
@@ -437,39 +451,41 @@ def test_date_arithmetic_subtract_datedelta(engine, cohort_with_population):
     data_definition.ref_minus_age = reference_date - age
 
     result = engine.extract(data_definition)
+
+    def _age(dob_obj):
+        return reference_date_obj - dob_obj
+
     assert result == [
         {
-            "patient_id": 1,
-            "age_in_days": 31,
-            "dob_minus_age": date(1990, 7, 10),
-            "dob_minus_10": date(1990, 7, 31),
-            "ref_minus_age": date(1990, 8, 10),
-        },
-        {
-            "patient_id": 2,
-            "age_in_days": 1096,
-            "dob_minus_age": date(1984, 9, 9),
-            "dob_minus_10": date(1987, 8, 31),
-            "ref_minus_age": date(1987, 9, 10),
-        },
+            "patient_id": patient_id,
+            "age_in_days": _age(patient_dob).days,
+            "dob_minus_age": patient_dob - _age(patient_dob),
+            "dob_minus_10": patient_dob - timedelta(days=10),
+            "ref_minus_age": reference_date_obj - _age(patient_dob),
+        }
+        for patient_id, patient_dob in [(1, patient1_dob), (2, patient2_dob)]
     ]
 
 
 def test_date_arithmetic_add_datedeltaseries_together(engine, cohort_with_population):
+    patient1_dob = date(1990, 8, 10)
+    patient2_dob = date(1987, 9, 10)
+    reference_date_obj_1990 = date(1990, 9, 10)
+    reference_date_obj_2000 = date(2000, 9, 10)
     input_data = [
-        patient(1, dob="1990-08-10"),
-        patient(2, dob="1987-09-10"),
+        patient(1, dob=str(patient1_dob)),
+        patient(2, dob=str(patient2_dob)),
     ]
     engine.setup(input_data)
 
     patients = tables.patients
     data_definition = cohort_with_population
-    reference_date = "1990-09-10"
-    reference_date1 = "2000-09-10"
+    reference_date_1990 = str(reference_date_obj_1990)
+    reference_date_2000 = str(reference_date_obj_2000)
     dob = patients.select_column(patients.date_of_birth)  # -> DateSeries
 
-    age_in_1990 = reference_date - dob  # -> DateDeltaSeries
-    age_in_2000 = reference_date1 - dob  # -> DateDeltaSeries
+    age_in_1990 = reference_date_1990 - dob  # -> DateDeltaSeries
+    age_in_2000 = reference_date_2000 - dob  # -> DateDeltaSeries
 
     data_definition.age_in_days_1990 = age_in_1990.convert_to_days()
     data_definition.age_in_days_2000 = age_in_2000.convert_to_days()
@@ -477,34 +493,39 @@ def test_date_arithmetic_add_datedeltaseries_together(engine, cohort_with_popula
     data_definition.combined_age = age_in_1990 + age_in_2000
 
     result = engine.extract(data_definition)
+
+    def _days_age_on(dob_obj, reference_date_obj):
+        return (reference_date_obj - dob_obj).days
+
     assert result == [
         {
-            "patient_id": 1,
-            "age_in_days_1990": 31,
-            "age_in_days_2000": 3684,
-            "combined_age": 31 + 3684,
-        },
-        {
-            "patient_id": 2,
-            "age_in_days_1990": 1096,
-            "age_in_days_2000": 4749,
-            "combined_age": 1096 + 4749,
-        },
+            "patient_id": patient_id,
+            "age_in_days_1990": _days_age_on(patient_dob, reference_date_obj_1990),
+            "age_in_days_2000": _days_age_on(patient_dob, reference_date_obj_2000),
+            "combined_age": (
+                _days_age_on(patient_dob, reference_date_obj_1990)
+                + _days_age_on(patient_dob, reference_date_obj_2000)
+            ),
+        }
+        for patient_id, patient_dob in [(1, patient1_dob), (2, patient2_dob)]
     ]
 
 
 def test_date_arithmetic_add_datedeltaseries_and_integer(
     engine, cohort_with_population
 ):
+    patient1_dob = date(1990, 8, 10)
+    patient2_dob = date(1987, 9, 10)
+    reference_date_obj = date(1990, 9, 10)
     input_data = [
-        patient(1, dob="1990-08-10"),
-        patient(2, dob="1987-09-10"),
+        patient(1, dob=str(patient1_dob)),
+        patient(2, dob=str(patient2_dob)),
     ]
     engine.setup(input_data)
 
     patients = tables.patients
     data_definition = cohort_with_population
-    reference_date = "1990-09-10"
+    reference_date = str(reference_date_obj)
     dob = patients.select_column(patients.date_of_birth)  # -> DateSeries
 
     age = reference_date - dob  # -> DateDeltaSeries
@@ -514,36 +535,38 @@ def test_date_arithmetic_add_datedeltaseries_and_integer(
     data_definition.ten_plus_age = 10 + age
 
     result = engine.extract(data_definition)
+
+    def _days_age(dob_obj):
+        return (reference_date_obj - dob_obj).days
+
     assert result == [
         {
-            "patient_id": 1,
-            "age_in_days": 31,
-            "age_plus_10": 41,
-            "ten_plus_age": 41,
-        },
-        {
-            "patient_id": 2,
-            "age_in_days": 1096,
-            "age_plus_10": 1106,
-            "ten_plus_age": 1106,
-        },
+            "patient_id": patient_id,
+            "age_in_days": _days_age(patient_dob),
+            "age_plus_10": _days_age(patient_dob) + 10,
+            "ten_plus_age": 10 + _days_age(patient_dob),
+        }
+        for patient_id, patient_dob in [(1, patient1_dob), (2, patient2_dob)]
     ]
 
 
 def test_date_arithmetic_add_multiple(engine, cohort_with_population):
+    patient_dob = date(1990, 8, 10)
+    reference_date_obj_1990 = date(1990, 9, 10)
+    reference_date_obj_1991 = date(1991, 9, 10)
     input_data = [
-        patient(1, dob="1990-08-10"),
+        patient(1, dob=str(patient_dob)),
     ]
     engine.setup(input_data)
 
     patients = tables.patients
     data_definition = cohort_with_population
-    reference_date = "1990-09-10"
-    reference_date1 = "1991-09-10"
+    reference_date_1990 = str(reference_date_obj_1990)
+    reference_date_1991 = str(reference_date_obj_1991)
     dob = patients.select_column(patients.date_of_birth)  # -> DateSeries
 
-    age_in_1990 = reference_date - dob  # -> DateDeltaSeries
-    age_in_1991 = reference_date1 - dob  # -> DateDeltaSeries
+    age_in_1990 = reference_date_1990 - dob  # -> DateDeltaSeries
+    age_in_1991 = reference_date_1991 - dob  # -> DateDeltaSeries
 
     data_definition.age_in_days_1990 = age_in_1990.convert_to_days()
     data_definition.age_in_days_1991 = age_in_1991.convert_to_days()
@@ -552,32 +575,41 @@ def test_date_arithmetic_add_multiple(engine, cohort_with_population):
     data_definition.dob_plus = dob + age_in_1990 + age_in_1991 + 10
 
     result = engine.extract(data_definition)
+
+    timedelta_age_1990 = (reference_date_obj_1990 - patient_dob).days
+    timedelta_age_1991 = (reference_date_obj_1991 - patient_dob).days
     assert result == [
         {
             "patient_id": 1,
-            "age_in_days_1990": 31,
-            "age_in_days_1991": 396,
-            "combined_age_plus_10": 437,
-            "dob_plus": date(1991, 10, 21),
+            "age_in_days_1990": timedelta_age_1990,
+            "age_in_days_1991": timedelta_age_1991,
+            "combined_age_plus_10": timedelta_age_1990 + timedelta_age_1991 + 10,
+            "dob_plus": patient_dob
+            + timedelta(days=timedelta_age_1990 + timedelta_age_1991 + 10),
         }
     ]
 
 
 def test_date_arithmetic_subtract_two_datedeltaseries(engine, cohort_with_population):
+    patient1_dob = date(1990, 8, 10)
+    patient2_dob = date(1987, 9, 10)
+    reference_date_obj_1990 = date(1990, 9, 10)
+    reference_date_obj_2000 = date(2000, 9, 10)
     input_data = [
-        patient(1, dob="1990-08-10"),
-        patient(2, dob="1987-09-10"),
+        patient(1, dob=str(patient1_dob)),
+        patient(2, dob=str(patient2_dob)),
     ]
+
     engine.setup(input_data)
 
     patients = tables.patients
     data_definition = cohort_with_population
-    reference_date = "1990-09-10"
-    reference_date1 = "2000-09-10"
+    reference_date_1990 = str(reference_date_obj_1990)
+    reference_date_2000 = str(reference_date_obj_2000)
     dob = patients.select_column(patients.date_of_birth)  # -> DateSeries
 
-    age_in_1990 = reference_date - dob  # -> DateDeltaSeries
-    age_in_2000 = reference_date1 - dob  # -> DateDeltaSeries
+    age_in_1990 = reference_date_1990 - dob  # -> DateDeltaSeries
+    age_in_2000 = reference_date_2000 - dob  # -> DateDeltaSeries
 
     data_definition.age_in_days_1990 = age_in_1990.convert_to_days()
     data_definition.age_in_days_2000 = age_in_2000.convert_to_days()
@@ -585,34 +617,37 @@ def test_date_arithmetic_subtract_two_datedeltaseries(engine, cohort_with_popula
     data_definition.age_diff = age_in_2000 - age_in_1990
 
     result = engine.extract(data_definition)
+
+    def _days_age_on(dob_obj, reference_date_obj):
+        return (reference_date_obj - dob_obj).days
+
     assert result == [
         {
-            "patient_id": 1,
-            "age_in_days_1990": 31,
-            "age_in_days_2000": 3684,
-            "age_diff": 3684 - 31,
-        },
-        {
-            "patient_id": 2,
-            "age_in_days_1990": 1096,
-            "age_in_days_2000": 4749,
-            "age_diff": 4749 - 1096,
-        },
+            "patient_id": patient_id,
+            "age_in_days_1990": _days_age_on(patient_dob, reference_date_obj_1990),
+            "age_in_days_2000": _days_age_on(patient_dob, reference_date_obj_2000),
+            "age_diff": _days_age_on(patient_dob, reference_date_obj_2000)
+            - _days_age_on(patient_dob, reference_date_obj_1990),
+        }
+        for patient_id, patient_dob in [(1, patient1_dob), (2, patient2_dob)]
     ]
 
 
 def test_date_arithmetic_subtract_datedeltaseries_and_integer(
     engine, cohort_with_population
 ):
+    patient1_dob = date(1990, 8, 10)
+    patient2_dob = date(1987, 9, 10)
+    reference_date_obj = date(1990, 9, 10)
     input_data = [
-        patient(1, dob="1990-08-10"),
-        patient(2, dob="1987-09-10"),
+        patient(1, dob=str(patient1_dob)),
+        patient(2, dob=str(patient2_dob)),
     ]
     engine.setup(input_data)
 
     patients = tables.patients
     data_definition = cohort_with_population
-    reference_date = "1990-09-10"
+    reference_date = str(reference_date_obj)
     dob = patients.select_column(patients.date_of_birth)  # -> DateSeries
 
     age = reference_date - dob  # -> DateDeltaSeries
@@ -621,36 +656,36 @@ def test_date_arithmetic_subtract_datedeltaseries_and_integer(
     data_definition.two_thousand_minus_age = 2000 - age
 
     result = engine.extract(data_definition)
+
+    def _days_age(dob_obj):
+        return (reference_date_obj - dob_obj).days
+
     assert result == [
         {
-            "patient_id": 1,
-            "age_in_days": 31,
-            "age_minus_10": 21,
-            "two_thousand_minus_age": 1969,
-        },
-        {
-            "patient_id": 2,
-            "age_in_days": 1096,
-            "age_minus_10": 1086,
-            "two_thousand_minus_age": 904,
-        },
+            "patient_id": patient_id,
+            "age_in_days": _days_age(patient_dob),
+            "age_minus_10": _days_age(patient_dob) - 10,
+            "two_thousand_minus_age": 2000 - _days_age(patient_dob),
+        }
+        for patient_id, patient_dob in [(1, patient1_dob), (2, patient2_dob)]
     ]
 
 
 def test_date_arithmetic_add_and_subtract(engine, cohort_with_population):
-    input_data = [
-        patient(1, dob="1990-08-10"),
-    ]
+    patient_dob = date(1990, 8, 10)
+    reference_date_obj_1990 = date(1990, 9, 10)
+    reference_date_obj_1991 = date(2000, 9, 10)
+    input_data = [patient(1, dob=str(patient_dob))]
     engine.setup(input_data)
 
     patients = tables.patients
     data_definition = cohort_with_population
-    reference_date = "1990-09-10"
-    reference_date1 = "1991-09-10"
+    reference_date_1990 = str(reference_date_obj_1990)
+    reference_date_1991 = str(reference_date_obj_1991)
     dob = patients.select_column(patients.date_of_birth)  # -> DateSeries
 
-    age_in_1990 = reference_date - dob  # -> DateDeltaSeries
-    age_in_1991 = reference_date1 - dob  # -> DateDeltaSeries
+    age_in_1990 = reference_date_1990 - dob  # -> DateDeltaSeries
+    age_in_1991 = reference_date_1991 - dob  # -> DateDeltaSeries
 
     data_definition.age_in_days_1990 = age_in_1990.convert_to_days()
     data_definition.age_in_days_1991 = age_in_1991.convert_to_days()
@@ -659,12 +694,17 @@ def test_date_arithmetic_add_and_subtract(engine, cohort_with_population):
     data_definition.dob_plus_age_diff_plus_10 = dob + age_in_1991 - age_in_1990 + 10
 
     result = engine.extract(data_definition)
+
+    timedelta_age_1990 = (reference_date_obj_1990 - patient_dob).days
+    timedelta_age_1991 = (reference_date_obj_1991 - patient_dob).days
+
     assert result == [
         {
             "patient_id": 1,
-            "age_in_days_1990": 31,
-            "age_in_days_1991": 396,
-            "age_diff_plus_10": 375,
-            "dob_plus_age_diff_plus_10": date(1991, 8, 20),
+            "age_in_days_1990": timedelta_age_1990,
+            "age_in_days_1991": timedelta_age_1991,
+            "age_diff_plus_10": timedelta_age_1991 - timedelta_age_1990 + 10,
+            "dob_plus_age_diff_plus_10": patient_dob
+            + timedelta(days=timedelta_age_1991 - timedelta_age_1990 + 10),
         }
     ]

--- a/tests/test_query_engine_dsl.py
+++ b/tests/test_query_engine_dsl.py
@@ -418,42 +418,6 @@ def test_date_arithmetic_add_datedeltaseries(engine, cohort_with_population):
     ]
 
 
-def test_date_arithmetic_radd(engine, cohort_with_population):
-    input_data = [
-        patient(1, dob="1990-08-10"),
-        patient(2, dob="1987-09-10"),
-    ]
-    engine.setup(input_data)
-
-    patients = tables.patients
-    data_definition = cohort_with_population
-
-    reference_date = "1990-09-10"
-    dob = patients.select_column(patients.date_of_birth)  # -> DateSeries
-
-    age = reference_date - dob
-    data_definition.age_in_days = age.convert_to_days()
-    # we can add a dateseries to a datedelta, as well as vice versa
-    data_definition.dob_plus_age = age + dob
-    data_definition.dob_plus_10 = 10 + dob
-
-    result = engine.extract(data_definition)
-    assert result == [
-        {
-            "patient_id": 1,
-            "age_in_days": 31,
-            "dob_plus_age": date(1990, 9, 10),
-            "dob_plus_10": date(1990, 8, 20),
-        },
-        {
-            "patient_id": 2,
-            "age_in_days": 1096,
-            "dob_plus_age": date(1990, 9, 10),
-            "dob_plus_10": date(1987, 9, 20),
-        },
-    ]
-
-
 def test_date_arithmetic_subtract_datedelta(engine, cohort_with_population):
     input_data = [
         patient(1, dob="1990-08-10"),

--- a/tests/test_query_engine_dsl.py
+++ b/tests/test_query_engine_dsl.py
@@ -510,6 +510,8 @@ def test_date_arithmetic_add_datedeltaseries_and_integer(
     age = reference_date - dob  # -> DateDeltaSeries
     data_definition.age_in_days = age.convert_to_days()
     data_definition.age_plus_10 = age + 10
+    # We can add a datedeltaseries to an int as well
+    data_definition.ten_plus_age = 10 + age
 
     result = engine.extract(data_definition)
     assert result == [
@@ -517,11 +519,13 @@ def test_date_arithmetic_add_datedeltaseries_and_integer(
             "patient_id": 1,
             "age_in_days": 31,
             "age_plus_10": 41,
+            "ten_plus_age": 41,
         },
         {
             "patient_id": 2,
             "age_in_days": 1096,
             "age_plus_10": 1106,
+            "ten_plus_age": 1106,
         },
     ]
 


### PR DESCRIPTION
[sc-418]
This allows adding and subtracting a number of days to/from a date/DateSeries.  It currently ONLY allows days, to avoid/postpone the issue of what it means to add e.g. 1 month to 31st Jan (28th Feb? 1st March?) and the ambiguity of e,g, 2022-01-01 + 3 (as the 3 will always be treated as days).

The number of days can be a simple integer, a DateDeltaSeries that represents a difference between two dates in days (e.g. age as `index_date - date_of_birth`) or an IntSeries created by converting a DateDeltaSeries to days (e.g.  `(index_date - date_of_birth).convert_to_days()`

It also adds methods to add/substract DateDeltaSeries to/from each other, to produce new DateDeltaSeries.