### PR TITLE
Script Checking for Added Coverage

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -8,3 +8,4 @@ max-line-length = 88
 per-file-ignores =
     scripts/dbx:INP001
     scripts/dbx-cleanup.py:INP001,F821
+    scripts/parse_coverage_output.py:INP001

--- a/.github/workflows/track-no-cover.yml
+++ b/.github/workflows/track-no-cover.yml
@@ -1,0 +1,37 @@
+---
+name: Check no cover Removal
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron:  "15 9 1 * *"
+
+jobs:
+  check-no-cover:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: "actions/setup-python@v2"
+        with:
+          python-version: "3.9"
+      - uses: extractions/setup-just@v1
+
+      - name: Did coverage change?
+        env:
+          CI: 1
+        run: |
+          set -euo pipefail
+
+          # stop ignoring no cover lines
+          sed -i.bak 's/"pragma: no cover",/# "pragma: no cover",/' pyproject.toml
+
+          just test | tee test-output.txt || true
+
+          # extract missing lines per file fom coverage report in the tests output
+          # python script: get the files table from coverage
+          # awk: break the table down into filename and missing lines number
+          python scripts/parse_coverage_output.py test-output.txt | awk '{ print $1 " " $3 }' - > no-cover.txt
+
+          # compare coverage report to the existing one
+          git diff --exit-code no-cover.txt

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -162,3 +162,21 @@ To do this:
 If using Community Edition, you will need to follow the instructions the
 command outputs to complete the cleanup process, as we cannot fully automate it
 from the cli.
+
+
+### Checking `no cover` Removal
+We have a number of lines omitted from test coverage using `pragma: no cover`.
+We'd like to know when they get test coverage.
+
+To do so we have a scheduled workflow which removes that string from coverage's omitted lines config and runs the tests.
+It parses the test output for the coverage section and compares it to the existing `no-cover.txt` to look for changes.
+It's scheduled to run on the first day of each month.
+
+#### How to fix a failure
+When this workflow fails it will print the changes to the action logs via `git-diff`.
+Hopefully this shows where the changes are, making them fixable.
+
+You can easily recreate the output locally by removing/commenting out the `pragma: no cover` line from the `exclude_lines` section of `[tool.coverage.report]` in `pyproject.toml`.
+
+The ideal path for fixing an error is to remove some `pragma: no cover` comments.
+However, it's not clear how stable this process is yet and it's fairly low priority so feel free to update the `no-cover.txt` and move on.

--- a/no-cover.txt
+++ b/no-cover.txt
@@ -1,0 +1,10 @@
+databuilder/__main__.py 1
+databuilder/query_engines/base_sql.py 1
+databuilder/query_engines/mssql_dialect.py 1
+databuilder/query_engines/mssql_lib.py 1
+databuilder/query_engines/spark_dialect.py 21
+tests/lib/databases.py 6
+tests/lib/databricks_schema.py 0
+tests/lib/docker.py 4
+tests/lib/util.py 0
+tests/query_engines/test_mssql_lib.py 1

--- a/scripts/parse_coverage_output.py
+++ b/scripts/parse_coverage_output.py
@@ -1,0 +1,36 @@
+import itertools
+import sys
+
+
+def is_line_break(line):
+    return {token for token in line} == {"-"}
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Pass a the text file to be parsed as an argument", file=sys.stderr)
+        sys.exit(1)
+
+    with open(sys.argv[1]) as f:
+        lines = f.readlines()
+
+    # make future parsing easier
+    # lstrip() because GHA prints all lines with two leading spaces
+    # rstrip("\n") because readlines includes newlines
+    lines = list(line.lstrip().rstrip("\n") for line in lines)
+
+    # dropwhile processes the given iterator until its predicate becomes false,
+    # so here we are saying "ignore lines until the first line break"
+    lines = itertools.dropwhile(lambda l: not is_line_break(l), lines)
+
+    # remove the line break line itself
+    next(lines)
+
+    # iterate the remaining lines until we find the next line break
+    lines = list(itertools.takewhile(lambda l: not is_line_break(l), lines))
+
+    print("\n".join(lines))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This adds a workflow to check if our coverage changes if we stop omitting lines with `pragma: no cover` from coverage reporting.  We have a number of these lines in the codebase, 25 at time of writing, and we'd like to know if we've covered those lines with tests we're adding.

I've documented why we're doing this and how to fix a failing test run in `DEVELOPERS.md`, if that's not clear, lets fix that before merging.