### PR TITLE
Ensure Query Model only contains allowed types

### DIFF
--- a/databuilder/dsl.py
+++ b/databuilder/dsl.py
@@ -287,7 +287,8 @@ class PatientSeries:
         return BoolSeries(value=self.value == other_value)
 
     def __ne__(self, other: PatientSeries | Comparator | str | int) -> BoolSeries:  # type: ignore[override]
-        return BoolSeries(value=self.value != other)
+        other_value = other.value if isinstance(other, PatientSeries) else other
+        return BoolSeries(value=self.value != other_value)
 
     def __hash__(self) -> int:
         return hash(repr(self.value))
@@ -371,7 +372,7 @@ class DateSeries(PatientSeries):
         if isinstance(delta_value, DateDeltaSeries) and isinstance(
             delta_value.value, DateDifference
         ):
-            return delta_value.convert_to_days()
+            return delta_value.convert_to_days().value
         elif isinstance(delta_value, int):
             return delta_value
         else:
@@ -437,10 +438,11 @@ class DateDeltaSeries(PatientSeries):
         Convert a DateSeltaSeries representing the difference between two dates to an
         IntSeries representing days.
         """
-        if isinstance(datedelta, DateDeltaSeries) and isinstance(
-            datedelta.value, DateDifference
-        ):
-            return datedelta.convert_to_days()
+        if isinstance(datedelta, DateDeltaSeries):
+            if isinstance(datedelta.value, DateDifference):
+                return datedelta.convert_to_days().value
+            else:
+                return datedelta.value
         return datedelta
 
     def __add__(
@@ -471,7 +473,7 @@ class DateDeltaSeries(PatientSeries):
             datestring = _validate_datestring(other)
             # This allows subtraction of a DateDeltaSeries from a date string
             # e.g. 2020-10-01
-            return DateSeries(DateSubtraction(datestring, self.convert_to_days()))
+            return DateSeries(DateSubtraction(datestring, self.convert_to_days().value))
         return DateDeltaSeries(
             DateDeltaSubtraction(self._delta_in_days(other), self._delta_in_days(self))
         )

--- a/databuilder/query_engines/base_sql.py
+++ b/databuilder/query_engines/base_sql.py
@@ -537,35 +537,22 @@ class BaseSQLQueryEngine(BaseQueryEngine):
         """
         return sqlalchemy.func.floor(self._convert_date_diff_to_days(start, end) / 7)
 
-    def _get_number_of_days_for_query(self, number_of_days):
-        if not isinstance(number_of_days, int):
-            number_of_days = self.get_element_from_value_from_function(
-                number_of_days.value
-            )
-        return number_of_days
-
     def date_add(self, start_date, number_of_days):
         """
         Add a number of days to a date.
-        number_of_days: an IntSeries with a DateDifference value in days or an integer representing a numer of days
         """
         raise NotImplementedError()
 
     def date_subtract(self, start_date, number_of_days):
         """
         Add a number of days to a date.
-        number_of_days: an IntSeries with a DateDifference value in days or an integer representing a numer of days
         """
         raise NotImplementedError()
 
     def date_delta_add(self, delta1, delta2):
-        delta1 = self._get_number_of_days_for_query(delta1)
-        delta2 = self._get_number_of_days_for_query(delta2)
         return type_coerce((delta1 + delta2), sqlalchemy_types.Integer())
 
     def date_delta_subtract(self, delta1, delta2):
-        delta1 = self._get_number_of_days_for_query(delta1)
-        delta2 = self._get_number_of_days_for_query(delta2)
         return type_coerce((delta1 - delta2), sqlalchemy_types.Integer())
 
     def round_to_first_of_month(self, date):

--- a/databuilder/query_engines/base_sql.py
+++ b/databuilder/query_engines/base_sql.py
@@ -42,6 +42,7 @@ order.
 import contextlib
 import copy
 import dataclasses
+import datetime
 import typing
 from collections import defaultdict
 from functools import cached_property
@@ -99,6 +100,12 @@ from .base import BaseQueryEngine
 # These are nodes which select a single column from a query (regardless of whether that
 # results in a single value per patient or in multiple values per patient)
 ColumnSelectorNode = Union[ValueFromRow, ValueFromAggregate, Column]
