### PR TITLE
Pin pip Version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ license = {file = "LICENSE"}
 classifiers = ["License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)"]
 requires-python = ">=3.9"
 dependencies = [
+  "pip==21.3.1",
   "pandas",
   "sqlalchemy",
   "structlog",

--- a/requirements.prod.txt
+++ b/requirements.prod.txt
@@ -234,3 +234,9 @@ thrift==0.15.0 \
     # via
     #   databricks-sql-connector
     #   opensafely-databuilder (pyproject.toml)
+
+# The following packages are considered to be unsafe in a requirements file:
+pip==21.3.1 \
+    --hash=sha256:deaf32dcd9ab821e359cd8330786bcd077604b5c5730c0b096eda46f95c24a2d \
+    --hash=sha256:fd11ba3d0fdb4c07fbc5ecbba0b1b719809420f25038f8ee3cd913d3faa3033a
+    # via opensafely-databuilder (pyproject.toml)


### PR DESCRIPTION
This pins pip to 21.3.1, the last 21.3.x release.  pip-tools is [currently broken with pip 22.x](https://github.com/jazzband/pip-tools/issues/1558).  We can remove this pin once pip-tools resolves the issue.