### PR TITLE
ci: Fix tagging of Docker images

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -45,7 +45,7 @@ jobs:
       # This relies on the tag having a version of the form vX.Y.Z
       - name: Build image
         run: |
-          PATCH="${GITHUB_REF#refs/*/}"
+          PATCH="${{ steps.previoustagref.outputs.tag }}"
           MAJOR="${PATCH%%.*}"
           MINOR="${PATCH%.*}"
 


### PR DESCRIPTION
The versions all currently get set to `main`, possibly because this
workflow is now triggered by a complete `workflow_run` on the `main`
branch.

Instead use the tag, that we've already checked is valid.