+
+# These are the basic types we accept as arguments in the Query Model
+Scalar = Union[None, bool, int, float, str, datetime.datetime, datetime.date]
+StaticValue = Union[Scalar, tuple[Scalar], list[Scalar]]
+
+SCALAR_TYPES = typing.get_args(Scalar)
 
 
 # This is an internal class that is injected into the DAG by the QueryEngine, but that
@@ -208,6 +215,34 @@ class BaseSQLQueryEngine(BaseQueryEngine):
             for query in cleanup_queries:
                 cursor.execute(query)
 
+    @singledispatchmethod_with_unions
+    def get_sql_element_or_value(self, value: Any) -> Any:
+        """
+        Certain places in our Query Model support values which can either be QueryNodes
+        themselves or plain static values (booleans, integers, dates, list of dates
+        etc). Note that the type signature really ought to be:
+
+            Union[QueryNode, StaticValue] -> Union[ClauseElement, StaticValue]
+
+        But the singledispatch decorator can't handle the StaticValue type properly (see
+        `get_static_value` below).
+        """
+        # Fallback for unhandled types
+        assert False, f"Unhandled type {value!r}"
+
+    @get_sql_element_or_value.register
+    def get_static_value(self, value: Union[Scalar, tuple, list]) -> StaticValue:
+        # This is a fudge: the type of `value` above really ought to be StaticValue but
+        # the singledispatch decorator can't handle the parameterized tuple and list
+        # types. So instead we accept all tuples and lists and enforce the types of
+        # their elements at runtime. See: https://bugs.python.org/issue46191
+        if isinstance(value, (tuple, list)) and any(
+            not isinstance(v, SCALAR_TYPES) for v in value
+        ):
+            assert False, f"Unhandled type {value!r}"
+        return value
+
+    @get_sql_element_or_value.register
     def get_sql_element(self, node: QueryNode) -> ClauseElement:
         """
         Caching wrapper around `get_sql_element_no_cache()` below, which is the
@@ -236,18 +271,7 @@ class BaseSQLQueryEngine(BaseQueryEngine):
         method below.
         """
         # Fallback for unhandled types
-        raise TypeError(f"Unhandled query node type: {node!r}")
-
-    def get_sql_element_or_value(self, value: Any) -> Any:
-        """
-        Certain places in our Query Model support values which can either be QueryNodes
-        themselves (which require resolving to SQL) or plain static values (booleans,
-        integers, dates, list of dates etc) which we can return unchanged to SQLAlchemy.
-        """
-        if isinstance(value, QueryNode):
-            return self.get_sql_element(value)
-        else:
-            return value
+        assert False, f"Unhandled query node type: {node!r}"
 
     @get_sql_element_no_cache.register
     def get_element_from_table(self, node: Table) -> Select:

--- a/databuilder/query_engines/mssql.py
+++ b/databuilder/query_engines/mssql.py
@@ -88,7 +88,6 @@ class MssqlQueryEngine(BaseSQLQueryEngine):
         """
         Add a number of days to a date, using the `dateadd` function
         """
-        number_of_days = self._get_number_of_days_for_query(number_of_days)
         start_date = type_coerce(start_date, sqlalchemy_types.Date())
         return type_coerce(
             sqlalchemy.func.dateadd(sqlalchemy.text("day"), number_of_days, start_date),
@@ -99,7 +98,6 @@ class MssqlQueryEngine(BaseSQLQueryEngine):
         """
         Subtract a number of days from a date, using the `dateadd` function
         """
-        number_of_days = self._get_number_of_days_for_query(number_of_days)
         start_date = type_coerce(start_date, sqlalchemy_types.Date())
         return type_coerce(
             sqlalchemy.func.dateadd(

--- a/databuilder/query_engines/spark.py
+++ b/databuilder/query_engines/spark.py
@@ -72,7 +72,6 @@ class SparkQueryEngine(BaseSQLQueryEngine):
         Add a number of days to a date, using the `dateadd` function
         The sparkSQL date_add function only allows adding days
         """
-        number_of_days = self._get_number_of_days_for_query(number_of_days)
         start_date = type_coerce(start_date, sqlalchemy_types.Date())
         return type_coerce(
             sqlalchemy.func.date_add(start_date, number_of_days),
@@ -83,7 +82,6 @@ class SparkQueryEngine(BaseSQLQueryEngine):
         """
         Subtract a number of days from a date, using the `date_add` function
         """
-        number_of_days = self._get_number_of_days_for_query(number_of_days)
         start_date = type_coerce(start_date, sqlalchemy_types.Date())
         return type_coerce(
             sqlalchemy.func.date_add(start_date, number_of_days * -1),

--- a/tests/test_dsl.py
+++ b/tests/test_dsl.py
@@ -696,11 +696,10 @@ def test_dateseries_add_datedelta():
     series_arg, delta_arg = output.value.arguments
 
     # first arg in the addition is the date column
-    # second arg is the DateDeltaSeries converted to an IntSeries in days
+    # second arg is the DateDeltaSeries converted to an DateDifference in days
     assert series_arg.column == series.value.column
-    assert isinstance(delta_arg, IntSeries)
-    assert isinstance(delta_arg.value, DateDifference)
-    assert delta_arg.value.arguments == ("2021-10-01", "2021-11-01", "days")
+    assert isinstance(delta_arg, DateDifference)
+    assert delta_arg.arguments == ("2021-10-01", "2021-11-01", "days")
 
 
 def test_dateseries_add_integer():
@@ -727,11 +726,10 @@ def test_datedelta_add_dateseries():
     series_arg, delta_arg = output.value.arguments
 
     # first arg in the addition is the date column
-    # second arg is the DateDeltaSeries converted to an IntSeries in days
+    # second arg is the DateDeltaSeries converted to an DateDifference in days
     assert series_arg.column == series.value.column
-    assert isinstance(delta_arg, IntSeries)
-    assert isinstance(delta_arg.value, DateDifference)
-    assert delta_arg.value.arguments == ("2021-10-01", "2021-11-01", "days")
+    assert isinstance(delta_arg, DateDifference)
+    assert delta_arg.arguments == ("2021-10-01", "2021-11-01", "days")
 
 
 def test_dateseries_radd_integer():
@@ -802,11 +800,10 @@ def test_dateseries_sub_datedelta():
     series_arg, delta_arg = output.value.arguments
 
     # first arg in the addition is the date column
-    # second arg is the DateDeltaSeries converted to an IntSeries in days
+    # second arg is the DateDeltaSeries converted to a DateDifference in days
     assert series_arg.column == series.value.column
-    assert isinstance(delta_arg, IntSeries)
-    assert isinstance(delta_arg.value, DateDifference)
-    assert delta_arg.value.arguments == ("2021-10-01", "2021-11-01", "days")
+    assert isinstance(delta_arg, DateDifference)
+    assert delta_arg.arguments == ("2021-10-01", "2021-11-01", "days")
 
 
 def test_dateseries_sub_integer():
@@ -832,9 +829,8 @@ def test_datedeltaseries_rsub_datestring():
     series_arg, delta_arg = output.value.arguments
 
     assert series_arg == "2021-12-10"
-    assert isinstance(delta_arg, IntSeries)
-    assert isinstance(delta_arg.value, DateDifference)
-    assert delta_arg.value.arguments == ("2021-10-01", "2021-11-01", "days")
+    assert isinstance(delta_arg, DateDifference)
+    assert delta_arg.arguments == ("2021-10-01", "2021-11-01", "days")
 
 
 def test_add_datedeltaseries_together():
@@ -847,10 +843,10 @@ def test_add_datedeltaseries_together():
     assert isinstance(output.value, DateDeltaAddition)
     delta1_arg, delta2_arg = output.value.arguments
 
-    assert isinstance(delta1_arg, IntSeries)
-    assert isinstance(delta2_arg, IntSeries)
-    assert delta1_arg.value.arguments == ("2021-10-01", "2021-11-01", "days")
-    assert delta2_arg.value.arguments == ("2021-01-01", "2021-02-01", "days")
+    assert isinstance(delta1_arg, DateDifference)
+    assert isinstance(delta2_arg, DateDifference)
+    assert delta1_arg.arguments == ("2021-10-01", "2021-11-01", "days")
+    assert delta2_arg.arguments == ("2021-01-01", "2021-02-01", "days")
 
 
 def test_add_datedeltaseries_and_integer():
@@ -862,8 +858,8 @@ def test_add_datedeltaseries_and_integer():
     assert isinstance(output.value, DateDeltaAddition)
     delta1_arg, delta2_arg = output.value.arguments
 
-    assert isinstance(delta1_arg, IntSeries)
-    assert delta1_arg.value.arguments == ("2021-10-01", "2021-11-01", "days")
+    assert isinstance(delta1_arg, DateDifference)
+    assert delta1_arg.arguments == ("2021-10-01", "2021-11-01", "days")
     assert delta2_arg == 20
 
 
@@ -878,9 +874,8 @@ def test_add_datedeltaseries_and_dateseries():
     series_arg, delta_arg = output.value.arguments
 
     assert series_arg.column == series.value.column
-    assert isinstance(delta_arg, IntSeries)
-    assert isinstance(delta_arg.value, DateDifference)
-    assert delta_arg.value.arguments == ("2021-10-01", "2021-11-01", "days")
+    assert isinstance(delta_arg, DateDifference)
+    assert delta_arg.arguments == ("2021-10-01", "2021-11-01", "days")
 
 
 def test_radd_datedeltaseries_and_integer():
@@ -892,8 +887,8 @@ def test_radd_datedeltaseries_and_integer():
     assert isinstance(output.value, DateDeltaAddition)
     delta1_arg, delta2_arg = output.value.arguments
 
-    assert isinstance(delta1_arg, IntSeries)
-    assert delta1_arg.value.arguments == ("2021-10-01", "2021-11-01", "days")
+    assert isinstance(delta1_arg, DateDifference)
+    assert delta1_arg.arguments == ("2021-10-01", "2021-11-01", "days")
     assert delta2_arg == 20
 
 
@@ -907,10 +902,10 @@ def test_datedeltaseries_sub():
     assert isinstance(output.value, DateDeltaSubtraction)
     delta1_arg, delta2_arg = output.value.arguments
 
-    assert isinstance(delta1_arg, IntSeries)
-    assert isinstance(delta2_arg, IntSeries)
-    assert delta1_arg.value.arguments == ("2021-10-01", "2021-11-01", "days")
-    assert delta2_arg.value.arguments == ("2021-01-01", "2021-02-01", "days")
+    assert isinstance(delta1_arg, DateDifference)
+    assert isinstance(delta2_arg, DateDifference)
+    assert delta1_arg.arguments == ("2021-10-01", "2021-11-01", "days")
+    assert delta2_arg.arguments == ("2021-01-01", "2021-02-01", "days")
 
 
 def test_datedeltaseries_sub_integer():
@@ -922,8 +917,8 @@ def test_datedeltaseries_sub_integer():
     assert isinstance(output.value, DateDeltaSubtraction)
     delta1_arg, delta2_arg = output.value.arguments
 
-    assert isinstance(delta1_arg, IntSeries)
-    assert delta1_arg.value.arguments == ("2021-10-01", "2021-11-01", "days")
+    assert isinstance(delta1_arg, DateDifference)
+    assert delta1_arg.arguments == ("2021-10-01", "2021-11-01", "days")
     assert delta2_arg == 10
 
 
@@ -936,6 +931,6 @@ def test_datedeltaseries_rsub():
     assert isinstance(output.value, DateDeltaSubtraction)
     delta1_arg, delta2_arg = output.value.arguments
 
-    assert isinstance(delta2_arg, IntSeries)
+    assert isinstance(delta2_arg, DateDifference)
     assert delta1_arg == 10
-    assert delta2_arg.value.arguments == ("2021-10-01", "2021-11-01", "days")
+    assert delta2_arg.arguments == ("2021-10-01", "2021-11-01", "days")


### PR DESCRIPTION
This PR adds type checking for the elements of the Query Model which aren't `QueryNode` instances, and fixes some cases where DSL classes previously leaked through.