### PR TITLE
test: Test med safety with DSL

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ branch = true
 omit = [
     "tests/acceptance/conftest.py",
     "tests/acceptance/test_long_covid_dsl.py",
+    "tests/acceptance/test_med_safety_dsl.py",
     "tests/acceptance/test_sro_measures_dsl.py",
 ]
 

--- a/tests/acceptance/codelists.py
+++ b/tests/acceptance/codelists.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from databuilder import codelist_from_csv, combine_codelists
+from databuilder import codelist, codelist_from_csv, combine_codelists
 
 
 def load_codelist(csv_file, system, column):
@@ -163,3 +163,26 @@ medication_review_2 = load_codelist(
 )
 
 medication_review_codelist = combine_codelists(medication_review_1, medication_review_2)
+
+oral_nsaid_codelist = load_codelist(
+    "pincer-nsaid-23edd06e.csv",
+    "snomed",
+    "id",
+)
+
+ppi_codelist = load_codelist(
+    "pincer-ppi-3cfd43a3.csv",
+    "snomed",
+    "id",
+)
+
+gib_admissions_codelist = load_codelist(
+    "nhsbsa-adm-gastro-intestinal-bleed-5d4b7131.csv",
+    "icd10",
+    "code",
+)
+
+placeholder_admissions_codelist = codelist(
+    ["K226", "K226", "K226", "K252", "K254", "K256", "K260", "K262", "K264", "K266"],
+    system="icd10",
+)

--- a/tests/acceptance/test_med_safety_dsl.py
+++ b/tests/acceptance/test_med_safety_dsl.py
@@ -1,0 +1,313 @@
+from databuilder.tables import (
+    clinical_events,
+    hospital_admissions,
+    patient_demographics,
+    practice_registrations,
+)
+from tests.lib.tpp_schema import organisation, patient, registration, snomed_event
+
+from .codelists import (
+    gib_admissions_codelist,
+    oral_nsaid_codelist,
+    placeholder_admissions_codelist,
+    ppi_codelist,
+)
+
+# The following codes are used by APC (Admitted Patient Care), the national dataset for
+# hospital admissions. They are specific to this dataset, so we don't represent them as
+# a codelist. For more information, see:
+# * https://docs.opensafely.org/dataset-apc/#admission_method
+# * https://datadictionary.nhs.uk/attributes/admission_method.html
+EMERGENCY_ADMISSION_CODES = [
+    "21",  # Emergency Admission: Emergency Care Department or dental casualty department of the Health Care Provider
+    "22",  # Emergency Admission: GENERAL PRACTITIONER: after a request for immediate admission has been made direct to a Hospital Provider, i.e. not through a Bed bureau, by a GENERAL PRACTITIONER or deputy
+    "23",  # Emergency Admission: Bed bureau
+    "24",  # Emergency Admission: Consultant Clinic, of this or another Health Care Provider
+    "25",  # Emergency Admission: Admission via Mental Health Crisis Resolution Team
+    "2A",  # Emergency Admission: Emergency Care Department of another provider where the PATIENT  had not been admitted
+    "2B",  # Emergency Admission: Transfer of an admitted PATIENT from another Hospital Provider in an emergency
+    "2D",  # Emergency Admission: Other emergency admission
+    "28",  # Emergency Admission: Other means, examples are:
+    # - admitted from the Emergency Care Department of another provider where they had not been admitted
+    # - transfer of an admitted PATIENT from another Hospital Provider in an emergency
+    # - baby born at home as intended
+]
+
+
+def test_med_safety_study(cohort, subtest, database):
+    setup_data(database)
+
+    index_date = "2019-09-01"
+    index_date_minus_3_months = "2019-06-01"
+
+    with subtest("population"):
+        filtered_practice_registrations = (
+            practice_registrations.filter(
+                practice_registrations.date_start <= index_date
+            )
+            # TODO: Reinstate the following when Predicates support logic operations
+            # .filter(
+            #     (practice_registrations.date_end >= index_date)
+            #     | (practice_registrations.date_end != None)
+            # )
+            .filter(practice_registrations.date_end >= index_date)
+        )
+
+        is_registered = filtered_practice_registrations.exists_for_patient()
+
+        # not_dead = (
+        #     patient_demographics.select_column(patient_demographics.date_of_death)
+        #     is not None
+        # )
+
+        # TODO: Missing feature: Arithmetic on BoolSeries
+        # cohort.set_population(is_registered & not_dead)
+
+        cohort.set_population(is_registered)
+
+    with subtest(
+        "practice_id", missing_feature="add practice ids to practice registrations"
+    ):
+        cohort.practice_id = (
+            filtered_practice_registrations.sort_by(practice_registrations.date_end)
+            .last_for_patient()
+            .select_column(practice_registrations.practice_id)
+        )
+        cohort.assert_results(practice_id=1)
+
+    with subtest("age"):
+        cohort.age = (
+            index_date
+            - patient_demographics.select_column(patient_demographics.date_of_birth)
+        ).convert_to_years()
+        cohort.assert_results(age=65)
+
+    with subtest("sex"):
+        cohort.sex = patient_demographics.select_column(patient_demographics.sex)
+        cohort.assert_results(sex="female")
+
+    # Indicators
+    # ==========
+
+    # GIB01
+    # -----
+    with subtest("oral_nsaid"):
+        cohort.oral_nsaid = (
+            clinical_events.filter(clinical_events.code.is_in(oral_nsaid_codelist))
+            .filter(clinical_events.date >= index_date_minus_3_months)
+            .filter(clinical_events.date <= index_date)
+            .exists_for_patient()
+        )
+        cohort.assert_results(oral_nsaid=True)
+
+    with subtest("ppi"):
+        cohort.ppi = (
+            clinical_events.filter(clinical_events.code.is_in(ppi_codelist))
+            .filter(clinical_events.date >= index_date_minus_3_months)
+            .filter(clinical_events.date <= index_date)
+            .exists_for_patient()
+        )
+        cohort.assert_results(ppi=True)
+
+    with subtest("indicator_gib_risk", missing_feature="Arithmetic on BoolSeries"):
+        at_gib_risk = cohort.oral_nsaid & (cohort.age >= 65)  # noqa: F841
+        not_at_gib_risk = at_gib_risk & ~cohort.ppi  # noqa: F841
+
+        # Why does the following numerator/denominator pair need to be commented out (to
+        # avoid raising a TypeError) but the other two numerator/denominator pairs do
+        # not?
+        # cohort.indicator_gib_risk_numerator = not_at_gib_risk
+        # cohort.indicator_gib_risk_denominator = at_gib_risk
+
+        cohort.assert_results(indicator_gib_risk_numerator=None)
+        cohort.assert_results(indicator_gib_risk_denominator=None)
+
+    with subtest(
+        "indicator_gib_num_admissions",
+        missing_feature="Missing TPPBackend.hospital_admissions",
+    ):
+        # TPPBackend.hospitalizations exists but doesn't expose an admission_method
+        # property. It's also not clear whether hospitalizations.code ==
+        # hospital_admissions.primary_diagnosis.
+        indicator_gib_num_admissions = (
+            hospital_admissions.filter(
+                hospital_admissions.primary_diagnosis.is_in(gib_admissions_codelist)
+            )
+            .filter(hospital_admissions.episode_is_finished is True)
+            .filter(hospital_admissions.admission_date >= index_date_minus_3_months)
+            .filter(hospital_admissions.admission_date <= index_date)
+        )
+        with subtest(
+            "indicator_gib_num_admissions_admission_method",
+            missing_feature="admission_method can contain alphanumeric codes, not just integers; it should be possible to query it with is_in",
+        ):
+            indicator_gib_num_admissions = indicator_gib_num_admissions.filter(
+                hospital_admissions.admission_method.is_in(EMERGENCY_ADMISSION_CODES)
+            )
+
+        cohort.indicator_gib_num_admissions = (
+            indicator_gib_num_admissions.count_for_patient()
+        )
+        cohort.assert_results(indicator_gib_num_admissions=None)
+
+        cohort.indicator_gib_admission_numerator = (
+            cohort.indicator_gib_risk_numerator
+            & (cohort.indicator_gib_num_admissions > 0)
+        )
+        cohort.assert_results(indicator_gib_admission_numerator=None)
+
+    # AKI01
+    # -----
+    with subtest("ras"):
+        # In the v1 study definition, the variable passed to the equivalent of is_in,
+        # below, is called a placeholder. However, it corresponds to the same underlying
+        # codelist as oral_nsaid_codelist, which makes the following property identical
+        # to cohort.oral_nsaid. We will retain it, despite the redundancy, because it
+        # makes comparing the v1 study definition to the cohort easier.
+        cohort.ras = (
+            clinical_events.filter(clinical_events.code.is_in(oral_nsaid_codelist))
+            .filter(clinical_events.date >= index_date_minus_3_months)
+            .filter(clinical_events.date <= index_date)
+            .exists_for_patient()
+        )
+        cohort.assert_results(ras=True)
+
+    with subtest("diuretic"):
+        # See above comment
+        cohort.diuretic = (
+            clinical_events.filter(clinical_events.code.is_in(oral_nsaid_codelist))
+            .filter(clinical_events.date >= index_date_minus_3_months)
+            .filter(clinical_events.date <= index_date)
+            .exists_for_patient()
+        )
+        cohort.assert_results(diuretic=True)
+
+    with subtest("indicator_aki_risk", missing_feature="Arithmetic on BoolSeries"):
+        cohort.indicator_aki_risk_numerator = (
+            cohort.oral_nsaid & cohort.ras & cohort.diuretic
+        )
+        cohort.indicator_aki_risk_denominator = (
+            cohort.oral_nsaid | cohort.ras | cohort.diuretic
+        )
+        cohort.assert_results(indicator_aki_risk_numerator=None)
+        cohort.assert_results(indicator_aki_risk_denominator=None)
+
+    with subtest(
+        "indicator_aki_num_admissions",
+        missing_feature="Missing TPPBackend.hospital_admissions",
+    ):
+        # TPPBackend.hospitalizations exists but doesn't expose an admission_method
+        # property. It's also not clear whether hospitalizations.code ==
+        # hospital_admissions.primary_diagnosis.
+        indicator_aki_num_admissions = (
+            hospital_admissions.filter(
+                hospital_admissions.primary_diagnosis.is_in(
+                    placeholder_admissions_codelist
+                )
+            )
+            .filter(hospital_admissions.episode_is_finished is True)
+            .filter(hospital_admissions.admission_date >= index_date_minus_3_months)
+            .filter(hospital_admissions.admission_date <= index_date)
+        )
+        with subtest(
+            "indicator_aki_num_admissions_admission_method",
+            missing_feature="admission_method can contain alphanumeric codes, not just integers; it should be possible to query it with is_in",
+        ):
+            indicator_aki_num_admissions = indicator_aki_num_admissions.filter(
+                hospital_admissions.admission_method.is_in(EMERGENCY_ADMISSION_CODES)
+            )
+
+        cohort.indicator_aki_num_admissions = (
+            indicator_aki_num_admissions.count_for_patient()
+        )
+        cohort.assert_results(indicator_aki_num_admissions=None)
+
+        cohort.indicator_aki_admission_numerator = (
+            cohort.indicator_aki_risk_numerator
+            & (cohort.indicator_aki_num_admissions > 0)
+        )
+        cohort.assert_results(indicator_aki_admission_numerator=None)
+
+    # PAIN01
+    # ------
+    with subtest("opioid"):
+        # In the v1 study definition, the variable passed to the equivalent of is_in,
+        # below, is called a placeholder. However, it corresponds to the same underlying
+        # codelist as oral_nsaid_codelist, which makes the following property identical
+        # to cohort.oral_nsaid. We will retain it, despite the redundancy, because it
+        # makes comparing the v1 study definition to the cohort easier.
+        cohort.opioid = (
+            clinical_events.filter(clinical_events.code.is_in(oral_nsaid_codelist))
+            .filter(clinical_events.date >= index_date_minus_3_months)
+            .filter(clinical_events.date <= index_date)
+            .exists_for_patient()
+        )
+        cohort.assert_results(opioid=True)
+
+    with subtest("sedative"):
+        # See above comment
+        cohort.sedative = (
+            clinical_events.filter(clinical_events.code.is_in(oral_nsaid_codelist))
+            .filter(clinical_events.date >= index_date_minus_3_months)
+            .filter(clinical_events.date <= index_date)
+            .exists_for_patient()
+        )
+        cohort.assert_results(sedative=True)
+
+    with subtest("indicator_pain_risk", missing_feature="Arithmetic on BoolSeries"):
+        cohort.indicator_pain_risk_numerator = cohort.opioid & cohort.sedative
+        cohort.indicator_pain_risk_denominator = cohort.opioid | cohort.sedative
+        cohort.assert_results(indicator_pain_risk_numerator=None)
+        cohort.assert_results(indicator_pain_risk_denominator=None)
+
+    with subtest(
+        "indicator_pain_num_admissions",
+        missing_feature="Missing TPPBackend.hospital_admissions",
+    ):
+        # TPPBackend.hospitalizations exists but doesn't expose an admission_method
+        # property. It's also not clear whether hospitalizations.code ==
+        # hospital_admissions.primary_diagnosis.
+        indicator_pain_num_admissions = (
+            hospital_admissions.filter(
+                hospital_admissions.primary_diagnosis.is_in(
+                    placeholder_admissions_codelist
+                )
+            )
+            .filter(hospital_admissions.episode_is_finished is True)
+            .filter(hospital_admissions.admission_date >= index_date_minus_3_months)
+            .filter(hospital_admissions.admission_date <= index_date)
+        )
+        with subtest(
+            "indicator_pain_num_admissions_admission_method",
+            missing_feature="admission_method can contain alphanumeric codes, not just integers; it should be possible to query it with is_in",
+        ):
+            indicator_pain_num_admissions.filter(
+                hospital_admissions.admission_method.is_in(EMERGENCY_ADMISSION_CODES)
+            )
+
+        cohort.indicator_pain_num_admissions = (
+            indicator_pain_num_admissions.count_for_patient()
+        )
+        cohort.assert_results(indicator_pain_num_admissions=None)
+
+        cohort.indicator_pain_admission_numerator = (
+            cohort.indicator_pain_risk_numerator
+            & (cohort.indicator_pain_num_admissions > 0)
+        )
+        cohort.assert_results(indicator_pain_admission_numerator=None)
+
+
+def setup_data(database):
+    database.setup(
+        organisation(organisation_id=1, region="South"),
+        patient(
+            1,
+            "F",
+            "1954-09-01",
+            registration(
+                start_date="2001-01-01", end_date="2026-06-26", organisation_id=1
+            ),
+            snomed_event(code="621911000001109", date="2019-06-01"),  # oral nsaid
+            snomed_event(code="240811000001108", date="2019-09-01"),  # ppi
+        ),
+    )

--- a/tests/fixtures/acceptance/codelists/nhsbsa-adm-gastro-intestinal-bleed-5d4b7131.csv
+++ b/tests/fixtures/acceptance/codelists/nhsbsa-adm-gastro-intestinal-bleed-5d4b7131.csv
@@ -1,0 +1,24 @@
+code,term
+I850,Oesophageal varices with bleeding
+K226,Gastro-oesophageal laceration-haemorrhage syndrome
+K228,Other specified diseases of oesophagus
+K250,Gastric ulcer : Acute with haemorrhage
+K252,Gastric ulcer : Acute with both haemorrhage and perforation
+K254,Gastric ulcer : Chronic or unspecified with haemorrhage
+K256,Gastric ulcer : Chronic or unspecified with both haemorrhage and perforation
+K260,Duodenal ulcer : Acute with haemorrhage
+K262,Duodenal ulcer : Acute with both haemorrhage and perforation
+K264,Duodenal ulcer : Chronic or unspecified with haemorrhage
+K266,Duodenal ulcer : Chronic or unspecified with both haemorrhage and perforation
+K270,"Peptic ulcer, site unspecified : Acute with haemorrhage"
+K272,"Peptic ulcer, site unspecified : Acute with both haemorrhage and perforation"
+K274,"Peptic ulcer, site unspecified : Chronic or unspecified with haemorrhage"
+K276,"Peptic ulcer, site unspecified : Chronic or unspecified with both haemorrhage and perforation"
+K280,Gastrojejunal ulcer : Acute with haemorrhage
+K282,Gastrojejunal ulcer : Acute with both haemorrhage and perforation
+K284,Gastrojejunal ulcer : Chronic or unspecified with haemorrhage
+K286,Gastrojejunal ulcer : Chronic or unspecified with both haemorrhage and perforation
+K290,Acute haemorrhagic gastritis
+K920,Haematemesis
+K921,Melaena
+K922,"Gastrointestinal haemorrhage, unspecified"

--- a/tests/fixtures/acceptance/codelists/pincer-nsaid-23edd06e.csv
+++ b/tests/fixtures/acceptance/codelists/pincer-nsaid-23edd06e.csv
@@ -1,0 +1,1467 @@
+id,term
+329923004,Aceclofenac
+329925006,Aceclofenac 100mg tablets
+10961811000001104,Aceclofenac 100mg tablets (A A H Pharmaceuticals Ltd)
+27840711000001109,Aceclofenac 100mg tablets (Accord Healthcare Ltd)
+10985211000001100,Aceclofenac 100mg tablets (Alliance Healthcare (Distribution) Ltd)
+37689911000001101,Aceclofenac 100mg tablets (CST Pharma Ltd)
+19700711000001109,Aceclofenac 100mg tablets (DE Pharmaceuticals)
+17748811000001101,Aceclofenac 100mg tablets (Phoenix Healthcare Distribution Ltd)
+33498211000001105,Aceclofenac 100mg tablets (Rivopharm (UK) Ltd)
+15058911000001106,Aceclofenac 100mg tablets (Sigma Pharmaceuticals Plc)
+329907004,Acemetacin 60mg capsules
+411996001,Acemetacin in oral dosage form
+784011000001106,Acoflam 100mg Retard tablets (Mercury Pharma Group Ltd)
+318711000001104,Acoflam 25mg gastro-resistant tablets (Mercury Pharma Group Ltd)
+541811000001109,Acoflam 75mg SR tablets (Mercury Pharma Group Ltd)
+8970311000001109,Advil 200mg tablets (Wyeth Consumer Healthcare)
+633211000001103,Advil Extra Strength 400mg tablets (Wyeth Consumer Healthcare)
+601311000001100,Anadin Ibuprofen 200mg tablets (Pfizer Consumer Healthcare Ltd)
+13101011000001106,Anadin Joint Pain 200mg tablets (Pfizer Consumer Healthcare Ltd)
+19510011000001106,Anadin LiquiFast 200mg effervescent tablets (Pfizer Consumer Healthcare Ltd)
+10752411000001106,Anadin LiquiFast 400mg capsules (Pfizer Consumer Healthcare Ltd)
+28939511000001106,Anadin Period Pain Relief 200mg capsules (Pfizer Consumer Healthcare Ltd)
+3918911000001101,Anadin Ultra 200mg capsules (Pfizer Consumer Healthcare Ltd)
+13829911000001108,Arcoxia 120mg tablets (DE Pharmaceuticals)
+19865311000001104,Arcoxia 120mg tablets (Lexon (UK) Ltd)
+16266111000001109,Arcoxia 120mg tablets (Mawdsley-Brooks & Company Ltd)
+3407911000001102,Arcoxia 120mg tablets (Merck Sharp & Dohme Ltd)
+17588311000001100,Arcoxia 120mg tablets (Necessity Supplies Ltd)
+11764811000001101,Arcoxia 120mg tablets (Waymade Healthcare Plc)
+18545411000001104,Arcoxia 30mg tablets (DE Pharmaceuticals)
+19865111000001101,Arcoxia 30mg tablets (Lexon (UK) Ltd)
+17492311000001105,Arcoxia 30mg tablets (Mawdsley-Brooks & Company Ltd)
+13122311000001105,Arcoxia 30mg tablets (Merck Sharp & Dohme Ltd)
+20132411000001101,Arcoxia 30mg tablets (Waymade Healthcare Plc)
+37358511000001100,Arcoxia 60mg tablets (CST Pharma Ltd)
+13829511000001101,Arcoxia 60mg tablets (DE Pharmaceuticals)
+13099411000001106,Arcoxia 60mg tablets (Dowelhurst Ltd)
+16138511000001106,Arcoxia 60mg tablets (Lexon (UK) Ltd)
+16265311000001101,Arcoxia 60mg tablets (Mawdsley-Brooks & Company Ltd)
+3406111000001103,Arcoxia 60mg tablets (Merck Sharp & Dohme Ltd)
+17587411000001108,Arcoxia 60mg tablets (Necessity Supplies Ltd)
+37620411000001105,Arcoxia 60mg tablets (Pilsco Ltd)
+14195411000001100,Arcoxia 60mg tablets (Sigma Pharmaceuticals Plc)
+11538811000001103,Arcoxia 60mg tablets (Waymade Healthcare Plc)
+37358211000001103,Arcoxia 90mg tablets (CST Pharma Ltd)
+13829711000001106,Arcoxia 90mg tablets (DE Pharmaceuticals)
+13099911000001103,Arcoxia 90mg tablets (Dowelhurst Ltd)
+16138711000001101,Arcoxia 90mg tablets (Lexon (UK) Ltd)
+16265711000001102,Arcoxia 90mg tablets (Mawdsley-Brooks & Company Ltd)
+3406811000001105,Arcoxia 90mg tablets (Merck Sharp & Dohme Ltd)
+17587811000001105,Arcoxia 90mg tablets (Necessity Supplies Ltd)
+37620611000001108,Arcoxia 90mg tablets (Pilsco Ltd)
+14195911000001108,Arcoxia 90mg tablets (Sigma Pharmaceuticals Plc)
+11539111000001103,Arcoxia 90mg tablets (Waymade Healthcare Plc)
+389511000001100,Arthrofen 200 tablets (Ashbourne Pharmaceuticals Ltd)
+933011000001107,Arthrofen 400 tablets (Ashbourne Pharmaceuticals Ltd)
+415611000001108,Arthrofen 600 tablets (Ashbourne Pharmaceuticals Ltd)
+624911000001107,Arthrosin 250 tablets (Ashbourne Pharmaceuticals Ltd)
+166111000001106,Arthrosin 500 tablets (Ashbourne Pharmaceuticals Ltd)
+922711000001104,Arthrosin EC 250 tablets (Ashbourne Pharmaceuticals Ltd)
+236611000001105,Arthrosin EC 500 tablets (Ashbourne Pharmaceuticals Ltd)
+29978211000001104,Arthrotec 50 gastro-resistant tablets (Lexon (UK) Ltd)
+3159911000001101,Arthrotec 50 gastro-resistant tablets (Pfizer Ltd)
+37620811000001107,Arthrotec 50 gastro-resistant tablets (Pilsco Ltd)
+29978411000001100,Arthrotec 75 gastro-resistant tablets (Lexon (UK) Ltd)
+3161411000001104,Arthrotec 75 gastro-resistant tablets (Pfizer Ltd)
+16148311000001101,Axorid 100mg/20mg modified-release capsules (Meda Pharmaceuticals Ltd)
+16140611000001108,Axorid 200mg/20mg modified-release capsules (Meda Pharmaceuticals Ltd)
+329546008,Azapropazone 300mg capsules
+329547004,Azapropazone 600mg tablets
+3912911000001104,Benoral 2g granules sachets (Sanofi-Synthelabo Ltd)
+710211000001107,Benoral 2g/5ml oral suspension (Sanofi-Synthelabo Ltd)
+114411000001108,Benoral 750mg tablets (Sanofi-Synthelabo Ltd)
+329533003,Benorilate 2g granules sachets sugar free
+35910211000001100,Benorilate 2g/5ml oral suspension sugar free
+627611000001107,Benorilate 2g/5ml oral suspension sugar free (A A H Pharmaceuticals Ltd)
+311811000001101,Benorilate 2g/5ml oral suspension sugar free (Alliance Healthcare (Distribution) Ltd)
+4578411000001105,Benorilate 2g/5ml oral suspension sugar free (Kent Pharmaceuticals Ltd)
+271011000001107,Benorilate 2g/5ml oral suspension sugar free (Mylan)
+738711000001108,Benorilate 2g/5ml oral suspension sugar free (Sterwin Medicines)
+766542002,Benorilate 400 mg/mL oral suspension
+329532008,Benorilate 750mg tablets
+774111000001104,Benorilate 750mg tablets (A A H Pharmaceuticals Ltd)
+926411000001106,Benorilate 750mg tablets (Kent Pharmaceuticals Ltd)
+536111000001107,Benorilate 750mg tablets (Sterwin Medicines)
+411998000,Benorylate in oral dosage form
+867711000001101,Berlind 75 Retard capsules (Tillomed Laboratories Ltd)
+4491011000001107,Bextra 10mg tablets (Pfizer Ltd)
+4491511000001104,Bextra 20mg tablets (Pfizer Ltd)
+4492311000001101,Bextra 40mg tablets (Pfizer Ltd)
+8781711000001100,Boots Cold and Flu Relief with Ibuprofen tablets (The Boots Company Plc)
+31003411000001100,Boots Ibuprofen 3 Months Plus 100mg/5ml oral suspension strawberry (The Boots Company Plc)
+18822611000001108,Boots Ibuprofen 6 Months Plus 100mg/5ml oral suspension strawberry (The Boots Company Plc)
+31004511000001103,Boots Ibuprofen and Codeine 200mg/12.8mg tablets (The Boots Company Plc)
+31005011000001105,Boots Ibuprofen Long Lasting 200mg capsules (The Boots Company Plc)
+31017911000001101,Boots Period Pain Relief 250mg gastro-resistant tablets (The Boots Company Plc)
+17982711000001105,Boots Rapid Ibuprofen lysine 342mg tablets (The Boots Company Plc)
+17811000001106,Brexidol 20mg tablets (Chiesi Ltd)
+13837411000001106,Brexidol 20mg tablets (DE Pharmaceuticals)
+16142811000001108,Brexidol 20mg tablets (Lexon (UK) Ltd)
+16347811000001100,Brexidol 20mg tablets (Mawdsley-Brooks & Company Ltd)
+14288711000001103,Brexidol 20mg tablets (Sigma Pharmaceuticals Plc)
+10494611000001100,Brexidol 20mg tablets (Waymade Healthcare Plc)
+18547611000001108,Brufen 100mg/5ml syrup (DE Pharmaceuticals)
+19866611000001104,Brufen 100mg/5ml syrup (Lexon (UK) Ltd)
+19729911000001108,Brufen 100mg/5ml syrup (Mawdsley-Brooks & Company Ltd)
+445711000001109,Brufen 100mg/5ml syrup (Mylan)
+17534011000001103,Brufen 100mg/5ml syrup (Sigma Pharmaceuticals Plc)
+30269111000001109,Brufen 100mg/5ml syrup (Waymade Healthcare Plc)
+643711000001106,Brufen 200mg tablets (Abbott Laboratories Ltd)
+263211000001109,Brufen 400mg tablets (Mylan)
+37380211000001105,Brufen 600mg effervescent granules sachets (CST Pharma Ltd)
+18547411000001105,Brufen 600mg effervescent granules sachets (DE Pharmaceuticals)
+29980411000001108,Brufen 600mg effervescent granules sachets (Lexon (UK) Ltd)
+18191711000001105,Brufen 600mg effervescent granules sachets (Mawdsley-Brooks & Company Ltd)
+3239211000001107,Brufen 600mg effervescent granules sachets (Mylan)
+17614211000001105,Brufen 600mg effervescent granules sachets (Necessity Supplies Ltd)
+30269311000001106,Brufen 600mg effervescent granules sachets (Waymade Healthcare Plc)
+230111000001100,Brufen 600mg tablets (Mylan)
+37380011000001100,Brufen Retard 800mg tablets (CST Pharma Ltd)
+38122811000001103,Brufen Retard 800mg tablets (DE Pharmaceuticals)
+5525711000001101,Brufen Retard 800mg tablets (Dowelhurst Ltd)
+29980611000001106,Brufen Retard 800mg tablets (Lexon (UK) Ltd)
+368011000001100,Brufen Retard 800mg tablets (Mylan)
+5489311000001103,Brufen Retard 800mg tablets (Waymade Healthcare Plc)
+4663611000001101,Butacote 100mg gastro-resistant tablets (Novartis Pharmaceuticals UK Ltd)
+4585211000001105,Calprofen 100mg/5ml oral suspension (McNeil Products Ltd)
+11753011000001104,Calprofen 100mg/5ml oral suspension 5ml sachets (McNeil Products Ltd)
+7643811000001101,Calprofen 100mg/5ml oral suspension paediatric (McNeil Products Ltd)
+29666011000001102,Care Ibuprofen for Children 100mg/5ml oral suspension (Thornton & Ross Ltd)
+13847111000001102,Celebrex 100mg capsules (DE Pharmaceuticals)
+5530911000001106,Celebrex 100mg capsules (Dowelhurst Ltd)
+16458511000001106,Celebrex 100mg capsules (Mawdsley-Brooks & Company Ltd)
+17623711000001105,Celebrex 100mg capsules (Necessity Supplies Ltd)
+18711000001102,Celebrex 100mg capsules (Pfizer Ltd)
+14492311000001100,Celebrex 100mg capsules (Sigma Pharmaceuticals Plc)
+18292411000001107,Celebrex 100mg capsules (Stephar (U.K.) Ltd)
+10500411000001103,Celebrex 100mg capsules (Waymade Healthcare Plc)
+13847411000001107,Celebrex 200mg capsules (DE Pharmaceuticals)
+5529911000001102,Celebrex 200mg capsules (Dowelhurst Ltd)
+16147411000001109,Celebrex 200mg capsules (Lexon (UK) Ltd)
+16458911000001104,Celebrex 200mg capsules (Mawdsley-Brooks & Company Ltd)
+17624111000001106,Celebrex 200mg capsules (Necessity Supplies Ltd)
+878111000001108,Celebrex 200mg capsules (Pfizer Ltd)
+14492711000001101,Celebrex 200mg capsules (Sigma Pharmaceuticals Plc)
+5346211000001101,Celebrex 200mg capsules (Waymade Healthcare Plc)
+330170001,Celecoxib 100mg capsules
+28378611000001105,Celecoxib 100mg capsules (A A H Pharmaceuticals Ltd)
+28378211000001108,Celecoxib 100mg capsules (Actavis UK Ltd)
+28039011000001105,Celecoxib 100mg capsules (Alliance Healthcare (Distribution) Ltd)
+32496211000001102,Celecoxib 100mg capsules (Brown & Burk UK Ltd)
+35906711000001107,Celecoxib 100mg capsules (Consilient Health Ltd)
+37893811000001100,Celecoxib 100mg capsules (Dawa Ltd)
+30136411000001104,Celecoxib 100mg capsules (DE Pharmaceuticals)
+32397411000001105,Celecoxib 100mg capsules (Kent Pharmaceuticals Ltd)
+36751811000001106,Celecoxib 100mg capsules (Macleods Pharma UK Ltd)
+30011211000001106,Celecoxib 100mg capsules (Mawdsley-Brooks & Company Ltd)
+35140711000001104,Celecoxib 100mg capsules (Milpharm Ltd)
+33588711000001109,Celecoxib 100mg capsules (Mylan)
+28011711000001103,Celecoxib 100mg capsules (Pfizer Ltd)
+29784511000001108,Celecoxib 100mg capsules (Sigma Pharmaceuticals Plc)
+28001111000001101,Celecoxib 100mg capsules (Teva UK Ltd)
+36859211000001109,Celecoxib 100mg capsules (Torrent Pharma (UK) Ltd)
+28292711000001100,Celecoxib 100mg capsules (Zentiva)
+330169002,Celecoxib 200mg capsules
+28378811000001109,Celecoxib 200mg capsules (A A H Pharmaceuticals Ltd)
+28378411000001107,Celecoxib 200mg capsules (Actavis UK Ltd)
+28039211000001100,Celecoxib 200mg capsules (Alliance Healthcare (Distribution) Ltd)
+32496411000001103,Celecoxib 200mg capsules (Brown & Burk UK Ltd)
+35906911000001109,Celecoxib 200mg capsules (Consilient Health Ltd)
+37894011000001108,Celecoxib 200mg capsules (Dawa Ltd)
+30136611000001101,Celecoxib 200mg capsules (DE Pharmaceuticals)
+36741411000001107,Celecoxib 200mg capsules (Macleods Pharma UK Ltd)
+30011411000001105,Celecoxib 200mg capsules (Mawdsley-Brooks & Company Ltd)
+34584911000001102,Celecoxib 200mg capsules (Milpharm Ltd)
+33588911000001106,Celecoxib 200mg capsules (Mylan)
+28011911000001101,Celecoxib 200mg capsules (Pfizer Ltd)
+29784111000001104,Celecoxib 200mg capsules (Sigma Pharmaceuticals Plc)
+28000911000001105,Celecoxib 200mg capsules (Teva UK Ltd)
+36859611000001106,Celecoxib 200mg capsules (Torrent Pharma (UK) Ltd)
+28292911000001103,Celecoxib 200mg capsules (Zentiva)
+425685004,Celecoxib 400mg capsules
+425451006,Celecoxib 50 mg/1 each oral capsule
+35573711000001100,Celecoxib 50mg/5ml oral suspension
+35571511000001106,Celecoxib 50mg/5ml oral suspension (Special Order)
+411999008,Celecoxib in oral dosage form
+766729004,Chlorpheniramine 2mg/ibuprofen 200mg/pseudoephedrine 30mg conventional release oral tablet
+3674211000001109,Clinoril 100mg tablets (Merck Sharp & Dohme Ltd)
+3676011000001109,Clinoril 200mg tablets (Merck Sharp & Dohme Ltd)
+497011000001107,Closteril 100 modified-release tablets (Pharmalife Healthcare Services Ltd)
+3673311000001103,Clotam Rapid 200mg tablets (Galen Ltd)
+3420111000001109,Codafen Continus tablets (Napp Pharmaceuticals Ltd)
+767793000,Codeine and ibuprofen in oral dosage form
+765579005,Codeine phosphate 20 mg and ibuprofen 300 mg prolonged-release oral tablet
+33563011000001103,Combogesic 500mg/150mg tablets (Thornton & Ross Ltd)
+640911000001100,Cuprofen 200mg tablets (SSL International Plc)
+9890311000001105,Cuprofen for Children 100mg/5ml oral suspension (SSL International Plc)
+621611000001103,Cuprofen Maximum Strength 400mg tablets (SSL International Plc)
+8092711000001106,Cuprofen PLUS tablets (SSL International Plc)
+386511000001105,Defanac 25mg gastro-resistant tablets (Ranbaxy (UK) Ltd)
+906311000001107,Defanac 75mg SR tablets (Ranbaxy (UK) Ltd)
+440911000001102,Defanac Retard 100mg tablets (Ranbaxy (UK) Ltd)
+418352003,Dexibuprofen 300mg tablets
+418855005,Dexibuprofen 400mg tablets
+768118003,Dexibuprofen in oral dosage form
+329963003,Dexketoprofen 25mg tablets
+5358611000001100,Dexketoprofen 25mg tablets (Waymade Healthcare Plc)
+412005007,Dexketoprofen in oral dosage form
+922511000001109,Dexomon 75mg SR tablets (Hillcross Pharmaceuticals Ltd)
+38411011000001109,Diclo-SR 75mg tablets (Strides Pharma UK Ltd)
+15242611000001108,Diclofenac 100mg/5ml oral solution
+15238211000001107,Diclofenac 100mg/5ml oral solution (Special Order)
+15242711000001104,Diclofenac 100mg/5ml oral suspension
+15238511000001105,Diclofenac 100mg/5ml oral suspension (Special Order)
+17369211000001102,Diclofenac 10mg dispersible tablets
+17359311000001102,Diclofenac 10mg dispersible tablets (Special Order)
+8455011000001100,Diclofenac 10mg/5ml oral solution
+8438311000001105,Diclofenac 10mg/5ml oral solution (Special Order)
+8455111000001104,Diclofenac 10mg/5ml oral suspension
+8438611000001100,Diclofenac 10mg/5ml oral suspension (Special Order)
+11650911000001102,Diclofenac 12.5mg/5ml oral solution
+11633411000001103,Diclofenac 12.5mg/5ml oral solution (Special Order)
+11651011000001105,Diclofenac 12.5mg/5ml oral suspension
+11632711000001101,Diclofenac 12.5mg/5ml oral suspension (Special Order)
+8455211000001105,Diclofenac 15mg/5ml oral solution
+8439711000001100,Diclofenac 15mg/5ml oral solution (Special Order)
+8455311000001102,Diclofenac 15mg/5ml oral suspension
+8440411000001100,Diclofenac 15mg/5ml oral suspension (Special Order)
+8455411000001109,Diclofenac 25mg/5ml oral solution
+8439611000001109,Diclofenac 25mg/5ml oral solution (Special Order)
+8455511000001108,Diclofenac 25mg/5ml oral suspension
+8440111000001105,Diclofenac 25mg/5ml oral suspension (Special Order)
+28422211000001104,Diclofenac 40mg/5ml oral solution
+28414411000001104,Diclofenac 40mg/5ml oral solution (Special Order)
+28422311000001107,Diclofenac 40mg/5ml oral suspension
+28414711000001105,Diclofenac 40mg/5ml oral suspension (Special Order)
+329591004,Diclofenac 50mg dispersible tablets sugar free
+11651311000001108,Diclofenac 50mg/5ml oral solution
+11634411000001100,Diclofenac 50mg/5ml oral solution (Special Order)
+11648711000001104,Diclofenac 50mg/5ml oral suspension
+11615511000001106,Diclofenac 50mg/5ml oral suspension (Drug Tariff Special Order)
+11652111000001101,Diclofenac 75mg/5ml oral solution
+11635911000001107,Diclofenac 75mg/5ml oral solution (Special Order)
+11651411000001101,Diclofenac 75mg/5ml oral suspension
+11635311000001106,Diclofenac 75mg/5ml oral suspension (Special Order)
+14062911000001108,Diclofenac potassium 12.5mg tablets
+329967002,Diclofenac potassium 25mg tablets
+17014711000001105,Diclofenac potassium 25mg tablets (A A H Pharmaceuticals Ltd)
+16236911000001100,Diclofenac potassium 25mg tablets (Accord Healthcare Ltd)
+329968007,Diclofenac potassium 50mg tablets
+16650211000001108,Diclofenac potassium 50mg tablets (A A H Pharmaceuticals Ltd)
+16237611000001108,Diclofenac potassium 50mg tablets (Accord Healthcare Ltd)
+18341211000001104,Diclofenac potassium 50mg tablets (Alliance Healthcare (Distribution) Ltd)
+30048011000001102,Diclofenac potassium 50mg tablets (DE Pharmaceuticals)
+18618611000001109,Diclofenac potassium 50mg tablets (Phoenix Healthcare Distribution Ltd)
+37084611000001101,Diclofenac sodium 100mg modified-release capsules
+10529711000001106,Diclofenac sodium 100mg modified-release capsules (Waymade Healthcare Plc)
+36563711000001106,Diclofenac sodium 100mg modified-release tablets
+36566511000001109,Diclofenac sodium 25mg gastro-resistant tablets
+555811000001109,Diclofenac sodium 25mg gastro-resistant tablets (A A H Pharmaceuticals Ltd)
+780411000001108,Diclofenac sodium 25mg gastro-resistant tablets (Actavis UK Ltd)
+271711000001109,Diclofenac sodium 25mg gastro-resistant tablets (Alliance Healthcare (Distribution) Ltd)
+10401011000001106,Diclofenac sodium 25mg gastro-resistant tablets (Arrow Generics Ltd)
+36784811000001104,Diclofenac sodium 25mg gastro-resistant tablets (Crescent Pharma Ltd)
+23862211000001104,Diclofenac sodium 25mg gastro-resistant tablets (DE Pharmaceuticals)
+37926711000001100,Diclofenac sodium 25mg gastro-resistant tablets (Dexcel-Pharma Ltd)
+182611000001101,Diclofenac sodium 25mg gastro-resistant tablets (IVAX Pharmaceuticals UK Ltd)
+829411000001105,Diclofenac sodium 25mg gastro-resistant tablets (Kent Pharmaceuticals Ltd)
+34604011000001106,Diclofenac sodium 25mg gastro-resistant tablets (Medreich Plc)
+534911000001102,Diclofenac sodium 25mg gastro-resistant tablets (Mylan)
+326211000001100,Diclofenac sodium 25mg gastro-resistant tablets (Pfizer Ltd)
+17891411000001103,Diclofenac sodium 25mg gastro-resistant tablets (Phoenix Healthcare Distribution Ltd)
+530011000001108,Diclofenac sodium 25mg gastro-resistant tablets (Sandoz Ltd)
+268911000001105,Diclofenac sodium 25mg gastro-resistant tablets (Sterwin Medicines)
+175011000001107,Diclofenac sodium 25mg gastro-resistant tablets (Teva UK Ltd)
+21943011000001106,Diclofenac sodium 25mg gastro-resistant tablets (Waymade Healthcare Plc)
+329598005,Diclofenac sodium 50mg gastro-resistant / Misoprostol 200microgram tablets
+329587009,Diclofenac sodium 50mg gastro-resistant tablets
+699311000001103,Diclofenac sodium 50mg gastro-resistant tablets (A A H Pharmaceuticals Ltd)
+30049011000001107,Diclofenac sodium 50mg gastro-resistant tablets (DE Pharmaceuticals)
+37926911000001103,Diclofenac sodium 50mg gastro-resistant tablets (Dexcel-Pharma Ltd)
+34603211000001104,Diclofenac sodium 50mg gastro-resistant tablets (Medreich Plc)
+17891611000001100,Diclofenac sodium 50mg gastro-resistant tablets (Phoenix Healthcare Distribution Ltd)
+18722511000001107,Diclofenac sodium 50mg gastro-resistant tablets (Sigma Pharmaceuticals Plc)
+252911000001102,Diclofenac sodium 50mg gastro-resistant tablets (Teva UK Ltd)
+329602007,Diclofenac sodium 75mg gastro-resistant / Misoprostol 200microgram tablets
+329574003,Diclofenac sodium 75mg gastro-resistant modified-release capsules
+37084911000001107,Diclofenac sodium 75mg modified-release capsules
+10530111000001102,Diclofenac sodium 75mg modified-release capsules (Waymade Healthcare Plc)
+13222101000001109,Diclofenac sodium 75mg modified-release tablets
+329607001,Diclofenac sodium 75mg modified-release tablets
+10686011000001100,Dicloflex 25mg gastro-resistant tablets (Almus Pharmaceuticals Ltd)
+570111000001107,Dicloflex 25mg gastro-resistant tablets (Dexcel-Pharma Ltd)
+10612711000001100,Dicloflex 25mg gastro-resistant tablets (Teva UK Ltd)
+18299411000001101,Dicloflex 75mg SR tablets (Actavis UK Ltd)
+10686411000001109,Dicloflex 75mg SR tablets (Almus Pharmaceuticals Ltd)
+225611000001103,Dicloflex 75mg SR tablets (Dexcel-Pharma Ltd)
+7854211000001109,Dicloflex 75mg SR tablets (Kent Pharmaceuticals Ltd)
+7852911000001109,Dicloflex 75mg SR tablets (Teva UK Ltd)
+10686711000001103,Dicloflex Retard 100mg tablets (Almus Pharmaceuticals Ltd)
+190611000001103,Dicloflex Retard 100mg tablets (Dexcel-Pharma Ltd)
+7854611000001106,Dicloflex Retard 100mg tablets (Kent Pharmaceuticals Ltd)
+7853311000001103,Dicloflex Retard 100mg tablets (Teva UK Ltd)
+18574111000001106,Diclomax Retard 100mg capsules (DE Pharmaceuticals)
+350511000001103,Diclomax Retard 100mg capsules (Galen Ltd)
+16258311000001101,Diclomax Retard 100mg capsules (Mawdsley-Brooks & Company Ltd)
+15417211000001101,Diclomax Retard 100mg capsules (Waymade Healthcare Plc)
+13865111000001104,Diclomax SR 75mg capsules (DE Pharmaceuticals)
+172511000001105,Diclomax SR 75mg capsules (Galen Ltd)
+16258611000001106,Diclomax SR 75mg capsules (Mawdsley-Brooks & Company Ltd)
+15417411000001102,Diclomax SR 75mg capsules (Waymade Healthcare Plc)
+193511000001108,Diclotard 75mg modified-release tablets (Galen Ltd)
+78311000001106,Diclovol 25mg gastro-resistant tablets (Arun Pharmaceuticals Ltd)
+282411000001101,Diclovol 75mg SR tablets (Arun Pharmaceuticals Ltd)
+7853611000001108,Diclovol 75mg SR tablets (Mylan)
+123311000001105,Diclovol Retard 100mg tablets (Arun Pharmaceuticals Ltd)
+7854011000001104,Diclovol Retard 100mg tablets (Mylan)
+334011000001103,Diclozip 25mg gastro-resistant tablets (Ashbourne Pharmaceuticals Ltd)
+329612000,Diflunisal 250mg tablets
+15870411000001104,Diflunisal 250mg tablets (Special Order)
+329613005,Diflunisal 500mg tablets
+767967003,Diflunisal in oral dosage form
+420943003,Diphenhydramine + ibuprofen
+420700002,Diphenhydramine 25 mg and ibuprofen 200 mg/1 each oral capsule
+441834006,Diphenhydramine 38 mg and ibuprofen 200 mg/1 each oral capsule
+768110005,Diphenhydramine and ibuprofen in oral dosage form
+3674011000001104,Dolobid 250mg tablets (Merck Sharp & Dohme Ltd)
+3674611000001106,Dolobid 500mg tablets (Merck Sharp & Dohme Ltd)
+5363211000001101,Dolobid 500mg tablets (Waymade Healthcare Plc)
+221211000001103,Dysman 250 capsules (Ashbourne Pharmaceuticals Ltd)
+180611000001102,Dysman 500 tablets (Ashbourne Pharmaceuticals Ltd)
+3979111000001103,Ebretin 200mg capsules (Ranbaxy (UK) Ltd)
+3979611000001106,Ebretin 300mg capsules (Ranbaxy (UK) Ltd)
+4626911000001105,Eccoxolac 300mg capsules (Meda Pharmaceuticals Ltd)
+5639311000001108,Econac SR 75mg tablets (Advanz Pharma)
+5639711000001107,Econac XL 100mg tablets (Advanz Pharma)
+589011000001106,Emflex 60mg capsules (Merck Serono Ltd)
+17627211000001107,Enstar SR 75 tablets (Ennogen Pharma Ltd)
+17627411000001106,Enstar XL 100 tablets (Ennogen Pharma Ltd)
+768562000,Esomeprazole and naproxen in oral dosage form
+768561007,Esomeprazole and naproxen product
+329616002,Etodolac 200mg capsules
+329620003,Etodolac 300mg capsules
+374937008,Etodolac 400 mg oral tablet
+765697009,Etodolac 400mg prolonged-release oral tablet
+374938003,Etodolac 500 mg oral tablet
+765503007,Etodolac 500mg prolonged-release oral tablet
+765538009,Etodolac 600 mg prolonged-release oral tablet
+13222201000001102,Etodolac 600mg modified-release tablets
+329622006,Etodolac 600mg modified-release tablets
+11141111000001109,Etodolac 600mg modified-release tablets (Alliance Healthcare (Distribution) Ltd)
+30054411000001100,Etodolac 600mg modified-release tablets (DE Pharmaceuticals)
+30810311000001107,Etodolac 600mg modified-release tablets (Mawdsley-Brooks & Company Ltd)
+23915011000001106,Etodolac 600mg modified-release tablets (Phoenix Healthcare Distribution Ltd)
+21977911000001102,Etodolac 600mg modified-release tablets (Waymade Healthcare Plc)
+20914211000001103,Etodolac 600mg modified-release tablets (Zentiva)
+412006008,Etodolac in oral dosage form
+33548811000001105,Etolyn 600mg modified-release tablets (Mylan)
+10925311000001102,Etopan XL 600mg tablets (Sun Pharmaceutical Industries Europe B.V.)
+407909000,Etoricoxib 120mg tablets
+34699411000001101,Etoricoxib 120mg tablets (A A H Pharmaceuticals Ltd)
+34624711000001101,Etoricoxib 120mg tablets (Accord Healthcare Ltd)
+34711311000001102,Etoricoxib 120mg tablets (Alliance Healthcare (Distribution) Ltd)
+34620811000001104,Etoricoxib 120mg tablets (Aspire Pharma Ltd)
+37378011000001105,Etoricoxib 120mg tablets (DE Pharmaceuticals)
+37065911000001108,Etoricoxib 120mg tablets (Mawdsley-Brooks & Company Ltd)
+35161211000001109,Etoricoxib 120mg tablets (Milpharm Ltd)
+34691711000001108,Etoricoxib 120mg tablets (Mylan)
+34618711000001102,Etoricoxib 120mg tablets (Teva UK Ltd)
+36833611000001108,Etoricoxib 120mg tablets (Torrent Pharma (UK) Ltd)
+37354011000001104,Etoricoxib 120mg tablets (Zentiva)
+13132911000001109,Etoricoxib 30mg tablets
+34698811000001106,Etoricoxib 30mg tablets (A A H Pharmaceuticals Ltd)
+34624211000001108,Etoricoxib 30mg tablets (Accord Healthcare Ltd)
+34710711000001106,Etoricoxib 30mg tablets (Alliance Healthcare (Distribution) Ltd)
+34620211000001100,Etoricoxib 30mg tablets (Aspire Pharma Ltd)
+37230511000001109,Etoricoxib 30mg tablets (Brown & Burk UK Ltd)
+37377011000001109,Etoricoxib 30mg tablets (DE Pharmaceuticals)
+37064511000001102,Etoricoxib 30mg tablets (Mawdsley-Brooks & Company Ltd)
+35160611000001101,Etoricoxib 30mg tablets (Milpharm Ltd)
+34691111000001107,Etoricoxib 30mg tablets (Mylan)
+34618111000001103,Etoricoxib 30mg tablets (Teva UK Ltd)
+36833011000001101,Etoricoxib 30mg tablets (Torrent Pharma (UK) Ltd)
+37354711000001102,Etoricoxib 30mg tablets (Zentiva)
+407907003,Etoricoxib 60mg tablets
+34699011000001105,Etoricoxib 60mg tablets (A A H Pharmaceuticals Ltd)
+34624411000001107,Etoricoxib 60mg tablets (Accord Healthcare Ltd)
+34710911000001108,Etoricoxib 60mg tablets (Alliance Healthcare (Distribution) Ltd)
+34620411000001101,Etoricoxib 60mg tablets (Aspire Pharma Ltd)
+37377411000001100,Etoricoxib 60mg tablets (DE Pharmaceuticals)
+37065011000001109,Etoricoxib 60mg tablets (Mawdsley-Brooks & Company Ltd)
+35160811000001102,Etoricoxib 60mg tablets (Milpharm Ltd)
+34691311000001109,Etoricoxib 60mg tablets (Mylan)
+34618311000001101,Etoricoxib 60mg tablets (Teva UK Ltd)
+36833211000001106,Etoricoxib 60mg tablets (Torrent Pharma (UK) Ltd)
+37355211000001105,Etoricoxib 60mg tablets (Zentiva)
+407908008,Etoricoxib 90mg tablets
+34699211000001100,Etoricoxib 90mg tablets (A A H Pharmaceuticals Ltd)
+34624611000001105,Etoricoxib 90mg tablets (Accord Healthcare Ltd)
+34711111000001104,Etoricoxib 90mg tablets (Alliance Healthcare (Distribution) Ltd)
+34620611000001103,Etoricoxib 90mg tablets (Aspire Pharma Ltd)
+37377611000001102,Etoricoxib 90mg tablets (DE Pharmaceuticals)
+37065411000001100,Etoricoxib 90mg tablets (Mawdsley-Brooks & Company Ltd)
+35161011000001104,Etoricoxib 90mg tablets (Milpharm Ltd)
+34691511000001103,Etoricoxib 90mg tablets (Mylan)
+34618511000001107,Etoricoxib 90mg tablets (Teva UK Ltd)
+36833411000001105,Etoricoxib 90mg tablets (Torrent Pharma (UK) Ltd)
+37355811000001106,Etoricoxib 90mg tablets (Zentiva)
+412000002,Etoricoxib in oral dosage form
+235611000001100,Feldene 10mg capsules (Pfizer Ltd)
+473411000001103,Feldene 10mg dispersible tablets (Pfizer Ltd)
+90611000001109,Feldene 20 capsules (Pfizer Ltd)
+126111000001103,Feldene 20mg dispersible tablets (Pfizer Ltd)
+18578511000001109,Feldene Melt 20mg tablets (DE Pharmaceuticals)
+19964211000001104,Feldene Melt 20mg tablets (Lexon (UK) Ltd)
+16576611000001103,Feldene Melt 20mg tablets (Mawdsley-Brooks & Company Ltd)
+18261111000001105,Feldene Melt 20mg tablets (Necessity Supplies Ltd)
+192711000001106,Feldene Melt 20mg tablets (Pfizer Ltd)
+14232711000001108,Feldene Melt 20mg tablets (Sigma Pharmaceuticals Plc)
+12560211000001105,Feldene Melt 20mg tablets (Waymade Healthcare Plc)
+17538811000001101,Feminax Express 342mg tablets (Bayer Plc)
+15512111000001104,Feminax Ultra 250mg gastro-resistant tablets (Bayer Plc)
+253811000001104,Fenactol 25mg gastro-resistant tablets (Discovery Pharmaceuticals)
+359411000001107,Fenactol 50mg gastro-resistant tablets (Dexcel-Pharma Ltd)
+656011000001104,Fenactol Retard 100mg tablets (Discovery Pharmaceuticals)
+210711000001105,Fenactol SR 75mg tablets (Discovery Pharmaceuticals)
+3159211000001105,Fenbid 300mg Spansules (Mercury Pharma Group Ltd)
+370190003,Fenbufen 200 mg/1 each oral capsule
+329630007,Fenbufen 300mg capsules
+940111000001102,Fenbufen 300mg capsules (A A H Pharmaceuticals Ltd)
+931711000001108,Fenbufen 300mg capsules (Alliance Healthcare (Distribution) Ltd)
+866711000001104,Fenbufen 300mg capsules (Genus Pharmaceuticals Ltd)
+920011000001100,Fenbufen 300mg capsules (IVAX Pharmaceuticals UK Ltd)
+329631006,Fenbufen 300mg tablets
+145711000001108,Fenbufen 300mg tablets (A A H Pharmaceuticals Ltd)
+895311000001105,Fenbufen 300mg tablets (Actavis UK Ltd)
+149811000001102,Fenbufen 300mg tablets (Alliance Healthcare (Distribution) Ltd)
+30111000001109,Fenbufen 300mg tablets (IVAX Pharmaceuticals UK Ltd)
+422611000001106,Fenbufen 300mg tablets (Kent Pharmaceuticals Ltd)
+431311000001107,Fenbufen 300mg tablets (Mylan)
+841711000001100,Fenbufen 300mg tablets (Sterwin Medicines)
+329636001,Fenbufen 450mg tablets
+757111000001107,Fenbufen 450mg tablets (A A H Pharmaceuticals Ltd)
+788011000001102,Fenbufen 450mg tablets (Actavis UK Ltd)
+209211000001107,Fenbufen 450mg tablets (Alliance Healthcare (Distribution) Ltd)
+13577411000001107,Fenbufen 450mg tablets (DE Pharmaceuticals)
+447611000001107,Fenbufen 450mg tablets (IVAX Pharmaceuticals UK Ltd)
+398311000001104,Fenbufen 450mg tablets (Kent Pharmaceuticals Ltd)
+594411000001100,Fenbufen 450mg tablets (Mylan)
+616611000001101,Fenbufen 450mg tablets (Sterwin Medicines)
+370191004,Fenbufen 600 mg oral tablet
+412007004,Fenbufen in oral dosage form
+98811000001106,Fenoket 200mg modified-release capsules (Opus Pharmaceuticals Ltd)
+329641009,Fenoprofen 300mg tablets
+329642002,Fenoprofen 600mg tablets
+374578000,Fenoprofen calcium 200 mg/1 each oral capsule
+388959005,Fenoprofen calcium 300 mg/1 each oral capsule
+412008009,Fenoprofen in oral dosage form
+3684611000001103,Fenopron 300 tablets (Typharm Ltd)
+3685511000001101,Fenopron 600 tablets (Typharm Ltd)
+4535711000001109,Fenpaed 100mg/5ml oral suspension (Pinewood Healthcare)
+8104311000001107,Fenpaed 100mg/5ml oral suspension 5ml sachets (Pinewood Healthcare)
+4632211000001100,Feverfen 100mg/5ml oral suspension (Wise Pharmaceuticals Ltd)
+18637011000001107,First Resort Double Action Pain Relief 12.5mg tablets (Actavis UK Ltd)
+18640211000001100,First Resort Period Pain Reliever 250mg gastro-resistant tablets (Actavis UK Ltd)
+658811000001106,Flamatak MR 100mg tablets (Actavis UK Ltd)
+13411000001102,Flamatak MR 75mg tablets (Actavis UK Ltd)
+602311000001109,Flamrase 25 EC tablets (Teva UK Ltd)
+49711000001102,Flamrase 75mg SR tablets (Teva UK Ltd)
+761911000001109,Flamrase SR 100mg tablets (Teva UK Ltd)
+34790511000001100,Flarin 200mg capsules (infirst Healthcare Ltd)
+2884211000001100,Flexin-25 Continus tablets (Napp Pharmaceuticals Ltd)
+2884711000001107,Flexin-50 Continus tablets (Napp Pharmaceuticals Ltd)
+306611000001105,Flexin-75 Continus tablets (Napp Pharmaceuticals Ltd)
+657911000001102,Flexotard MR 100mg tablets (Pfizer Ltd)
+329649006,Flurbiprofen 100mg tablets
+91911000001105,Flurbiprofen 100mg tablets (A A H Pharmaceuticals Ltd)
+363911000001106,Flurbiprofen 100mg tablets (Actavis UK Ltd)
+410711000001109,Flurbiprofen 100mg tablets (Alliance Healthcare (Distribution) Ltd)
+4821011000001109,Flurbiprofen 100mg tablets (Genus Pharmaceuticals Ltd)
+732111000001109,Flurbiprofen 100mg tablets (Kent Pharmaceuticals Ltd)
+24616611000001106,Flurbiprofen 100mg tablets (Mylan)
+17910111000001107,Flurbiprofen 100mg tablets (Phoenix Healthcare Distribution Ltd)
+686111000001107,Flurbiprofen 100mg tablets (Sandoz Ltd)
+22014911000001109,Flurbiprofen 100mg tablets (Waymade Healthcare Plc)
+765919009,Flurbiprofen 200 mg prolonged-release oral capsule
+36059011000001103,Flurbiprofen 200mg modified-release capsules
+329648003,Flurbiprofen 50mg tablets
+477611000001108,Flurbiprofen 50mg tablets (A A H Pharmaceuticals Ltd)
+825611000001105,Flurbiprofen 50mg tablets (Actavis UK Ltd)
+510811000001107,Flurbiprofen 50mg tablets (Alliance Healthcare (Distribution) Ltd)
+4820811000001106,Flurbiprofen 50mg tablets (Genus Pharmaceuticals Ltd)
+323611000001109,Flurbiprofen 50mg tablets (Kent Pharmaceuticals Ltd)
+24616411000001108,Flurbiprofen 50mg tablets (Mylan)
+17909911000001101,Flurbiprofen 50mg tablets (Phoenix Healthcare Distribution Ltd)
+574511000001107,Flurbiprofen 50mg tablets (Sandoz Ltd)
+412009001,Flurbiprofen in oral dosage form
+767786004,Flurbiprofen in oromucosal dosage form
+767787008,Flurbiprofen in rectal dosage form
+766353007,Flurbiprofen sodium 0.03% conventional release eye drops
+538211000001100,Froben 100mg tablets (Abbott Laboratories Ltd)
+762311000001104,Froben 50mg tablets (Abbott Laboratories Ltd)
+27511000001103,Froben SR 200mg capsules (Abbott Laboratories Ltd)
+5545311000001102,Froben SR 200mg capsules (Dowelhurst Ltd)
+5368511000001107,Froben SR 200mg capsules (Waymade Healthcare Plc)
+9993111000001106,Galpharm Ibuprofen For Children 100mg/5ml oral suspension 5ml sachets (Galpharm International Ltd)
+11775811000001106,Galpharm Maximum Strength Ibuprofen 400mg liquid capsules (Galpharm International Ltd)
+17303111000001109,Galpharm Migraine Relief 200mg capsules (Galpharm International Ltd)
+17303811000001102,Galpharm Period Pain Relief 250mg gastro-resistant tablets (Galpharm International Ltd)
+32811000001101,Galprofen 100mg/5ml oral suspension (Galpharm International Ltd)
+474111000001105,Galprofen 200mg tablets (Galpharm International Ltd)
+258411000001107,Galprofen Cold and Flu 200mg tablets (Galpharm International Ltd)
+3996111000001104,Galprofen Long Lasting 200mg capsules (Galpharm International Ltd)
+13630511000001104,Galprofen Long Lasting 300mg capsules (Galpharm International Ltd)
+11270111000001101,Galprofen Migraine Relief 200mg capsules (Galpharm International Ltd)
+336911000001107,Hedex Ibuprofen 200mg caplets (GlaxoSmithKline Consumer Healthcare)
+17042011000001106,Hedex Ibuprofen 200mg tablets (Omega Pharma Ltd)
+768402000,Hydrocodone and ibuprofen in oral dosage form
+768401007,Hydrocodone and ibuprofen product
+429392006,Hydrocodone bitartrate 10 mg and ibuprofen 200 mg oral tablet
+429393001,Hydrocodone bitartrate 2.5 mg and ibuprofen 200 mg oral tablet
+428210006,Hydrocodone bitartrate 5 mg and ibuprofen 200 mg oral tablet
+377489000,Hydrocodone bitartrate 7.5 mg and ibuprofen 200 mg oral tablet
+16528311000001106,Ibucalm 200mg tablets (Aspar Pharmaceuticals Ltd)
+16528811000001102,Ibucalm 400mg tablets (Aspar Pharmaceuticals Ltd)
+195311000001101,Ibufem 200mg tablets (Galpharm International Ltd)
+36105911000001102,Ibular 200mg tablets (Ennogen Pharma Ltd)
+36106111000001106,Ibular 400mg tablets (Ennogen Pharma Ltd)
+414443003,Ibuprofen + oxycodone
+370192006,Ibuprofen 100 mg oral tablet
+32392411000001107,Ibuprofen 100mg chewable capsules
+370194007,Ibuprofen 100mg chewable tablet
+370196009,Ibuprofen 100mg/2.5mL oral suspension
+13093911000001101,Ibuprofen 100mg/5ml / Pseudoephedrine 15mg/5ml oral suspension sugar free
+329710002,Ibuprofen 100mg/5ml oral suspension
+4615511000001102,Ibuprofen 100mg/5ml oral suspension 5ml sachets sugar free
+9458211000001101,Ibuprofen 100mg/5ml oral suspension 5ml sachets sugar free (A A H Pharmaceuticals Ltd)
+13623911000001100,Ibuprofen 100mg/5ml oral suspension 5ml sachets sugar free (Pinewood Healthcare)
+9210011000001100,Ibuprofen 100mg/5ml oral suspension 5ml sachets sugar free (Thornton & Ross Ltd)
+13222501000001104,Ibuprofen 100mg/5ml oral suspension sugar free
+329686007,Ibuprofen 100mg/5ml oral suspension sugar free
+731611000001107,Ibuprofen 100mg/5ml oral suspension sugar free (A A H Pharmaceuticals Ltd)
+30804111000001103,Ibuprofen 100mg/5ml oral suspension sugar free (Actavis UK Ltd)
+23811000001106,Ibuprofen 100mg/5ml oral suspension sugar free (Alliance Healthcare (Distribution) Ltd)
+24174611000001106,Ibuprofen 100mg/5ml oral suspension sugar free (DE Pharmaceuticals)
+3323411000001100,Ibuprofen 100mg/5ml oral suspension sugar free (Kent Pharmaceuticals Ltd)
+18109611000001102,Ibuprofen 100mg/5ml oral suspension sugar free (Phoenix Healthcare Distribution Ltd)
+13623411000001108,Ibuprofen 100mg/5ml oral suspension sugar free (Pinewood Healthcare)
+37421811000001101,Ibuprofen 100mg/5ml oral suspension sugar free (Relonchem Ltd)
+26311000001106,Ibuprofen 100mg/5ml oral suspension sugar free (Sandoz Ltd)
+15100811000001100,Ibuprofen 100mg/5ml oral suspension sugar free (Sigma Pharmaceuticals Plc)
+7944111000001109,Ibuprofen 100mg/5ml oral suspension sugar free (Teva UK Ltd)
+9209811000001100,Ibuprofen 100mg/5ml oral suspension sugar free (Thornton & Ross Ltd)
+5021111000001102,Ibuprofen 100mg/5ml oral suspension sugar free (Vantage)
+329675005,Ibuprofen 200 mg and codeine phosphate 12.5 mg oral tablet
+420858007,Ibuprofen 200 mg and pseudoephedrine 30 mg/1 each oral capsule
+766026002,Ibuprofen 200 mg prolonged-release oral capsule
+329683004,Ibuprofen 200mg / Codeine 12.8mg tablets
+16036311000001108,Ibuprofen 200mg / Phenylephrine 5mg tablets
+34878411000001108,Ibuprofen 200mg / Phenylephrine 6.1mg tablets
+407904005,Ibuprofen 200mg / Pseudoephedrine hydrochloride 30mg tablets
+18557911000001100,Ibuprofen 200mg caplets (Bristol Laboratories Ltd)
+9172611000001104,Ibuprofen 200mg caplets (Galpharm International Ltd)
+7926811000001106,Ibuprofen 200mg caplets (Lloyds Pharmacy Ltd)
+9746811000001108,Ibuprofen 200mg caplets (The Boots Company Plc)
+27170011000001102,Ibuprofen 200mg caplets (Wockhardt UK Ltd)
+370195008,Ibuprofen 200mg capsules
+23279311000001100,Ibuprofen 200mg capsules (AM Distributions (Yorkshire) Ltd)
+32465611000001107,"Ibuprofen 200mg capsules (Bell,Sons & Co (Druggists) Ltd)"
+24625711000001103,Ibuprofen 200mg capsules (Colorama Pharmaceuticals Ltd)
+31993111000001104,Ibuprofen 200mg capsules (Ennogen Healthcare Ltd)
+17307311000001104,Ibuprofen 200mg capsules (Galpharm International Ltd)
+15019211000001100,Ibuprofen 200mg capsules (Kent Pharmaceuticals Ltd)
+14703311000001100,Ibuprofen 200mg capsules (Numark Ltd)
+19525111000001109,Ibuprofen 200mg effervescent tablets
+36045011000001103,Ibuprofen 200mg modified-release capsules
+3875511000001104,Ibuprofen 200mg orodispersible tablets sugar free
+329652003,Ibuprofen 200mg tablets
+771311000001100,Ibuprofen 200mg tablets (A A H Pharmaceuticals Ltd)
+715411000001104,Ibuprofen 200mg tablets (Alliance Healthcare (Distribution) Ltd)
+9805311000001101,Ibuprofen 200mg tablets (Almus Pharmaceuticals Ltd)
+10378911000001102,Ibuprofen 200mg tablets (Arrow Generics Ltd)
+892211000001107,Ibuprofen 200mg tablets (Aspar Pharmaceuticals Ltd)
+17023611000001107,"Ibuprofen 200mg tablets (Bell,Sons & Co (Druggists) Ltd)"
+14772411000001106,Ibuprofen 200mg tablets (Boston Healthcare Ltd)
+16056611000001104,Ibuprofen 200mg tablets (Bristol Laboratories Ltd)
+28984611000001101,Ibuprofen 200mg tablets (Crescent Pharma Ltd)
+13578911000001103,Ibuprofen 200mg tablets (DE Pharmaceuticals)
+18074911000001106,Ibuprofen 200mg tablets (Fannin UK Ltd)
+14784511000001105,Ibuprofen 200mg tablets (Galpharm International Ltd)
+869811000001101,Ibuprofen 200mg tablets (IVAX Pharmaceuticals UK Ltd)
+201711000001104,Ibuprofen 200mg tablets (Kent Pharmaceuticals Ltd)
+30212411000001106,Ibuprofen 200mg tablets (Mawdsley-Brooks & Company Ltd)
+35851611000001107,Ibuprofen 200mg tablets (Medreich Plc)
+38695411000001100,Ibuprofen 200mg tablets (Noumed Life Sciences Ltd)
+342211000001103,Ibuprofen 200mg tablets (OBG Pharmaceuticals Ltd)
+17931411000001104,Ibuprofen 200mg tablets (Phoenix Healthcare Distribution Ltd)
+859511000001108,Ibuprofen 200mg tablets (Ranbaxy (UK) Ltd)
+11579811000001108,Ibuprofen 200mg tablets (Sandoz Ltd)
+29875911000001106,Ibuprofen 200mg tablets (Sigma Pharmaceuticals Plc)
+4603011000001107,Ibuprofen 200mg tablets (Sussex Pharmaceutical Ltd)
+110611000001104,Ibuprofen 200mg tablets (Teva UK Ltd)
+367511000001109,Ibuprofen 200mg tablets (Thornton & Ross Ltd)
+327311000001106,Ibuprofen 200mg tablets (Vantage)
+22046511000001104,Ibuprofen 200mg tablets (Waymade Healthcare Plc)
+9501811000001106,Ibuprofen 200mg tablets (Wockhardt UK Ltd)
+3313611000001105,Ibuprofen 200mg tablets (Zentiva)
+654211000001104,Ibuprofen 200mg tablets film coated (Actavis UK Ltd)
+805711000001106,Ibuprofen 200mg tablets sugar coated (Actavis UK Ltd)
+6407711000001109,Ibuprofen 200mg tablets sugar coated (Kent Pharmaceuticals Ltd)
+12637311000001104,Ibuprofen 200mg/5ml oral suspension
+12597711000001104,Ibuprofen 200mg/5ml oral suspension (Special Order)
+36608611000001101,Ibuprofen 200mg/5ml oral suspension sugar free
+408075007,Ibuprofen 300 mg and pseudoephedrine 45 mg/1 each oral capsule
+765908006,Ibuprofen 300 mg prolonged-release oral capsule
+4623511000001106,Ibuprofen 300mg / Pseudoephedrine 45mg modified-release capsules
+36045211000001108,Ibuprofen 300mg modified-release / Codeine 20mg tablets
+36045311000001100,Ibuprofen 300mg modified-release capsules
+414444009,Ibuprofen 400 mg and oxycodone 5 mg oral tablet
+18558411000001107,Ibuprofen 400mg caplets (Bristol Laboratories Ltd)
+7928011000001101,Ibuprofen 400mg caplets (Lloyds Pharmacy Ltd)
+9746611000001109,Ibuprofen 400mg caplets (The Boots Company Plc)
+10774611000001104,Ibuprofen 400mg capsules
+329653008,Ibuprofen 400mg tablets
+913811000001105,Ibuprofen 400mg tablets (A A H Pharmaceuticals Ltd)
+497111000001108,Ibuprofen 400mg tablets (Alliance Healthcare (Distribution) Ltd)
+9816611000001104,Ibuprofen 400mg tablets (Almus Pharmaceuticals Ltd)
+10379111000001107,Ibuprofen 400mg tablets (Arrow Generics Ltd)
+522911000001108,Ibuprofen 400mg tablets (Aspar Pharmaceuticals Ltd)
+14772911000001103,Ibuprofen 400mg tablets (Boston Healthcare Ltd)
+16057111000001105,Ibuprofen 400mg tablets (Bristol Laboratories Ltd)
+28984811000001102,Ibuprofen 400mg tablets (Crescent Pharma Ltd)
+13579211000001102,Ibuprofen 400mg tablets (DE Pharmaceuticals)
+18075111000001107,Ibuprofen 400mg tablets (Fannin UK Ltd)
+9648711000001108,Ibuprofen 400mg tablets (Galpharm International Ltd)
+878411000001103,Ibuprofen 400mg tablets (IVAX Pharmaceuticals UK Ltd)
+491911000001103,Ibuprofen 400mg tablets (Kent Pharmaceuticals Ltd)
+30213011000001106,Ibuprofen 400mg tablets (Mawdsley-Brooks & Company Ltd)
+36042811000001102,Ibuprofen 400mg tablets (Medreich Plc)
+38695211000001104,Ibuprofen 400mg tablets (Noumed Life Sciences Ltd)
+714611000001102,Ibuprofen 400mg tablets (OBG Pharmaceuticals Ltd)
+17931611000001101,Ibuprofen 400mg tablets (Phoenix Healthcare Distribution Ltd)
+644111000001107,Ibuprofen 400mg tablets (Ranbaxy (UK) Ltd)
+37062811000001105,Ibuprofen 400mg tablets (Relonchem Ltd)
+779411000001108,Ibuprofen 400mg tablets (Sandoz Ltd)
+15055611000001106,Ibuprofen 400mg tablets (Sigma Pharmaceuticals Plc)
+434811000001101,Ibuprofen 400mg tablets (Sterwin Medicines)
+4604211000001104,Ibuprofen 400mg tablets (Sussex Pharmaceutical Ltd)
+1511000001104,Ibuprofen 400mg tablets (Teva UK Ltd)
+207911000001105,Ibuprofen 400mg tablets (Thornton & Ross Ltd)
+333311000001102,Ibuprofen 400mg tablets (Vantage)
+22046911000001106,Ibuprofen 400mg tablets (Waymade Healthcare Plc)
+9502111000001109,Ibuprofen 400mg tablets (Wockhardt UK Ltd)
+11177511000001107,Ibuprofen 400mg tablets (Zentiva)
+273411000001104,Ibuprofen 400mg tablets film coated (Actavis UK Ltd)
+415811000001107,Ibuprofen 400mg tablets sugar coated (Actavis UK Ltd)
+420811000001109,Ibuprofen 400mg tablets sugar coated (Kent Pharmaceuticals Ltd)
+370197000,Ibuprofen 40mg/mL oral drops
+370193001,Ibuprofen 50mg chewable tablet
+438856002,Ibuprofen 50mg/1.25mL oral suspension
+329677002,Ibuprofen 600mg effervescent granules sachets
+329654002,Ibuprofen 600mg tablets
+451211000001103,Ibuprofen 600mg tablets (A A H Pharmaceuticals Ltd)
+641211000001103,Ibuprofen 600mg tablets (Actavis UK Ltd)
+334411000001107,Ibuprofen 600mg tablets (Alliance Healthcare (Distribution) Ltd)
+9805911000001100,Ibuprofen 600mg tablets (Almus Pharmaceuticals Ltd)
+10379411000001102,Ibuprofen 600mg tablets (Arrow Generics Ltd)
+901511000001105,Ibuprofen 600mg tablets (Aspar Pharmaceuticals Ltd)
+14773611000001104,Ibuprofen 600mg tablets (Boston Healthcare Ltd)
+21033511000001107,Ibuprofen 600mg tablets (Bristol Laboratories Ltd)
+36080311000001102,Ibuprofen 600mg tablets (Crescent Pharma Ltd)
+36513111000001106,Ibuprofen 600mg tablets (Dalkeith Laboratories Ltd)
+37422011000001104,Ibuprofen 600mg tablets (DE Pharmaceuticals)
+18078211000001108,Ibuprofen 600mg tablets (Fannin UK Ltd)
+25311000001101,Ibuprofen 600mg tablets (IVAX Pharmaceuticals UK Ltd)
+32011000001107,Ibuprofen 600mg tablets (Kent Pharmaceuticals Ltd)
+36043011000001104,Ibuprofen 600mg tablets (Medreich Plc)
+36700311000001101,Ibuprofen 600mg tablets (Noumed Life Sciences Ltd)
+177111000001104,Ibuprofen 600mg tablets (OBG Pharmaceuticals Ltd)
+17931811000001102,Ibuprofen 600mg tablets (Phoenix Healthcare Distribution Ltd)
+15711000001109,Ibuprofen 600mg tablets (Ranbaxy (UK) Ltd)
+37079111000001100,Ibuprofen 600mg tablets (Relonchem Ltd)
+281911000001103,Ibuprofen 600mg tablets (Sandoz Ltd)
+15101111000001101,Ibuprofen 600mg tablets (Sigma Pharmaceuticals Plc)
+928211000001108,Ibuprofen 600mg tablets (Sterwin Medicines)
+349811000001107,Ibuprofen 600mg tablets (Teva UK Ltd)
+22057111000001108,Ibuprofen 600mg tablets (Waymade Healthcare Plc)
+11177711000001102,Ibuprofen 600mg tablets (Zentiva)
+372911000001106,Ibuprofen 600mg tablets film coated (Alliance Healthcare (Distribution) Ltd)
+765699007,Ibuprofen 800 mg prolonged-release oral tablet
+13222401000001103,Ibuprofen 800mg modified-release tablets
+329662005,Ibuprofen 800mg modified-release tablets
+329708004,Ibuprofen 800mg tablets
+768708002,Ibuprofen and oxycodone in oral dosage form
+768707007,Ibuprofen and pseudoephedrine in oral dosage form
+13636911000001109,Ibuprofen for Children 100mg/5ml oral suspension (Galpharm International Ltd)
+350321003,Ibuprofen in oral dosage form
+421839006,Ibuprofen in parenteral dosage form
+350322005,Ibuprofen in topical dosage form
+4557011000001104,Ibuprofen lysine 200mg tablets
+21681311000001104,Ibuprofen lysine 400mg oral powder sachets
+10245111000001102,Ibuprofen lysine 400mg tablets
+36760411000001109,Ibuprofen Seven Plus Pain Relief 200mg/5ml oral suspension (Aspire Pharma Ltd)
+14606211000001108,Ibuprofen sodium dihydrate 200mg tablets
+14606311000001100,Ibuprofen sodium dihydrate 400mg tablets
+36603011000001101,Ibuprofen Twelve Plus Pain Relief 200mg/5ml oral suspension (Aspire Pharma Ltd)
+400268004,Ibuprofen+menthol
+409119003,Ibuprofen+pseudoephedrine 100mg/15mg oral 5mL suspension
+258511000001106,Indocid 25mg capsules (Merck Sharp & Dohme Ltd)
+581911000001106,Indocid 50mg capsules (Merck Sharp & Dohme Ltd)
+4541711000001108,Indocid 5mg/ml oral suspension (Merck Sharp & Dohme Ltd)
+10505811000001107,Indocid R 75mg capsules (Dowelhurst Ltd)
+172111000001101,Indocid R 75mg capsules (Merck Sharp & Dohme Ltd)
+3311000001106,Indolar SR 75mg capsules (Sandoz Ltd)
+84411000001101,Indomax 75 SR capsules (Ashbourne Pharmaceuticals Ltd)
+12637811000001108,Indometacin 1.2mg/5ml oral solution
+12599511000001102,Indometacin 1.2mg/5ml oral solution (Special Order)
+12637911000001103,Indometacin 1.2mg/5ml oral suspension
+12599211000001100,Indometacin 1.2mg/5ml oral suspension (Special Order)
+12638011000001101,Indometacin 10mg/5ml oral solution
+12600111000001108,Indometacin 10mg/5ml oral solution (Special Order)
+12638111000001100,Indometacin 10mg/5ml oral suspension
+12599811000001104,Indometacin 10mg/5ml oral suspension (Special Order)
+12638211000001106,Indometacin 12mg/5ml oral solution
+12600711000001109,Indometacin 12mg/5ml oral solution (Special Order)
+12638311000001103,Indometacin 12mg/5ml oral suspension
+12600411000001103,Indometacin 12mg/5ml oral suspension (Special Order)
+12638411000001105,Indometacin 15mg/5ml oral solution
+12601911000001104,Indometacin 15mg/5ml oral solution (Special Order)
+12638511000001109,Indometacin 15mg/5ml oral suspension
+12601411000001107,Indometacin 15mg/5ml oral suspension (Special Order)
+12638611000001108,Indometacin 20mg/5ml oral solution
+12603111000001101,Indometacin 20mg/5ml oral solution (Special Order)
+12638711000001104,Indometacin 20mg/5ml oral suspension
+12602811000001100,Indometacin 20mg/5ml oral suspension (Special Order)
+766065004,Indometacin 25 mg prolonged-release oral capsule
+329714006,Indometacin 25mg capsules
+746311000001109,Indometacin 25mg capsules (A A H Pharmaceuticals Ltd)
+24411000001107,Indometacin 25mg capsules (Actavis UK Ltd)
+387211000001109,Indometacin 25mg capsules (Alliance Healthcare (Distribution) Ltd)
+11405211000001107,Indometacin 25mg capsules (Almus Pharmaceuticals Ltd)
+10381711000001100,Indometacin 25mg capsules (Arrow Generics Ltd)
+14783711000001102,Indometacin 25mg capsules (Boston Healthcare Ltd)
+18559111000001109,Indometacin 25mg capsules (Bristol Laboratories Ltd)
+34016011000001105,Indometacin 25mg capsules (Crescent Pharma Ltd)
+24176011000001109,Indometacin 25mg capsules (DE Pharmaceuticals)
+11017711000001100,Indometacin 25mg capsules (Dr Reddy's Laboratories (UK) Ltd)
+20324411000001101,Indometacin 25mg capsules (Genesis Pharmaceuticals Ltd)
+770811000001101,Indometacin 25mg capsules (Kent Pharmaceuticals Ltd)
+17932611000001107,Indometacin 25mg capsules (Phoenix Healthcare Distribution Ltd)
+4331311000001106,Indometacin 25mg capsules (Sandoz Ltd)
+29877911000001101,Indometacin 25mg capsules (Sigma Pharmaceuticals Plc)
+564511000001104,Indometacin 25mg capsules (The Boots Company Plc)
+26779711000001102,Indometacin 25mg capsules (Tillomed Laboratories Ltd)
+22061111000001107,Indometacin 25mg capsules (Waymade Healthcare Plc)
+13223301000001100,Indometacin 25mg modified-release capsules
+329757001,Indometacin 25mg modified-release capsules
+36046611000001100,Indometacin 25mg modified-release tablets
+8561611000001108,Indometacin 25mg/5ml oral solution
+8544911000001109,Indometacin 25mg/5ml oral solution (Special Order)
+376878007,Indometacin 25mg/5ml oral suspension
+8545911000001108,Indometacin 25mg/5ml oral suspension (Drug Tariff Special Order)
+4562011000001108,Indometacin 25mg/5ml oral suspension sugar free
+12638811000001107,Indometacin 31.25mg/5ml oral solution
+12603711000001100,Indometacin 31.25mg/5ml oral solution (Special Order)
+12638911000001102,Indometacin 31.25mg/5ml oral suspension
+12603411000001106,Indometacin 31.25mg/5ml oral suspension (Special Order)
+12639011000001106,Indometacin 3mg/5ml oral solution
+12604311000001102,Indometacin 3mg/5ml oral solution (Special Order)
+12639111000001107,Indometacin 3mg/5ml oral suspension
+12604011000001100,Indometacin 3mg/5ml oral suspension (Special Order)
+12639211000001101,Indometacin 500micrograms/5ml oral solution
+12604911000001101,Indometacin 500micrograms/5ml oral solution (Special Order)
+12639311000001109,Indometacin 500micrograms/5ml oral suspension
+12604611000001107,Indometacin 500micrograms/5ml oral suspension (Special Order)
+329715007,Indometacin 50mg capsules
+799011000001106,Indometacin 50mg capsules (A A H Pharmaceuticals Ltd)
+100211000001103,Indometacin 50mg capsules (Actavis UK Ltd)
+604011000001100,Indometacin 50mg capsules (Alliance Healthcare (Distribution) Ltd)
+9807011000001106,Indometacin 50mg capsules (Almus Pharmaceuticals Ltd)
+28919111000001108,Indometacin 50mg capsules (Crescent Pharma Ltd)
+24176411000001100,Indometacin 50mg capsules (DE Pharmaceuticals)
+11017511000001105,Indometacin 50mg capsules (Dr Reddy's Laboratories (UK) Ltd)
+20324611000001103,Indometacin 50mg capsules (Genesis Pharmaceuticals Ltd)
+749911000001101,Indometacin 50mg capsules (Kent Pharmaceuticals Ltd)
+525611000001106,Indometacin 50mg capsules (Mylan)
+17932811000001106,Indometacin 50mg capsules (Phoenix Healthcare Distribution Ltd)
+4331511000001100,Indometacin 50mg capsules (Sandoz Ltd)
+29878111000001103,Indometacin 50mg capsules (Sigma Pharmaceuticals Plc)
+787911000001104,Indometacin 50mg capsules (The Boots Company Plc)
+26780111000001103,Indometacin 50mg capsules (Tillomed Laboratories Ltd)
+22061611000001104,Indometacin 50mg capsules (Waymade Healthcare Plc)
+36046711000001109,Indometacin 50mg modified-release tablets
+8561811000001107,Indometacin 50mg/5ml oral solution
+8544811000001104,Indometacin 50mg/5ml oral solution (Special Order)
+8561911000001102,Indometacin 50mg/5ml oral suspension
+8545311000001107,Indometacin 50mg/5ml oral suspension (Special Order)
+15914011000001100,Indometacin 5mg/5ml oral solution
+15881811000001103,Indometacin 5mg/5ml oral solution (Special Order)
+15914111000001104,Indometacin 5mg/5ml oral suspension
+15881511000001101,Indometacin 5mg/5ml oral suspension (Special Order)
+766064000,Indometacin 75 mg prolonged-release oral capsule
+36046811000001101,Indometacin 75mg modified-release capsules
+853011000001103,Indometacin 75mg modified-release capsules (Kent Pharmaceuticals Ltd)
+36046911000001106,Indometacin 75mg modified-release tablets
+375433008,Indomethacin 75mg capsule
+777811000001102,Indomod 25mg modified-release capsules (Pfizer Ltd)
+541311000001100,Indomod 75mg modified-release capsules (Pfizer Ltd)
+732311000001106,Jomethid XL 200mg capsules (Actavis UK Ltd)
+642011000001100,Junior Ibuprofen 100mg/5ml oral suspension (Numark Ltd)
+2892711000001101,Keral 25mg tablets (A. Menarini Farmaceutica Internazionale SRL)
+294311000001102,Ketocid 200 modified-release capsules (Chiesi Ltd)
+766002004,Ketoprofen 100 mg prolonged-release oral capsule
+16174311000001107,Ketoprofen 100mg / Omeprazole 20mg modified-release capsules
+3377811000001108,Ketoprofen 100mg capsules
+881711000001108,Ketoprofen 100mg capsules (A A H Pharmaceuticals Ltd)
+823911000001100,Ketoprofen 100mg capsules (Alliance Healthcare (Distribution) Ltd)
+39411000001109,Ketoprofen 100mg capsules (Mylan)
+65111000001107,Ketoprofen 100mg capsules (Sandoz Ltd)
+823411000001108,Ketoprofen 100mg capsules (The Boots Company Plc)
+36037011000001106,Ketoprofen 100mg modified-release capsules
+4575711000001106,Ketoprofen 100mg modified-release capsules (A A H Pharmaceuticals Ltd)
+505811000001104,Ketoprofen 100mg modified-release capsules (Alliance Healthcare (Distribution) Ltd)
+778511000001101,Ketoprofen 100mg modified-release capsules (Kent Pharmaceuticals Ltd)
+370199002,Ketoprofen 12.5 mg oral tablet
+765954002,Ketoprofen 150 mg prolonged-release oral capsule
+36037211000001101,Ketoprofen 150mg modified-release capsules
+765934003,Ketoprofen 200 mg prolonged-release oral capsule
+16174411000001100,Ketoprofen 200mg / Omeprazole 20mg modified-release capsules
+36037311000001109,Ketoprofen 200mg modified-release capsules
+659911000001109,Ketoprofen 200mg modified-release capsules (Kent Pharmaceuticals Ltd)
+373974003,Ketoprofen 25 mg/1 each oral capsule
+329758006,Ketoprofen 50mg capsules
+513511000001103,Ketoprofen 50mg capsules (A A H Pharmaceuticals Ltd)
+886811000001105,Ketoprofen 50mg capsules (Alliance Healthcare (Distribution) Ltd)
+365911000001107,Ketoprofen 50mg capsules (Kent Pharmaceuticals Ltd)
+109311000001102,Ketoprofen 50mg capsules (Mylan)
+915411000001107,Ketoprofen 50mg capsules (Sandoz Ltd)
+15103511000001109,Ketoprofen 50mg capsules (Sigma Pharmaceuticals Plc)
+373975002,Ketoprofen 75 mg/1 each oral capsule
+412012003,Ketoprofen in oral dosage form
+715712009,Ketorolac + phenylephrine
+333981003,Ketorolac 10mg tablets
+356262000,Ketorolac in oral dosage form
+8211000001106,Ketotard XL 200mg capsules (Galen Ltd)
+419711000001102,Ketovail 100mg modified-release capsules (Teva UK Ltd)
+106011000001106,Ketovail 200mg modified-release capsules (Teva UK Ltd)
+403111000001103,Ketozip 200 XL capsules (Ashbourne Pharmaceuticals Ltd)
+867111000001102,Ketpron XL 100mg capsules (Mercury Pharma Group Ltd)
+240011000001102,Ketpron XL 200mg capsules (Mercury Pharma Group Ltd)
+409145007,Lansoprazole + naproxen
+482011000001109,Larafen CR 200mg capsules (Ennogen Pharma Ltd)
+75311000001102,Lederfen 300mg capsules (Mercury Pharma Group Ltd)
+269711000001104,Lederfen 300mg tablets (Mercury Pharma Group Ltd)
+343711000001102,Lederfen 450mg tablets (Mercury Pharma Group Ltd)
+8133411000001105,Lemsip Cold and Flu Sinus 12 Hr Ibuprofen + Pseudoephedrine modified-release capsules (Reckitt Benckiser Healthcare (UK) Ltd)
+9466411000001106,Lemsip Flu 12 Hr Ibuprofen + Pseudoephedrine modified-release capsules (Reckitt Benckiser Healthcare (UK) Ltd)
+4616511000001109,Lemsip Ibuprofen modified-release capsules (Reckitt Benckiser Healthcare (UK) Ltd)
+15987611000001104,Lemsip Max All Night Cold & Flu tablets (Reckitt Benckiser Healthcare (UK) Ltd)
+901911000001103,Librofem 200mg tablets (LPC Medical (UK) Ltd)
+7929311000001109,Lloydspharmacy Ibuprofen 100mg/5ml oral suspension (Lloyds Pharmacy Ltd)
+13860211000001101,Lloydspharmacy Ibuprofen 200mg liquid capsules (Lloyds Pharmacy Ltd)
+13750411000001109,Lloydspharmacy Ibuprofen Long Lasting 200mg capsules (Lloyds Pharmacy Ltd)
+13860411000001102,Lloydspharmacy Maximum Strength Ibuprofen 400mg liquid capsules (Lloyds Pharmacy Ltd)
+921411000001100,Lodine SR 600mg tablets (Almirall Ltd)
+450611000001106,Lofensaid 25mg gastro-resistant tablets (Opus Pharmaceuticals Ltd)
+490411000001102,Lofensaid Retard 100 tablets (Opus Pharmaceuticals Ltd)
+213511000001106,Lofensaid Retard 75 tablets (Opus Pharmaceuticals Ltd)
+408601001,Lornoxicam 4mg tablets
+408602008,Lornoxicam 8mg tablets
+17061411000001100,Lornoxicam 8mg tablets (Special Order)
+412014002,Lornoxicam in oral dosage form
+9865311000001100,Lumiracoxib 100mg tablets
+9865211000001108,Lumiracoxib 400mg tablets
+7997811000001101,Mandafen 400mg tablets (M & A Pharmachem Ltd)
+17238111000001100,Mandafen 600mg tablets (M & A Pharmachem Ltd)
+7997311000001105,Mandafen for Children 100mg/5ml oral suspension sugar free (M & A Pharmachem Ltd)
+19690911000001104,Manorfen 200mg tablets (The Manor Drug Company (Nottingham) Ltd)
+3021311000001105,Manorfen 400mg tablets (The Manor Drug Company (Nottingham) Ltd)
+769133000,Mefenamic acid 10 mg/mL oral suspension
+329790001,Mefenamic acid 250mg capsules
+269111000001100,Mefenamic acid 250mg capsules (A A H Pharmaceuticals Ltd)
+19310911000001108,Mefenamic acid 250mg capsules (Advanz Pharma)
+188111000001107,Mefenamic acid 250mg capsules (Alliance Healthcare (Distribution) Ltd)
+10389911000001104,Mefenamic acid 250mg capsules (Arrow Generics Ltd)
+24378611000001109,Mefenamic acid 250mg capsules (DE Pharmaceuticals)
+14945211000001109,Mefenamic acid 250mg capsules (Essential Generics Ltd)
+767711000001103,Mefenamic acid 250mg capsules (Kent Pharmaceuticals Ltd)
+756011000001108,Mefenamic acid 250mg capsules (Mylan)
+17939411000001103,Mefenamic acid 250mg capsules (Phoenix Healthcare Distribution Ltd)
+29904711000001109,Mefenamic acid 250mg capsules (Sigma Pharmaceuticals Plc)
+21791511000001102,Mefenamic acid 250mg capsules (Waymade Healthcare Plc)
+164411000001109,Mefenamic acid 250mg capsules (Zentiva)
+8662311000001102,Mefenamic acid 250mg/5ml oral suspension
+8607611000001109,Mefenamic acid 250mg/5ml oral suspension (Special Order)
+329803004,Mefenamic acid 500mg tablets
+411211000001108,Mefenamic acid 500mg tablets (A A H Pharmaceuticals Ltd)
+774611000001107,Mefenamic acid 500mg tablets (Actavis UK Ltd)
+393211000001104,Mefenamic acid 500mg tablets (Alliance Healthcare (Distribution) Ltd)
+17970611000001108,Mefenamic acid 500mg tablets (Almus Pharmaceuticals Ltd)
+13581311000001100,Mefenamic acid 500mg tablets (DE Pharmaceuticals)
+14945411000001108,Mefenamic acid 500mg tablets (Essential Generics Ltd)
+740211000001103,Mefenamic acid 500mg tablets (IVAX Pharmaceuticals UK Ltd)
+189011000001101,Mefenamic acid 500mg tablets (Kent Pharmaceuticals Ltd)
+37119811000001109,Mefenamic acid 500mg tablets (Mawdsley-Brooks & Company Ltd)
+37723411000001105,Mefenamic acid 500mg tablets (Pilsco Ltd)
+15109011000001103,Mefenamic acid 500mg tablets (Sigma Pharmaceuticals Plc)
+655611000001101,Mefenamic acid 500mg tablets (Teva UK Ltd)
+21791711000001107,Mefenamic acid 500mg tablets (Waymade Healthcare Plc)
+122811000001109,Mefenamic acid 500mg tablets (Zentiva)
+8662411000001109,Mefenamic acid 500mg/5ml oral suspension
+8608211000001106,Mefenamic acid 500mg/5ml oral suspension (Special Order)
+35369111000001107,Mefenamic acid 50mg/5ml oral suspension
+259811000001102,Mefenamic acid 50mg/5ml oral suspension (A A H Pharmaceuticals Ltd)
+186711000001109,Mefenamic acid 50mg/5ml oral suspension (Alliance Healthcare (Distribution) Ltd)
+26853411000001107,Mefenamic acid 50mg/5ml oral suspension (Ennogen Healthcare Ltd)
+11508411000001105,Mefenamic acid 50mg/5ml oral suspension (Essential Generics Ltd)
+11484811000001108,Mefenamic acid 50mg/5ml oral suspension (Special Order)
+412018004,Mefenamic acid in oral dosage form
+22648611000001108,Meloxicam 15mg orodispersible tablets sugar free
+23679611000001108,Meloxicam 15mg orodispersible tablets sugar free (A A H Pharmaceuticals Ltd)
+22640411000001107,Meloxicam 15mg orodispersible tablets sugar free (Rhodes Pharma Ltd)
+329928008,Meloxicam 15mg tablets
+9835011000001107,Meloxicam 15mg tablets (A A H Pharmaceuticals Ltd)
+10304811000001109,Meloxicam 15mg tablets (Actavis UK Ltd)
+9906111000001103,Meloxicam 15mg tablets (Alliance Healthcare (Distribution) Ltd)
+11426411000001108,Meloxicam 15mg tablets (Almus Pharmaceuticals Ltd)
+13413411000001104,Meloxicam 15mg tablets (Arrow Generics Ltd)
+13930111000001109,Meloxicam 15mg tablets (DE Pharmaceuticals)
+24378911000001103,Meloxicam 15mg tablets (DE Pharmaceuticals)
+5496511000001100,Meloxicam 15mg tablets (Dowelhurst Ltd)
+10302411000001100,Meloxicam 15mg tablets (Focus Pharmaceuticals Ltd)
+10615011000001107,Meloxicam 15mg tablets (Genus Pharmaceuticals Ltd)
+14162511000001105,Meloxicam 15mg tablets (Healthcare Pharma Ltd)
+10198411000001108,Meloxicam 15mg tablets (IVAX Pharmaceuticals UK Ltd)
+9856311000001104,Meloxicam 15mg tablets (Kent Pharmaceuticals Ltd)
+30827211000001109,Meloxicam 15mg tablets (Mawdsley-Brooks & Company Ltd)
+9991611000001102,Meloxicam 15mg tablets (Mylan)
+10440311000001108,Meloxicam 15mg tablets (Niche Generics Ltd)
+17939811000001101,Meloxicam 15mg tablets (Phoenix Healthcare Distribution Ltd)
+10962511000001105,Meloxicam 15mg tablets (Sandoz Ltd)
+14493911000001106,Meloxicam 15mg tablets (Sigma Pharmaceuticals Plc)
+15109311000001100,Meloxicam 15mg tablets (Sigma Pharmaceuticals Plc)
+10701211000001107,Meloxicam 15mg tablets (Somex Pharma)
+17204011000001100,Meloxicam 15mg tablets (Sovereign Medical Ltd)
+9834611000001101,Meloxicam 15mg tablets (Teva UK Ltd)
+5389911000001106,Meloxicam 15mg tablets (Waymade Healthcare Plc)
+21792211000001107,Meloxicam 15mg tablets (Waymade Healthcare Plc)
+9870511000001106,Meloxicam 15mg tablets (Zentiva)
+13822011000001102,Meloxicam 15mg/5ml oral suspension
+13817711000001108,Meloxicam 15mg/5ml oral suspension (Special Order)
+12700711000001103,Meloxicam 3.75mg/5ml oral suspension
+12690511000001101,Meloxicam 3.75mg/5ml oral suspension (Special Order)
+22648711000001104,Meloxicam 7.5mg orodispersible tablets sugar free
+23679411000001105,Meloxicam 7.5mg orodispersible tablets sugar free (A A H Pharmaceuticals Ltd)
+22640911000001104,Meloxicam 7.5mg orodispersible tablets sugar free (Rhodes Pharma Ltd)
+329927003,Meloxicam 7.5mg tablets
+9834811000001102,Meloxicam 7.5mg tablets (A A H Pharmaceuticals Ltd)
+10304311000001100,Meloxicam 7.5mg tablets (Actavis UK Ltd)
+9905911000001107,Meloxicam 7.5mg tablets (Alliance Healthcare (Distribution) Ltd)
+11426211000001109,Meloxicam 7.5mg tablets (Almus Pharmaceuticals Ltd)
+13413211000001103,Meloxicam 7.5mg tablets (Arrow Generics Ltd)
+24379111000001108,Meloxicam 7.5mg tablets (DE Pharmaceuticals)
+5496611000001101,Meloxicam 7.5mg tablets (Dowelhurst Ltd)
+10302611000001102,Meloxicam 7.5mg tablets (Focus Pharmaceuticals Ltd)
+10614811000001102,Meloxicam 7.5mg tablets (Genus Pharmaceuticals Ltd)
+14162311000001104,Meloxicam 7.5mg tablets (Healthcare Pharma Ltd)
+10198211000001109,Meloxicam 7.5mg tablets (IVAX Pharmaceuticals UK Ltd)
+9856111000001101,Meloxicam 7.5mg tablets (Kent Pharmaceuticals Ltd)
+30827011000001104,Meloxicam 7.5mg tablets (Mawdsley-Brooks & Company Ltd)
+9991411000001100,Meloxicam 7.5mg tablets (Mylan)
+10440011000001105,Meloxicam 7.5mg tablets (Niche Generics Ltd)
+17939611000001100,Meloxicam 7.5mg tablets (Phoenix Healthcare Distribution Ltd)
+10962111000001101,Meloxicam 7.5mg tablets (Sandoz Ltd)
+15109611000001105,Meloxicam 7.5mg tablets (Sigma Pharmaceuticals Plc)
+10702311000001108,Meloxicam 7.5mg tablets (Somex Pharma)
+17203811000001108,Meloxicam 7.5mg tablets (Sovereign Medical Ltd)
+9834411000001104,Meloxicam 7.5mg tablets (Teva UK Ltd)
+5389711000001109,Meloxicam 7.5mg tablets (Waymade Healthcare Plc)
+21792011000001102,Meloxicam 7.5mg tablets (Waymade Healthcare Plc)
+9870211000001108,Meloxicam 7.5mg tablets (Zentiva)
+15857511000001104,Meloxicam 7.5mg/5ml oral suspension
+15856111000001105,Meloxicam 7.5mg/5ml oral suspension (Special Order)
+412001003,Meloxicam in oral dosage form
+427159000,Meloxicam in rectal dosage form
+903411000001105,Migrafen 200mg tablets (Chatfield Laboratories)
+22591711000001107,Misofen 50mg/200microgram gastro-resistant tablets (Morningside Healthcare Ltd)
+22592011000001102,Misofen 75mg/200microgram gastro-resistant tablets (Morningside Healthcare Ltd)
+81511000001104,Mobic 15mg tablets (Boehringer Ingelheim Ltd)
+5561611000001101,Mobic 15mg tablets (Dowelhurst Ltd)
+16207711000001109,Mobic 15mg tablets (Lexon (UK) Ltd)
+16556511000001100,Mobic 15mg tablets (Mawdsley-Brooks & Company Ltd)
+17585111000001107,Mobic 15mg tablets (Necessity Supplies Ltd)
+14713411000001105,Mobic 15mg tablets (Sigma Pharmaceuticals Plc)
+5390911000001104,Mobic 15mg tablets (Waymade Healthcare Plc)
+591611000001104,Mobic 7.5mg tablets (Boehringer Ingelheim Ltd)
+5562611000001107,Mobic 7.5mg tablets (Dowelhurst Ltd)
+16207511000001104,Mobic 7.5mg tablets (Lexon (UK) Ltd)
+17516811000001106,Mobic 7.5mg tablets (Mawdsley-Brooks & Company Ltd)
+17585511000001103,Mobic 7.5mg tablets (Necessity Supplies Ltd)
+14713011000001101,Mobic 7.5mg tablets (Sigma Pharmaceuticals Plc)
+5389511000001104,Mobic 7.5mg tablets (Waymade Healthcare Plc)
+5590411000001105,Mobiflex 20mg tablets (Dowelhurst Ltd)
+213111000001102,Mobiflex 20mg tablets (Mylan)
+14713911000001102,Mobiflex 20mg tablets (Sigma Pharmaceuticals Plc)
+5482811000001102,Mobiflex 20mg tablets (Waymade Healthcare Plc)
+3953411000001109,Motifene 75mg modified-release capsules (Daiichi Sankyo UK Ltd)
+868911000001103,Motrin 400mg tablets (Pfizer Ltd)
+550011000001109,Motrin 600mg tablets (Pfizer Ltd)
+62911000001102,Motrin 800mg tablets (Pfizer Ltd)
+400480005,Nabumetone 500mg dispersible tablets sugar free
+329910006,Nabumetone 500mg tablets
+282011000001105,Nabumetone 500mg tablets (A A H Pharmaceuticals Ltd)
+802111000001103,Nabumetone 500mg tablets (Actavis UK Ltd)
+436011000001102,Nabumetone 500mg tablets (Alliance Healthcare (Distribution) Ltd)
+17966411000001101,Nabumetone 500mg tablets (Almus Pharmaceuticals Ltd)
+17308011000001101,Nabumetone 500mg tablets (Beechmere Pharmaceuticals Ltd)
+30062011000001105,Nabumetone 500mg tablets (DE Pharmaceuticals)
+5506011000001100,Nabumetone 500mg tablets (Dowelhurst Ltd)
+18080011000001108,Nabumetone 500mg tablets (Fannin UK Ltd)
+10301011000001101,Nabumetone 500mg tablets (Focus Pharmaceuticals Ltd)
+5003211000001101,Nabumetone 500mg tablets (IVAX Pharmaceuticals UK Ltd)
+212611000001100,Nabumetone 500mg tablets (Kent Pharmaceuticals Ltd)
+351111000001101,Nabumetone 500mg tablets (Mylan)
+17944911000001106,Nabumetone 500mg tablets (Phoenix Healthcare Distribution Ltd)
+4870111000001103,Nabumetone 500mg tablets (Sandoz Ltd)
+635011000001109,Nabumetone 500mg tablets (Teva UK Ltd)
+35861211000001104,Nabumetone 500mg tablets (Tillomed Laboratories Ltd)
+21816811000001106,Nabumetone 500mg tablets (Waymade Healthcare Plc)
+329912003,Nabumetone 500mg/5ml oral suspension
+32778411000001103,Nabumetone 500mg/5ml oral suspension
+32777811000001100,Nabumetone 500mg/5ml oral suspension (Special Order)
+32751811000001105,Nabumetone 500mg/5ml oral suspension sugar free
+374639008,Nabumetone 750 mg oral tablet
+412002005,Nabumetone in oral dosage form
+3226311000001108,Napratec OP tablets (Pfizer Ltd)
+4550611000001107,Naprosyn 125mg/5ml oral suspension (Roche Products Ltd)
+894311000001106,Naprosyn 250mg tablets (Atnahs Pharma UK Ltd)
+162011000001106,Naprosyn 500mg tablets (Atnahs Pharma UK Ltd)
+5392911000001100,Naprosyn 500mg tablets (Waymade Healthcare Plc)
+178811000001105,Naprosyn EC 250mg tablets (Atnahs Pharma UK Ltd)
+17609911000001102,Naprosyn EC 250mg tablets (Necessity Supplies Ltd)
+611711000001104,Naprosyn EC 375mg tablets (Atnahs Pharma UK Ltd)
+434011000001107,Naprosyn EC 500mg tablets (Atnahs Pharma UK Ltd)
+17610611000001100,Naprosyn EC 500mg tablets (Necessity Supplies Ltd)
+61111000001105,Naprosyn S/R 500mg tablets (Roche Products Ltd)
+765577007,Naproxen (as naproxen sodium) 500 mg gastro-resistant oral tablet
+12301311000001108,Naproxen 100mg/5ml oral suspension
+12257211000001109,Naproxen 100mg/5ml oral suspension (Special Order)
+329852000,Naproxen 125mg/5ml oral suspension
+8637511000001100,Naproxen 125mg/5ml oral suspension (Special Order)
+32638811000001105,Naproxen 125mg/5ml oral suspension sugar free
+32775911000001100,Naproxen 125mg/5ml oral suspension sugar free (A A H Pharmaceuticals Ltd)
+33136211000001102,Naproxen 125mg/5ml oral suspension sugar free (Alliance Healthcare (Distribution) Ltd)
+370201000,Naproxen 200 mg oral tablet
+416821000,Naproxen 200 mg/1 each oral capsule
+12301411000001101,Naproxen 200mg/5ml oral suspension
+12257611000001106,Naproxen 200mg/5ml oral suspension (Drug Tariff Special Order)
+765604005,Naproxen 200mg/pseudoephedrine 120mg prolonged-release oral tablet
+31306711000001103,Naproxen 250mg effervescent tablets sugar free
+329838002,Naproxen 250mg gastro-resistant tablets
+367911000001102,Naproxen 250mg gastro-resistant tablets (A A H Pharmaceuticals Ltd)
+129111000001106,Naproxen 250mg gastro-resistant tablets (Actavis UK Ltd)
+547811000001102,Naproxen 250mg gastro-resistant tablets (Alliance Healthcare (Distribution) Ltd)
+11426611000001106,Naproxen 250mg gastro-resistant tablets (Almus Pharmaceuticals Ltd)
+30062411000001101,Naproxen 250mg gastro-resistant tablets (DE Pharmaceuticals)
+20325711000001106,Naproxen 250mg gastro-resistant tablets (Genesis Pharmaceuticals Ltd)
+764211000001103,Naproxen 250mg gastro-resistant tablets (IVAX Pharmaceuticals UK Ltd)
+5474911000001107,Naproxen 250mg gastro-resistant tablets (Kent Pharmaceuticals Ltd)
+37122511000001106,Naproxen 250mg gastro-resistant tablets (Mawdsley-Brooks & Company Ltd)
+37999211000001105,Naproxen 250mg gastro-resistant tablets (Medreich Plc)
+687211000001104,Naproxen 250mg gastro-resistant tablets (Mylan)
+17945511000001103,Naproxen 250mg gastro-resistant tablets (Phoenix Healthcare Distribution Ltd)
+16212811000001102,Naproxen 250mg gastro-resistant tablets (Ranbaxy (UK) Ltd)
+579011000001103,Naproxen 250mg gastro-resistant tablets (Sandoz Ltd)
+29928311000001106,Naproxen 250mg gastro-resistant tablets (Sigma Pharmaceuticals Plc)
+36782111000001103,Naproxen 250mg gastro-resistant tablets (Sovereign Medical Ltd)
+603311000001104,Naproxen 250mg gastro-resistant tablets (Teva UK Ltd)
+21817711000001100,Naproxen 250mg gastro-resistant tablets (Waymade Healthcare Plc)
+329806007,Naproxen 250mg tablets
+889911000001109,Naproxen 250mg tablets (A A H Pharmaceuticals Ltd)
+18464611000001101,Naproxen 250mg tablets (Accord Healthcare Ltd)
+86111000001104,Naproxen 250mg tablets (Actavis UK Ltd)
+60511000001108,Naproxen 250mg tablets (Alliance Healthcare (Distribution) Ltd)
+13845911000001109,Naproxen 250mg tablets (Almus Pharmaceuticals Ltd)
+10396611000001103,Naproxen 250mg tablets (Arrow Generics Ltd)
+36597211000001105,Naproxen 250mg tablets (Bristol Laboratories Ltd)
+28985211000001102,Naproxen 250mg tablets (Crescent Pharma Ltd)
+13581711000001101,Naproxen 250mg tablets (DE Pharmaceuticals)
+36011911000001106,Naproxen 250mg tablets (Genesis Pharmaceuticals Ltd)
+150011000001103,Naproxen 250mg tablets (IVAX Pharmaceuticals UK Ltd)
+774811000001106,Naproxen 250mg tablets (Kent Pharmaceuticals Ltd)
+30849711000001108,Naproxen 250mg tablets (Mawdsley-Brooks & Company Ltd)
+19195411000001104,Naproxen 250mg tablets (Milpharm Ltd)
+630611000001105,Naproxen 250mg tablets (Mylan)
+18627511000001101,Naproxen 250mg tablets (Phoenix Healthcare Distribution Ltd)
+29928511000001100,Naproxen 250mg tablets (Sigma Pharmaceuticals Plc)
+360911000001103,Naproxen 250mg tablets (Teva UK Ltd)
+21818111000001100,Naproxen 250mg tablets (Waymade Healthcare Plc)
+521711000001104,Naproxen 250mg tablets (Wockhardt UK Ltd)
+8669711000001109,Naproxen 250mg/5ml oral suspension
+8638311000001107,Naproxen 250mg/5ml oral suspension (Special Order)
+32636911000001104,Naproxen 25mg/ml oral suspension sugar free (Orion Pharma (UK) Ltd)
+36904811000001109,Naproxen 320mg/5ml oral suspension
+36877511000001102,Naproxen 320mg/5ml oral suspension (Special Order)
+765713002,Naproxen 375 mg gastro-resistant oral tablet
+376021003,Naproxen 375 mg oral tablet
+36564511000001103,Naproxen 375mg gastro-resistant tablets
+7898511000001105,Naproxen 375mg gastro-resistant tablets (A A H Pharmaceuticals Ltd)
+658611000001107,Naproxen 375mg gastro-resistant tablets (Actavis UK Ltd)
+817811000001105,Naproxen 375mg gastro-resistant tablets (Alliance Healthcare (Distribution) Ltd)
+30062611000001103,Naproxen 375mg gastro-resistant tablets (DE Pharmaceuticals)
+842611000001103,Naproxen 375mg gastro-resistant tablets (Kent Pharmaceuticals Ltd)
+37999411000001109,Naproxen 375mg gastro-resistant tablets (Medreich Plc)
+15236411000001105,Naproxen 375mg gastro-resistant tablets (Sigma Pharmaceuticals Plc)
+37336111000001109,Naproxen 375mg gastro-resistant tablets (Sovereign Medical Ltd)
+18245811000001107,Naproxen 500mg / Esomeprazole 20mg modified-release tablets
+329839005,Naproxen 500mg gastro-resistant tablets
+936011000001104,Naproxen 500mg gastro-resistant tablets (A A H Pharmaceuticals Ltd)
+27711000001108,Naproxen 500mg gastro-resistant tablets (Actavis UK Ltd)
+692711000001105,Naproxen 500mg gastro-resistant tablets (Alliance Healthcare (Distribution) Ltd)
+11426811000001105,Naproxen 500mg gastro-resistant tablets (Almus Pharmaceuticals Ltd)
+30062811000001104,Naproxen 500mg gastro-resistant tablets (DE Pharmaceuticals)
+20325911000001108,Naproxen 500mg gastro-resistant tablets (Genesis Pharmaceuticals Ltd)
+678411000001107,Naproxen 500mg gastro-resistant tablets (IVAX Pharmaceuticals UK Ltd)
+297211000001103,Naproxen 500mg gastro-resistant tablets (Kent Pharmaceuticals Ltd)
+30850111000001100,Naproxen 500mg gastro-resistant tablets (Mawdsley-Brooks & Company Ltd)
+37999611000001107,Naproxen 500mg gastro-resistant tablets (Medreich Plc)
+368211000001105,Naproxen 500mg gastro-resistant tablets (Mylan)
+17945711000001108,Naproxen 500mg gastro-resistant tablets (Phoenix Healthcare Distribution Ltd)
+16213011000001104,Naproxen 500mg gastro-resistant tablets (Ranbaxy (UK) Ltd)
+279011000001106,Naproxen 500mg gastro-resistant tablets (Sandoz Ltd)
+29928711000001105,Naproxen 500mg gastro-resistant tablets (Sigma Pharmaceuticals Plc)
+36781911000001106,Naproxen 500mg gastro-resistant tablets (Sovereign Medical Ltd)
+143611000001103,Naproxen 500mg gastro-resistant tablets (Teva UK Ltd)
+21817911000001103,Naproxen 500mg gastro-resistant tablets (Waymade Healthcare Plc)
+36030111000001106,Naproxen 500mg modified-release tablets
+329807003,Naproxen 500mg tablets
+396811000001107,Naproxen 500mg tablets (A A H Pharmaceuticals Ltd)
+18464911000001107,Naproxen 500mg tablets (Accord Healthcare Ltd)
+161211000001108,Naproxen 500mg tablets (Actavis UK Ltd)
+521011000001101,Naproxen 500mg tablets (Alliance Healthcare (Distribution) Ltd)
+13846111000001100,Naproxen 500mg tablets (Almus Pharmaceuticals Ltd)
+10396811000001104,Naproxen 500mg tablets (Arrow Generics Ltd)
+36597611000001107,Naproxen 500mg tablets (Bristol Laboratories Ltd)
+28985411000001103,Naproxen 500mg tablets (Crescent Pharma Ltd)
+30063011000001101,Naproxen 500mg tablets (DE Pharmaceuticals)
+37999811000001106,Naproxen 500mg tablets (Genesis Pharmaceuticals Ltd)
+408811000001100,Naproxen 500mg tablets (IVAX Pharmaceuticals UK Ltd)
+377711000001106,Naproxen 500mg tablets (Kent Pharmaceuticals Ltd)
+30849911000001105,Naproxen 500mg tablets (Mawdsley-Brooks & Company Ltd)
+36026111000001106,Naproxen 500mg tablets (Medreich Plc)
+19195611000001101,Naproxen 500mg tablets (Milpharm Ltd)
+447511000001108,Naproxen 500mg tablets (Mylan)
+36926211000001106,Naproxen 500mg tablets (Noumed Life Sciences Ltd)
+3224611000001107,Naproxen 500mg tablets (Pfizer Ltd)
+18627211000001104,Naproxen 500mg tablets (Phoenix Healthcare Distribution Ltd)
+29928911000001107,Naproxen 500mg tablets (Sigma Pharmaceuticals Plc)
+80711000001101,Naproxen 500mg tablets (Sterwin Medicines)
+220511000001107,Naproxen 500mg tablets (Teva UK Ltd)
+21818311000001103,Naproxen 500mg tablets (Waymade Healthcare Plc)
+481611000001108,Naproxen 500mg tablets (Wockhardt UK Ltd)
+36030211000001100,Naproxen 500mg tablets and Misoprostol 200microgram tablets
+8669811000001101,Naproxen 500mg/5ml oral suspension
+8639711000001102,Naproxen 500mg/5ml oral suspension (Special Order)
+34328011000001102,Naproxen 50mg/ml oral suspension (A A H Pharmaceuticals Ltd)
+34195911000001106,Naproxen 50mg/ml oral suspension (Alliance Healthcare (Distribution) Ltd)
+37609211000001109,Naproxen 50mg/ml oral suspension (DE Pharmaceuticals)
+33743911000001109,Naproxen 50mg/ml oral suspension (Thornton & Ross Ltd)
+36904911000001104,Naproxen 60mg/5ml oral suspension
+36877011000001105,Naproxen 60mg/5ml oral suspension (Special Order)
+12301511000001102,Naproxen 70mg/5ml oral suspension
+12258111000001102,Naproxen 70mg/5ml oral suspension (Special Order)
+12301611000001103,Naproxen 75mg/5ml oral suspension
+12258411000001107,Naproxen 75mg/5ml oral suspension (Special Order)
+409480003,Naproxen and pseudoephedrine
+768375001,Naproxen and sumatriptan in oral dosage form
+768374002,Naproxen and sumatriptan product
+439298001,Naproxen in oral dosage form
+438461006,Naproxen in rectal dosage form
+420276008,Naproxen sodium 220 mg/1 each oral capsule
+765642004,Naproxen sodium 220mg/pseudoephedrine 120mg prolonged-release oral tablet
+322299000,Naproxen sodium 275mg tablets
+765688005,Naproxen sodium 375mg gastro-resistant oral tablet
+433315007,Naproxen sodium 500 mg and sumatriptan 85 mg oral tablet
+766017000,Naproxen sodium 500mg gastro-resistant oral tablet
+376010007,Naproxen sodium 550 mg oral tablet
+36736411000001102,Nexocin EC 250mg gastro-resistant tablets (Noumed Life Sciences Ltd)
+36737011000001109,Nexocin EC 375mg gastro-resistant tablets (Noumed Life Sciences Ltd)
+36737211000001104,Nexocin EC 500mg gastro-resistant tablets (Noumed Life Sciences Ltd)
+13090211000001100,Novo-Diflunisal 250mg tablets (Imported (Canada))
+24584811000001108,Numark Max Strength Pharmacy Ibuprofen 400mg tablets (Numark Ltd)
+621911000001109,Nurofen 200mg caplets (Reckitt Benckiser Healthcare (UK) Ltd)
+3917611000001108,Nurofen 200mg liquid capsules (Reckitt Benckiser Healthcare (UK) Ltd)
+694411000001106,Nurofen 200mg tablets (Reckitt Benckiser Healthcare (UK) Ltd)
+4545511000001100,Nurofen Advance 200mg tablets (Crookes Healthcare Ltd)
+8061211000001108,Nurofen Back Pain SR 300mg capsules (Reckitt Benckiser Healthcare (UK) Ltd)
+23658411000001100,Nurofen Cold & Flu Relief 200mg/5mg tablets (Reckitt Benckiser Healthcare (UK) Ltd)
+4606211000001109,Nurofen Cold and Flu tablets (Reckitt Benckiser Healthcare (UK) Ltd)
+23658611000001102,Nurofen Day & Night Cold & Flu 200mg/5mg tablets (Reckitt Benckiser Healthcare (UK) Ltd)
+11934511000001100,Nurofen Express 200mg liquid capsules (Reckitt Benckiser Healthcare (UK) Ltd)
+14740311000001102,Nurofen Express 256mg caplets (Reckitt Benckiser Healthcare (UK) Ltd)
+14600611000001108,Nurofen Express 256mg tablets (Reckitt Benckiser Healthcare (UK) Ltd)
+11934111000001109,Nurofen Express 342mg caplets (Reckitt Benckiser Healthcare (UK) Ltd)
+11934911000001107,Nurofen Express 400mg liquid capsules (Reckitt Benckiser Healthcare (UK) Ltd)
+14601611000001103,Nurofen Express 512mg tablets (Reckitt Benckiser Healthcare (UK) Ltd)
+11935111000001108,Nurofen Express 684mg caplets (Reckitt Benckiser Healthcare (UK) Ltd)
+21524011000001101,Nurofen Express Period Pain 200mg capsules (Reckitt Benckiser Healthcare (UK) Ltd)
+21679511000001103,Nurofen Express Soluble 400mg oral powder sachets (Reckitt Benckiser Healthcare (UK) Ltd)
+10768811000001101,Nurofen Extra Strength 400mg capsules (Reckitt Benckiser Healthcare (UK) Ltd)
+32390811000001108,Nurofen for Children 100mg chewable capsules (Reckitt Benckiser Healthcare (UK) Ltd)
+664811000001105,Nurofen for Children 100mg/5ml oral suspension orange (Reckitt Benckiser Healthcare (UK) Ltd)
+9164611000001101,Nurofen for Children 100mg/5ml oral suspension strawberry (Reckitt Benckiser Healthcare (UK) Ltd)
+38692711000001102,Nurofen for Children 200mg/5ml oral suspension orange (Reckitt Benckiser Healthcare (UK) Ltd)
+38692911000001100,Nurofen for Children 200mg/5ml oral suspension strawberry (Reckitt Benckiser Healthcare (UK) Ltd)
+23649811000001108,"Nurofen for Children Cold, Pain and Fever Orange Flavour 100mg/5ml oral suspension (Reckitt Benckiser Healthcare (UK) Ltd)"
+23649611000001109,"Nurofen for Children Cold, Pain and Fever Strawberry Flavour 100mg/5ml oral suspension (Reckitt Benckiser Healthcare (UK) Ltd)"
+4605611000001101,Nurofen for Children Singles 100mg/5ml oral suspension 5ml sachets orange (Reckitt Benckiser Healthcare (UK) Ltd)
+9164311000001106,Nurofen for Children Singles 100mg/5ml oral suspension 5ml sachets strawberry (Reckitt Benckiser Healthcare (UK) Ltd)
+31394911000001107,Nurofen Joint & Back Pain Relief 200mg capsules (Reckitt Benckiser Healthcare (UK) Ltd)
+31394411000001104,Nurofen Joint & Back Pain Relief 256mg caplets (Reckitt Benckiser Healthcare (UK) Ltd)
+31393111000001107,Nurofen Joint & Back Pain Relief 256mg tablets (Reckitt Benckiser Healthcare (UK) Ltd)
+3158711000001107,Nurofen Long Lasting 300mg capsules (Crookes Healthcare Ltd)
+31394111000001109,Nurofen Max Strength Joint & Back Pain Relief 512mg tablets (Reckitt Benckiser Healthcare (UK) Ltd)
+10239611000001109,Nurofen Maximum Strength Migraine Pain 684mg caplets (Reckitt Benckiser Healthcare (UK) Ltd)
+3869111000001103,Nurofen Meltlets 200mg tablets (Reckitt Benckiser Healthcare (UK) Ltd)
+4603811000001101,Nurofen Migraine Pain 342mg tablets (Reckitt Benckiser Healthcare (UK) Ltd)
+3915411000001104,Nurofen Plus tablets (Reckitt Benckiser Healthcare (UK) Ltd)
+4603411000001103,Nurofen Recovery 200mg orodispersible tablets (Reckitt Benckiser Healthcare (UK) Ltd)
+30785411000001108,Nurofen Sinus & Blocked Nose 200mg/5mg tablets (Reckitt Benckiser Healthcare (UK) Ltd)
+30785611000001106,Nurofen Sinus Pain Relief 200mg/5mg tablets (Reckitt Benckiser Healthcare (UK) Ltd)
+31396411000001107,Nurofen Sinus Pressure & Headache Relief 200mg/30mg tablets (Reckitt Benckiser Healthcare (UK) Ltd)
+9444911000001101,Nurofen Sinus tablets (Reckitt Benckiser Healthcare (UK) Ltd)
+9511211000001108,Nurofen Tension Headache 342mg caplets (Reckitt Benckiser Healthcare (UK) Ltd)
+18594011000001100,Nuromol 200mg/500mg tablets (Reckitt Benckiser Healthcare (UK) Ltd)
+819011000001108,Nycopren 250mg gastro-resistant tablets (Ardern Healthcare Ltd)
+174811000001102,Nycopren 500mg gastro-resistant tablets (Ardern Healthcare Ltd)
+7987311000001109,Obifen 400mg tablets (Ayrton Saunders Ltd)
+17302511000001107,Onsenal 400mg capsules (Pfizer Ltd)
+384674003,Ophthalmic flurbiprofen
+411997005,Oral form azapropazone
+412011005,Oral form indomethacin
+13093011000001100,Orbifen Cold & Flu oral suspension (Orbis Consumer Products Ltd)
+477011000001101,Orbifen For Children 100mg/5ml oral suspension (Orbis Consumer Products Ltd)
+7664811000001108,Orbifen For Children 100mg/5ml oral suspension 5ml sachets (Orbis Consumer Products Ltd)
+458511000001105,Orudis 100mg capsules (Sanofi)
+429511000001103,Orudis 50mg capsules (Sanofi)
+18893911000001104,Oruvail 100 modified-release capsules (Mawdsley-Brooks & Company Ltd)
+155411000001100,Oruvail 100 modified-release capsules (Sanofi)
+10857811000001108,Oruvail 100 modified-release capsules (Waymade Healthcare Plc)
+657811000001107,Oruvail 150 modified-release capsules (Sanofi)
+37399311000001105,Oruvail 200 modified-release capsules (CST Pharma Ltd)
+13942911000001105,Oruvail 200 modified-release capsules (DE Pharmaceuticals)
+5567511000001106,Oruvail 200 modified-release capsules (Dowelhurst Ltd)
+16218011000001106,Oruvail 200 modified-release capsules (Lexon (UK) Ltd)
+17343411000001105,Oruvail 200 modified-release capsules (Mawdsley-Brooks & Company Ltd)
+17615911000001102,Oruvail 200 modified-release capsules (Necessity Supplies Ltd)
+345311000001100,Oruvail 200 modified-release capsules (Sanofi)
+14671611000001106,Oruvail 200 modified-release capsules (Sigma Pharmaceuticals Plc)
+5396711000001103,Oruvail 200 modified-release capsules (Waymade Healthcare Plc)
+24511000001106,Pacifene 200mg tablets (Sussex Pharmaceutical Ltd)
+33568211000001100,Paracetamol 500mg / Ibuprofen 150mg tablets
+18595211000001106,Paracetamol 500mg / Ibuprofen 200mg tablets
+17317011000001104,Paramed Ibuprofen 200mg liquid capsules (Galpharm International Ltd)
+392111000001104,Pardelprin MR 75mg capsules (Actavis UK Ltd)
+424385004,Parenteral form indometacin
+374348005,Phenylbutazone 100 mg/1 each oral capsule
+347249002,Phenylbutazone 100mg gastro-resistant tablets
+329854004,Phenylbutazone 100mg tablets
+11256211000001106,Phenylbutazone 100mg tablets (A A H Pharmaceuticals Ltd)
+10360711000001106,Phenylbutazone 100mg tablets (Alliance Healthcare (Distribution) Ltd)
+10423311000001100,Phenylbutazone 100mg tablets (Essential Generics Ltd)
+329855003,Phenylbutazone 200mg tablets
+11256411000001105,Phenylbutazone 200mg tablets (A A H Pharmaceuticals Ltd)
+10361211000001105,Phenylbutazone 200mg tablets (Alliance Healthcare (Distribution) Ltd)
+10423711000001101,Phenylbutazone 200mg tablets (Essential Generics Ltd)
+767769005,Phenylbutazone in oral dosage form
+329862007,Piroxicam 10mg capsules
+928911000001104,Piroxicam 10mg capsules (A A H Pharmaceuticals Ltd)
+468211000001100,Piroxicam 10mg capsules (Actavis UK Ltd)
+385011000001106,Piroxicam 10mg capsules (Alliance Healthcare (Distribution) Ltd)
+494511000001107,Piroxicam 10mg capsules (Approved Prescription Services Ltd)
+10403211000001102,Piroxicam 10mg capsules (Arrow Generics Ltd)
+28986111000001102,Piroxicam 10mg capsules (Crescent Pharma Ltd)
+30112511000001107,Piroxicam 10mg capsules (DE Pharmaceuticals)
+13243911000001104,Piroxicam 10mg capsules (Dowelhurst Ltd)
+310111000001102,Piroxicam 10mg capsules (IVAX Pharmaceuticals UK Ltd)
+735411000001107,Piroxicam 10mg capsules (Kent Pharmaceuticals Ltd)
+30857611000001107,Piroxicam 10mg capsules (Mawdsley-Brooks & Company Ltd)
+286411000001100,Piroxicam 10mg capsules (Mylan)
+17878511000001101,Piroxicam 10mg capsules (Phoenix Healthcare Distribution Ltd)
+9191811000001101,Piroxicam 10mg capsules (Sandoz Ltd)
+18734211000001102,Piroxicam 10mg capsules (Sigma Pharmaceuticals Plc)
+317911000001103,Piroxicam 10mg capsules (The Boots Company Plc)
+21848811000001100,Piroxicam 10mg capsules (Waymade Healthcare Plc)
+329881004,Piroxicam 10mg dispersible tablets
+828011000001106,Piroxicam 10mg dispersible tablets (A A H Pharmaceuticals Ltd)
+361811000001100,Piroxicam 10mg dispersible tablets (Alliance Healthcare (Distribution) Ltd)
+13244511000001109,Piroxicam 10mg dispersible tablets (Dowelhurst Ltd)
+681811000001105,Piroxicam 10mg dispersible tablets (Kent Pharmaceuticals Ltd)
+455811000001104,Piroxicam 10mg dispersible tablets (Mylan)
+14714811000001105,Piroxicam 10mg dispersible tablets (Sigma Pharmaceuticals Plc)
+329904006,Piroxicam 20 mg oral tablet
+329863002,Piroxicam 20mg capsules
+723011000001101,Piroxicam 20mg capsules (A A H Pharmaceuticals Ltd)
+627511000001108,Piroxicam 20mg capsules (Actavis UK Ltd)
+267611000001103,Piroxicam 20mg capsules (Alliance Healthcare (Distribution) Ltd)
+450411000001108,Piroxicam 20mg capsules (Approved Prescription Services Ltd)
+10403611000001100,Piroxicam 20mg capsules (Arrow Generics Ltd)
+28986311000001100,Piroxicam 20mg capsules (Crescent Pharma Ltd)
+30112711000001102,Piroxicam 20mg capsules (DE Pharmaceuticals)
+13244211000001106,Piroxicam 20mg capsules (Dowelhurst Ltd)
+63311000001108,Piroxicam 20mg capsules (IVAX Pharmaceuticals UK Ltd)
+146611000001109,Piroxicam 20mg capsules (Kent Pharmaceuticals Ltd)
+30857811000001106,Piroxicam 20mg capsules (Mawdsley-Brooks & Company Ltd)
+92811000001109,Piroxicam 20mg capsules (Mylan)
+17878711000001106,Piroxicam 20mg capsules (Phoenix Healthcare Distribution Ltd)
+9192011000001104,Piroxicam 20mg capsules (Sandoz Ltd)
+18734411000001103,Piroxicam 20mg capsules (Sigma Pharmaceuticals Plc)
+694111000001101,Piroxicam 20mg capsules (The Boots Company Plc)
+21849011000001101,Piroxicam 20mg capsules (Waymade Healthcare Plc)
+766066003,Piroxicam 20mg conventional release orodispersible tablet
+329882006,Piroxicam 20mg dispersible tablets
+497711000001109,Piroxicam 20mg dispersible tablets (A A H Pharmaceuticals Ltd)
+451911000001107,Piroxicam 20mg dispersible tablets (Alliance Healthcare (Distribution) Ltd)
+13244711000001104,Piroxicam 20mg dispersible tablets (Dowelhurst Ltd)
+878611000001100,Piroxicam 20mg dispersible tablets (Kent Pharmaceuticals Ltd)
+276611000001107,Piroxicam 20mg dispersible tablets (Mylan)
+14716311000001107,Piroxicam 20mg dispersible tablets (Sigma Pharmaceuticals Plc)
+36017011000001102,Piroxicam 20mg orodispersible tablets sugar free
+3439011000001103,Piroxicam betadex 20mg tablets
+440256005,Piroxicam in oral dosage form
+403211000001109,Pirozip 10 capsules (Ashbourne Pharmaceuticals Ltd)
+910811000001103,Pirozip 20 capsules (Ashbourne Pharmaceuticals Ltd)
+226811000001107,Ponstan 250mg capsules (Chemidex Pharma Ltd)
+586711000001103,Ponstan Forte 500mg tablets (Chemidex Pharma Ltd)
+844911000001100,Preservex 100mg tablets (Almirall Ltd)
+37386211000001107,Preservex 100mg tablets (CST Pharma Ltd)
+9859411000001104,Prexige 100mg tablets (Novartis Pharmaceuticals UK Ltd)
+9859911000001107,Prexige 400mg tablets (Novartis Pharmaceuticals UK Ltd)
+413827009,Product containing chlorphenamine and ibuprofen and pseudoephedrine
+9244911000001100,Pure Health Junior Ibuprofen 100mg/5ml oral suspension (Lexon (UK) Ltd)
+424201008,Rectal form indometacin
+240311000001104,Relcofen 400mg tablets (Actavis UK Ltd)
+2843411000001106,Relifex 500mg dispersible tablets (Meda Pharmaceuticals Ltd)
+5621511000001101,Relifex 500mg tablets (Dowelhurst Ltd)
+3023411000001104,Relifex 500mg tablets (Mylan)
+5406211000001101,Relifex 500mg tablets (Waymade Healthcare Plc)
+911611000001107,Rheumacin LA 75mg capsules (Hillcross Pharmaceuticals Ltd)
+715111000001109,Rheumatac Retard 75 tablets (Advanz Pharma)
+128211000001105,Rheumox 300mg capsules (Mercury Pharma Group Ltd)
+241811000001100,Rheumox 600mg tablets (Mercury Pharma Group Ltd)
+324811000001106,Rhumalgan CR 100 tablets (Sandoz Ltd)
+358411000001104,Rhumalgan CR 75 tablets (Sandoz Ltd)
+22468711000001106,Rhumalgan SR 75mg capsules (Actavis UK Ltd)
+18681011000001105,Rhumalgan SR 75mg capsules (Almus Pharmaceuticals Ltd)
+8197611000001106,Rhumalgan SR 75mg capsules (Sandoz Ltd)
+22421611000001104,Rhumalgan XL 100mg capsules (Actavis UK Ltd)
+18680711000001104,Rhumalgan XL 100mg capsules (Almus Pharmaceuticals Ltd)
+8196311000001104,Rhumalgan XL 100mg capsules (Sandoz Ltd)
+330162006,Rofecoxib 12.5mg tablets
+330164007,Rofecoxib 12.5mg/5ml oral suspension sugar free
+330163001,Rofecoxib 25mg tablets
+330165008,Rofecoxib 25mg/5ml oral suspension sugar free
+388930005,Rofecoxib 50mg tablets
+412003000,Rofecoxib in oral dosage form
+35096411000001107,Seractil 300mg tablets (Gebro Pharma GmbH)
+9447211000001103,Seractil 300mg tablets (Thornton & Ross Ltd)
+13939911000001101,Seractil 300mg tablets (Waymade Healthcare Plc)
+9447611000001101,Seractil 400mg tablets (Thornton & Ross Ltd)
+35029011000001101,Skudexa 75mg/25mg tablets (A. Menarini Farmaceutica Internazionale SRL)
+103411000001107,Slo-Indo 75mg capsules (Mylan)
+667011000001107,Slofenac 75mg SR tablets (Sterwin Medicines)
+10194911000001107,Solpadeine Migraine Ibuprofen & Codeine tablets (Omega Pharma Ltd)
+3916211000001109,Solpaflex tablets (GlaxoSmithKline Consumer Healthcare)
+31279811000001102,Stirlescent 250mg effervescent tablets (Stirling Anglian Pharmaceuticals Ltd)
+34874211000001103,Sudafed Sinus Pain Relief 200mg/6.1mg tablets (McNeil Products Ltd)
+8008611000001103,Sudafed Sinus Pressure & Pain tablets (McNeil Products Ltd)
+329887000,Sulindac 100mg tablets
+3671411000001106,Sulindac 100mg tablets (A A H Pharmaceuticals Ltd)
+3674511000001107,Sulindac 100mg tablets (Alliance Healthcare (Distribution) Ltd)
+13583611000001109,Sulindac 100mg tablets (DE Pharmaceuticals)
+17412711000001105,Sulindac 100mg tablets (Essential Generics Ltd)
+3673711000001104,Sulindac 100mg tablets (Kent Pharmaceuticals Ltd)
+3671811000001108,Sulindac 100mg tablets (Mylan)
+375512001,Sulindac 150 mg oral tablet
+329888005,Sulindac 200mg tablets
+3675211000001105,Sulindac 200mg tablets (A A H Pharmaceuticals Ltd)
+3676211000001104,Sulindac 200mg tablets (Alliance Healthcare (Distribution) Ltd)
+13583811000001108,Sulindac 200mg tablets (DE Pharmaceuticals)
+17415011000001103,Sulindac 200mg tablets (Essential Generics Ltd)
+3675811000001106,Sulindac 200mg tablets (Kent Pharmaceuticals Ltd)
+3675511000001108,Sulindac 200mg tablets (Mylan)
+324411000001109,Surgam 200mg tablets (Sanofi)
+308411000001108,Surgam 300mg tablets (Sanofi)
+495411000001109,Surgam SA 300mg capsules (Sanofi)
+56411000001103,Synflex 275mg tablets (Roche Products Ltd)
+329914002,Tenoxicam 20mg tablets
+92511000001106,Tenoxicam 20mg tablets (A A H Pharmaceuticals Ltd)
+602711000001108,Tenoxicam 20mg tablets (Alliance Healthcare (Distribution) Ltd)
+5511811000001103,Tenoxicam 20mg tablets (Dowelhurst Ltd)
+753111000001104,Tenoxicam 20mg tablets (Kent Pharmaceuticals Ltd)
+565511000001103,Tenoxicam 20mg tablets (Sandoz Ltd)
+15229011000001105,Tenoxicam 20mg tablets (Sigma Pharmaceuticals Plc)
+21786211000001109,Tenoxicam 20mg tablets (Waymade Healthcare Plc)
+768202002,Tenoxicam in oral dosage form
+329895001,Tiaprofenic acid 200mg tablets
+765956000,Tiaprofenic acid 300 mg prolonged-release oral capsule
+35918311000001105,Tiaprofenic acid 300mg modified-release capsules
+329896000,Tiaprofenic acid 300mg tablets
+767781009,Tiaprofenic acid in oral dosage form
+7498011000001106,Tiloket 50mg capsules (Tillomed Laboratories Ltd)
+804611000001103,Tiloket CR 100mg capsules (Tillomed Laboratories Ltd)
+29742611000001106,Tiloket CR 200mg capsules (Tillomed Laboratories Ltd)
+322820004,Tolfenamic acid 200mg tablets
+30334411000001102,Tolfenamic acid 200mg tablets (A A H Pharmaceuticals Ltd)
+30802611000001103,Tolfenamic acid 200mg tablets (Alliance Healthcare (Distribution) Ltd)
+37827211000001100,Tolfenamic acid 200mg tablets (DE Pharmaceuticals)
+29988311000001104,Tolfenamic acid 200mg tablets (Galen Ltd)
+768783009,Tolfenamic acid in oral dosage form
+32868711000001103,Tolmetin 600mg tablets
+32868911000001101,Tolmetin 600mg tablets (Imported (United States))
+768781006,Tolmetin in oral dosage form
+370228005,Tolmetin sodium 200 mg oral tablet
+375121005,Tolmetin sodium 400 mg/1 each oral capsule
+374240001,Tolmetin sodium 600 mg oral tablet
+4061811000001108,Toradol 10mg tablets (Roche Products Ltd)
+35029711000001104,Tramadol 75mg / Dexketoprofen 25mg tablets
+385585000,Valdecoxib 10mg tablets
+385586004,Valdecoxib 20mg tablets
+408146004,Valdecoxib 40mg tablets
+412004006,Valdecoxib in oral dosage form
+434411000001103,Valdic 100 Retard tablets (Fannin UK Ltd)
+205911000001100,Valdic 75 Retard tablets (Fannin UK Ltd)
+793611000001101,Valket 200 Retard capsules (Tillomed Laboratories Ltd)
+18233711000001101,Vimovo 500mg/20mg modified-release tablets (AstraZeneca UK Ltd)
+5595311000001105,Vioxx 12.5mg tablets (Dowelhurst Ltd)
+2840811000001101,Vioxx 12.5mg tablets (Merck Sharp & Dohme Ltd)
+5424311000001107,Vioxx 12.5mg tablets (Waymade Healthcare Plc)
+2842711000001108,Vioxx 12.5mg/5ml oral suspension (Merck Sharp & Dohme Ltd)
+5595511000001104,Vioxx 25mg tablets (Dowelhurst Ltd)
+2841311000001100,Vioxx 25mg tablets (Merck Sharp & Dohme Ltd)
+5426311000001101,Vioxx 25mg tablets (Waymade Healthcare Plc)
+2843111000001101,Vioxx 25mg/5ml oral suspension (Merck Sharp & Dohme Ltd)
+2841511000001106,VioxxAcute 25mg tablets (Merck Sharp & Dohme Ltd)
+2842311000001109,VioxxAcute 50mg tablets (Merck Sharp & Dohme Ltd)
+341611000001107,Volraman 25mg gastro-resistant tablets (LPC Medical (UK) Ltd)
+632211000001109,Volsaid Retard 100 tablets (Chiesi Ltd)
+814411000001103,Volsaid Retard 75 tablets (Chiesi Ltd)
+2911000001100,Voltarol 25mg gastro-resistant tablets (Novartis Pharmaceuticals UK Ltd)
+5597111000001104,Voltarol 75mg SR tablets (Dowelhurst Ltd)
+20030411000001108,Voltarol 75mg SR tablets (Lexon (UK) Ltd)
+17476511000001109,Voltarol 75mg SR tablets (Mawdsley-Brooks & Company Ltd)
+763111000001107,Voltarol 75mg SR tablets (Novartis Pharmaceuticals UK Ltd)
+17526411000001101,Voltarol Joint Pain 12.5mg tablets (Novartis Consumer Health UK Ltd)
+14033611000001100,Voltarol Pain-eze 12.5mg tablets (Novartis Consumer Health UK Ltd)
+16446911000001100,Voltarol Rapid 50mg tablets (Lexon (UK) Ltd)
+605911000001102,Voltarol Rapid 50mg tablets (Novartis Pharmaceuticals UK Ltd)
+14760511000001104,Voltarol Rapid 50mg tablets (Sigma Pharmaceuticals Plc)
+5597311000001102,Voltarol Retard 100mg tablets (Dowelhurst Ltd)
+18158711000001105,Voltarol Retard 100mg tablets (Mawdsley-Brooks & Company Ltd)
+804711000001107,Voltarol Retard 100mg tablets (Novartis Pharmaceuticals UK Ltd)
+14761111000001102,Voltarol Retard 100mg tablets (Sigma Pharmaceuticals Plc)
+5425611000001101,Voltarol Retard 100mg tablets (Waymade Healthcare Plc)
+4506111000001109,Xefo 4mg tablets (CeNeS Pharmaceuticals Plc)
+4506711000001105,Xefo 8mg tablets (CeNeS Pharmaceuticals Plc)

--- a/tests/fixtures/acceptance/codelists/pincer-ppi-3cfd43a3.csv
+++ b/tests/fixtures/acceptance/codelists/pincer-ppi-3cfd43a3.csv
@@ -1,0 +1,1198 @@
+id,term
+240811000001108,Acid-Eze 200mg tablets (Manx Healthcare Ltd)
+720411000001102,Acitak 400mg tablets (Opus Pharmaceuticals Ltd)
+764369003,Aspirin and omeprazole in oral dosage form
+763644001,Aspirin and omeprazole product
+181211000001105,Axid 100mg/4ml solution for infusion ampoules (Flynn Pharma Ltd)
+5569011000001107,Axid 150mg capsules (Dowelhurst Ltd)
+176911000001104,Axid 150mg capsules (Flynn Pharma Ltd)
+608111000001105,Axid 300mg capsules (Flynn Pharma Ltd)
+16148311000001101,Axorid 100mg/20mg modified-release capsules (Meda Pharmaceuticals Ltd)
+16140611000001108,Axorid 200mg/20mg modified-release capsules (Meda Pharmaceuticals Ltd)
+31000811000001105,Boots Heartburn Relief 75mg tablets (The Boots Company Plc)
+417913002,Calcium carbonate 800mg/famotidine 10mg/magnesium hydroxide 165mg chewable tablet
+418223003,Calcium carbonate and famotidine and magnesium hydroxide
+353401002,Cimetidine 100mg tablets
+769639000,Cimetidine 200 mg/2 mL solution for injection ampoule
+4651511000001106,Cimetidine 200mg chewable tablets sugar free
+317222006,Cimetidine 200mg tablets
+385511000001103,Cimetidine 200mg tablets (A A H Pharmaceuticals Ltd)
+18459311000001104,Cimetidine 200mg tablets (Accord Healthcare Ltd)
+524711000001101,Cimetidine 200mg tablets (Actavis UK Ltd)
+446911000001104,Cimetidine 200mg tablets (Alliance Healthcare (Distribution) Ltd)
+10392611000001104,Cimetidine 200mg tablets (Arrow Generics Ltd)
+23586811000001103,Cimetidine 200mg tablets (Bristol Laboratories Ltd)
+23819711000001104,Cimetidine 200mg tablets (DE Pharmaceuticals)
+11555111000001101,Cimetidine 200mg tablets (Dexcel-Pharma Ltd)
+13221611000001109,Cimetidine 200mg tablets (Dowelhurst Ltd)
+28780411000001100,Cimetidine 200mg tablets (Ennogen Pharma Ltd)
+33260011000001104,Cimetidine 200mg tablets (Essential Generics Ltd)
+913011000001104,Cimetidine 200mg tablets (IVAX Pharmaceuticals UK Ltd)
+242711000001101,Cimetidine 200mg tablets (Kent Pharmaceuticals Ltd)
+36025511000001109,Cimetidine 200mg tablets (Medreich Plc)
+55011000001103,Cimetidine 200mg tablets (Mylan)
+17857211000001101,Cimetidine 200mg tablets (Phoenix Healthcare Distribution Ltd)
+752611000001102,Cimetidine 200mg tablets (Ranbaxy (UK) Ltd)
+138311000001104,Cimetidine 200mg tablets (Sandoz Ltd)
+29788111000001105,Cimetidine 200mg tablets (Sigma Pharmaceuticals Plc)
+917311000001108,Cimetidine 200mg tablets (Teva UK Ltd)
+13743211000001102,Cimetidine 200mg tablets (Tillomed Laboratories Ltd)
+21843011000001104,Cimetidine 200mg tablets (Waymade Healthcare Plc)
+410865003,Cimetidine 200mg/20mL oral suspension
+36140611000001106,Cimetidine 200mg/2ml solution for injection ampoules
+36140711000001102,Cimetidine 200mg/5ml oral solution
+36140811000001105,Cimetidine 200mg/5ml oral solution sugar free
+5992611000001104,Cimetidine 200mg/5ml oral solution sugar free (A A H Pharmaceuticals Ltd)
+5993911000001103,Cimetidine 200mg/5ml oral solution sugar free (Alliance Healthcare (Distribution) Ltd)
+37166711000001107,Cimetidine 200mg/5ml oral solution sugar free (DE Pharmaceuticals)
+5992911000001105,Cimetidine 200mg/5ml oral solution sugar free (Rosemont Pharmaceuticals Ltd)
+348003002,Cimetidine 200mg/5ml oral suspension sugar free
+369311000001108,Cimetidine 200mg/5ml oral suspension sugar free (Rosemont Pharmaceuticals Ltd)
+30847411000001106,Cimetidine 200mg/5ml oral suspension sugar free (Special Order)
+376795009,Cimetidine 300 mg oral tablet
+766467002,Cimetidine 40 mg/mL oral solution
+317196009,Cimetidine 400mg effervescent tablets sugar free
+317223001,Cimetidine 400mg tablets
+759011000001102,Cimetidine 400mg tablets (A A H Pharmaceuticals Ltd)
+18459511000001105,Cimetidine 400mg tablets (Accord Healthcare Ltd)
+357611000001100,Cimetidine 400mg tablets (Actavis UK Ltd)
+131511000001100,Cimetidine 400mg tablets (Alliance Healthcare (Distribution) Ltd)
+9795511000001107,Cimetidine 400mg tablets (Almus Pharmaceuticals Ltd)
+10392811000001100,Cimetidine 400mg tablets (Arrow Generics Ltd)
+14784111000001101,Cimetidine 400mg tablets (Boston Healthcare Ltd)
+23587011000001107,Cimetidine 400mg tablets (Bristol Laboratories Ltd)
+23820111000001104,Cimetidine 400mg tablets (DE Pharmaceuticals)
+11555411000001106,Cimetidine 400mg tablets (Dexcel-Pharma Ltd)
+13221911000001103,Cimetidine 400mg tablets (Dowelhurst Ltd)
+28780611000001102,Cimetidine 400mg tablets (Ennogen Pharma Ltd)
+33260611000001106,Cimetidine 400mg tablets (Essential Generics Ltd)
+705711000001108,Cimetidine 400mg tablets (IVAX Pharmaceuticals UK Ltd)
+798711000001104,Cimetidine 400mg tablets (Kent Pharmaceuticals Ltd)
+36025711000001104,Cimetidine 400mg tablets (Medreich Plc)
+311511000001104,Cimetidine 400mg tablets (Mylan)
+17857411000001102,Cimetidine 400mg tablets (Phoenix Healthcare Distribution Ltd)
+318211000001106,Cimetidine 400mg tablets (Ranbaxy (UK) Ltd)
+18511000001107,Cimetidine 400mg tablets (Sandoz Ltd)
+91411000001102,Cimetidine 400mg tablets (Teva UK Ltd)
+13743411000001103,Cimetidine 400mg tablets (Tillomed Laboratories Ltd)
+21843311000001101,Cimetidine 400mg tablets (Waymade Healthcare Plc)
+317224007,Cimetidine 800mg tablets
+789511000001104,Cimetidine 800mg tablets (A A H Pharmaceuticals Ltd)
+18459711000001100,Cimetidine 800mg tablets (Accord Healthcare Ltd)
+324111000001104,Cimetidine 800mg tablets (Actavis UK Ltd)
+402211000001103,Cimetidine 800mg tablets (Alliance Healthcare (Distribution) Ltd)
+10393011000001102,Cimetidine 800mg tablets (Arrow Generics Ltd)
+23587211000001102,Cimetidine 800mg tablets (Bristol Laboratories Ltd)
+23820811000001106,Cimetidine 800mg tablets (DE Pharmaceuticals)
+11555611000001109,Cimetidine 800mg tablets (Dexcel-Pharma Ltd)
+13222311000001108,Cimetidine 800mg tablets (Dowelhurst Ltd)
+28780811000001103,Cimetidine 800mg tablets (Ennogen Pharma Ltd)
+354611000001106,Cimetidine 800mg tablets (IVAX Pharmaceuticals UK Ltd)
+810011000001100,Cimetidine 800mg tablets (Kent Pharmaceuticals Ltd)
+30014311000001100,Cimetidine 800mg tablets (Mawdsley-Brooks & Company Ltd)
+36043211000001109,Cimetidine 800mg tablets (Medreich Plc)
+237211000001105,Cimetidine 800mg tablets (Mylan)
+17857611000001104,Cimetidine 800mg tablets (Phoenix Healthcare Distribution Ltd)
+8750611000001107,Cimetidine 800mg tablets (Ranbaxy (UK) Ltd)
+304511000001100,Cimetidine 800mg tablets (Sandoz Ltd)
+29788311000001107,Cimetidine 800mg tablets (Sigma Pharmaceuticals Plc)
+310711000001101,Cimetidine 800mg tablets (Teva UK Ltd)
+13743611000001100,Cimetidine 800mg tablets (Tillomed Laboratories Ltd)
+21843511000001107,Cimetidine 800mg tablets (Waymade Healthcare Plc)
+766617001,Cimetidine hydrochloride 300mg/50mL(0.9%) conventional release solution for infusion 50mL bag
+349797006,Cimetidine in oral dosage form
+349798001,Cimetidine in parenteral dosage form
+349799009,Cimetidine+alginate
+4643911000001101,Dyspamet 200mg chewable tablets (GlaxoSmithKline UK Ltd)
+899311000001107,Dyspamet 200mg/5ml oral suspension (Mercury Pharma Group Ltd)
+17603611000001106,Emozul 20mg gastro-resistant capsules (Consilient Health Ltd)
+17603311000001101,Emozul 40mg gastro-resistant capsules (Consilient Health Ltd)
+16132311000001103,Esomeprazole 10mg gastro-resistant granules sachets
+423220004,Esomeprazole 20mg delayed release oral suspension
+17631311000001107,Esomeprazole 20mg gastro-resistant capsules
+19669111000001105,Esomeprazole 20mg gastro-resistant capsules (A A H Pharmaceuticals Ltd)
+24529111000001106,Esomeprazole 20mg gastro-resistant capsules (Actavis UK Ltd)
+21347511000001100,Esomeprazole 20mg gastro-resistant capsules (Alliance Healthcare (Distribution) Ltd)
+33694511000001103,Esomeprazole 20mg gastro-resistant capsules (Aristo Pharma Ltd)
+29868911000001108,Esomeprazole 20mg gastro-resistant capsules (Creo Pharma Ltd)
+23974711000001101,Esomeprazole 20mg gastro-resistant capsules (DE Pharmaceuticals)
+30126411000001101,Esomeprazole 20mg gastro-resistant capsules (Mawdsley-Brooks & Company Ltd)
+19468611000001109,Esomeprazole 20mg gastro-resistant capsules (Mylan)
+29857511000001105,Esomeprazole 20mg gastro-resistant capsules (Sigma Pharmaceuticals Plc)
+21976411000001108,Esomeprazole 20mg gastro-resistant capsules (Waymade Healthcare Plc)
+317335000,Esomeprazole 20mg gastro-resistant tablets
+19675711000001104,Esomeprazole 20mg gastro-resistant tablets (A A H Pharmaceuticals Ltd)
+20947311000001106,Esomeprazole 20mg gastro-resistant tablets (Actavis UK Ltd)
+21733711000001100,Esomeprazole 20mg gastro-resistant tablets (Alliance Healthcare (Distribution) Ltd)
+30762311000001105,Esomeprazole 20mg gastro-resistant tablets (Almus Pharmaceuticals Ltd)
+36378411000001100,Esomeprazole 20mg gastro-resistant tablets (Cipla EU Ltd)
+37121611000001104,Esomeprazole 20mg gastro-resistant tablets (Crescent Pharma Ltd)
+23975411000001108,Esomeprazole 20mg gastro-resistant tablets (DE Pharmaceuticals)
+32412011000001109,Esomeprazole 20mg gastro-resistant tablets (Kent Pharmaceuticals Ltd)
+30126611000001103,Esomeprazole 20mg gastro-resistant tablets (Mawdsley-Brooks & Company Ltd)
+37210911000001107,Esomeprazole 20mg gastro-resistant tablets (NorthStar Healthcare Unlimited Company)
+23914611000001100,Esomeprazole 20mg gastro-resistant tablets (Phoenix Healthcare Distribution Ltd)
+20101411000001102,Esomeprazole 20mg gastro-resistant tablets (Ranbaxy (UK) Ltd)
+24662211000001107,Esomeprazole 20mg gastro-resistant tablets (Sandoz Ltd)
+29857911000001103,Esomeprazole 20mg gastro-resistant tablets (Sigma Pharmaceuticals Plc)
+19629111000001102,Esomeprazole 20mg gastro-resistant tablets (Teva UK Ltd)
+36855211000001106,Esomeprazole 20mg gastro-resistant tablets (Torrent Pharma (UK) Ltd)
+21977111000001100,Esomeprazole 20mg gastro-resistant tablets (Waymade Healthcare Plc)
+22809711000001107,Esomeprazole 20mg gastro-resistant tablets (Zentiva)
+416354005,Esomeprazole 20mg powder for injection solution vial
+425350008,Esomeprazole 40mg delayed release oral suspension
+17631411000001100,Esomeprazole 40mg gastro-resistant capsules
+19669311000001107,Esomeprazole 40mg gastro-resistant capsules (A A H Pharmaceuticals Ltd)
+24529311000001108,Esomeprazole 40mg gastro-resistant capsules (Actavis UK Ltd)
+21347711000001105,Esomeprazole 40mg gastro-resistant capsules (Alliance Healthcare (Distribution) Ltd)
+33694311000001109,Esomeprazole 40mg gastro-resistant capsules (Aristo Pharma Ltd)
+29869111000001103,Esomeprazole 40mg gastro-resistant capsules (Creo Pharma Ltd)
+23975011000001104,Esomeprazole 40mg gastro-resistant capsules (DE Pharmaceuticals)
+19468411000001106,Esomeprazole 40mg gastro-resistant capsules (Mylan)
+29858311000001103,Esomeprazole 40mg gastro-resistant capsules (Sigma Pharmaceuticals Plc)
+21976711000001102,Esomeprazole 40mg gastro-resistant capsules (Waymade Healthcare Plc)
+317334001,Esomeprazole 40mg gastro-resistant tablets
+19675911000001102,Esomeprazole 40mg gastro-resistant tablets (A A H Pharmaceuticals Ltd)
+20947511000001100,Esomeprazole 40mg gastro-resistant tablets (Actavis UK Ltd)
+21734011000001100,Esomeprazole 40mg gastro-resistant tablets (Alliance Healthcare (Distribution) Ltd)
+30762511000001104,Esomeprazole 40mg gastro-resistant tablets (Almus Pharmaceuticals Ltd)
+36379611000001106,Esomeprazole 40mg gastro-resistant tablets (Cipla EU Ltd)
+23975711000001102,Esomeprazole 40mg gastro-resistant tablets (DE Pharmaceuticals)
+32412211000001104,Esomeprazole 40mg gastro-resistant tablets (Kent Pharmaceuticals Ltd)
+37064211000001100,Esomeprazole 40mg gastro-resistant tablets (Mawdsley-Brooks & Company Ltd)
+37211111000001103,Esomeprazole 40mg gastro-resistant tablets (NorthStar Healthcare Unlimited Company)
+23914811000001101,Esomeprazole 40mg gastro-resistant tablets (Phoenix Healthcare Distribution Ltd)
+20101811000001100,Esomeprazole 40mg gastro-resistant tablets (Ranbaxy (UK) Ltd)
+24662911000001103,Esomeprazole 40mg gastro-resistant tablets (Sandoz Ltd)
+29858111000001100,Esomeprazole 40mg gastro-resistant tablets (Sigma Pharmaceuticals Plc)
+19630711000001106,Esomeprazole 40mg gastro-resistant tablets (Teva UK Ltd)
+36855411000001105,Esomeprazole 40mg gastro-resistant tablets (Torrent Pharma (UK) Ltd)
+21977311000001103,Esomeprazole 40mg gastro-resistant tablets (Waymade Healthcare Plc)
+22808511000001108,Esomeprazole 40mg gastro-resistant tablets (Zentiva)
+7322511000001101,Esomeprazole 40mg powder for solution for injection vials
+20372111000001102,Esomeprazole 40mg powder for solution for injection vials (A A H Pharmaceuticals Ltd)
+34752611000001109,Esomeprazole 40mg powder for solution for injection vials (Bowmed Ibisqus Ltd)
+20552311000001104,Esomeprazole 40mg powder for solution for injection vials (Sun Pharmaceutical Industries Europe B.V.)
+16074011000001103,Esomeprazole 40mg/5ml oral suspension
+16041511000001105,Esomeprazole 40mg/5ml oral suspension (Special Order)
+768562000,Esomeprazole and naproxen in oral dosage form
+768561007,Esomeprazole and naproxen product
+768221005,Esomeprazole in oral dosage form
+768543003,Esomeprazole in parenteral dosage form
+377036007,Esomeprazole magnesium 20 mg/1 each oral capsule
+765891007,Esomeprazole magnesium 20mg gastro-resistant oral capsule
+377037003,Esomeprazole magnesium 40 mg/1 each oral capsule
+765918001,Esomeprazole magnesium 40mg gastro-resistant oral capsule
+410883006,Famotidine 10mg chewable tablet
+353399008,Famotidine 10mg tablets
+414231001,Famotidine 20mg orally disintegrating tablet
+317275005,Famotidine 20mg tablets
+528211000001102,Famotidine 20mg tablets (A A H Pharmaceuticals Ltd)
+195511000001107,Famotidine 20mg tablets (Alliance Healthcare (Distribution) Ltd)
+10406711000001102,Famotidine 20mg tablets (Arrow Generics Ltd)
+37379311000001102,Famotidine 20mg tablets (DE Pharmaceuticals)
+285211000001105,Famotidine 20mg tablets (IVAX Pharmaceuticals UK Ltd)
+730011000001109,Famotidine 20mg tablets (Kent Pharmaceuticals Ltd)
+428411000001105,Famotidine 20mg tablets (Mylan)
+10444211000001108,Famotidine 20mg tablets (Niche Generics Ltd)
+17905111000001101,Famotidine 20mg tablets (Phoenix Healthcare Distribution Ltd)
+697611000001103,Famotidine 20mg tablets (Sandoz Ltd)
+15083811000001103,Famotidine 20mg tablets (Sigma Pharmaceuticals Plc)
+80811000001109,Famotidine 20mg tablets (Teva UK Ltd)
+13750711000001103,Famotidine 20mg tablets (Tillomed Laboratories Ltd)
+21979011000001105,Famotidine 20mg tablets (Waymade Healthcare Plc)
+414232008,Famotidine 40mg orally disintegrating tablet
+317276006,Famotidine 40mg tablets
+736411000001103,Famotidine 40mg tablets (A A H Pharmaceuticals Ltd)
+253611000001103,Famotidine 40mg tablets (Alliance Healthcare (Distribution) Ltd)
+10407011000001101,Famotidine 40mg tablets (Arrow Generics Ltd)
+37379611000001107,Famotidine 40mg tablets (DE Pharmaceuticals)
+316711000001103,Famotidine 40mg tablets (IVAX Pharmaceuticals UK Ltd)
+21311000001103,Famotidine 40mg tablets (Kent Pharmaceuticals Ltd)
+478911000001101,Famotidine 40mg tablets (Mylan)
+10444411000001107,Famotidine 40mg tablets (Niche Generics Ltd)
+17905311000001104,Famotidine 40mg tablets (Phoenix Healthcare Distribution Ltd)
+354311000001101,Famotidine 40mg tablets (Sandoz Ltd)
+15084011000001106,Famotidine 40mg tablets (Sigma Pharmaceuticals Plc)
+485411000001108,Famotidine 40mg tablets (Teva UK Ltd)
+13751011000001109,Famotidine 40mg tablets (Tillomed Laboratories Ltd)
+21979211000001100,Famotidine 40mg tablets (Waymade Healthcare Plc)
+376960003,Famotidine 40mg/5mL suspension
+423206006,Famotidine in oral dosage form
+422402000,Famotidine in parenteral dosage form
+641411000001104,Galenamet 400mg tablets (Galen Ltd)
+5340811000001102,Gavilast 75mg tablets (Reckitt Benckiser Healthcare (UK) Ltd)
+35010711000001103,Gavilast Heartburn and Indigestion 75mg tablets (Reckitt Benckiser Healthcare (UK) Ltd)
+5341111000001103,Gavilast-P 75mg tablets (Reckitt Benckiser Healthcare (UK) Ltd)
+36062111000001102,Generic HeliClear
+3948411000001101,Generic HeliMet
+4349811000001102,Generic Pepcidtwo chewable tablets
+37556211000001102,Guardium acid reflux control 20mg gastro-resistant tablets (Reckitt Benckiser Healthcare (UK) Ltd)
+888511000001108,HeliClear (Wyeth Pharmaceuticals)
+3944411000001105,HeliMet (Wyeth Pharmaceuticals)
+181911000001101,Histac 150mg tablets (Ranbaxy (UK) Ltd)
+682911000001106,Histac 300mg tablets (Ranbaxy (UK) Ltd)
+16174311000001107,Ketoprofen 100mg / Omeprazole 20mg modified-release capsules
+16174411000001100,Ketoprofen 200mg / Omeprazole 20mg modified-release capsules
+409145007,Lansoprazole + naproxen
+14742811000001107,Lansoprazole 10mg oral powder sachets
+14707311000001107,Lansoprazole 10mg oral powder sachets (Special Order)
+15533711000001104,Lansoprazole 10mg/5ml oral solution
+15525711000001100,Lansoprazole 10mg/5ml oral solution (Special Order)
+15533811000001107,Lansoprazole 10mg/5ml oral suspension
+15526011000001106,Lansoprazole 10mg/5ml oral suspension (Special Order)
+16036411000001101,Lansoprazole 11mg/5ml oral solution
+16023711000001102,Lansoprazole 11mg/5ml oral solution (Special Order)
+16036511000001102,Lansoprazole 11mg/5ml oral suspension
+16025711000001101,Lansoprazole 11mg/5ml oral suspension (Special Order)
+317310006,Lansoprazole 15mg gastro-resistant capsules
+10131611000001105,Lansoprazole 15mg gastro-resistant capsules (A A H Pharmaceuticals Ltd)
+9908111000001104,Lansoprazole 15mg gastro-resistant capsules (Actavis UK Ltd)
+9905311000001106,Lansoprazole 15mg gastro-resistant capsules (Alliance Healthcare (Distribution) Ltd)
+17973711000001108,Lansoprazole 15mg gastro-resistant capsules (Almus Pharmaceuticals Ltd)
+10436111000001105,Lansoprazole 15mg gastro-resistant capsules (Arrow Generics Ltd)
+24389311000001101,Lansoprazole 15mg gastro-resistant capsules (Bristol Laboratories Ltd)
+10288611000001105,Lansoprazole 15mg gastro-resistant capsules (Consilient Health Ltd)
+24355211000001102,Lansoprazole 15mg gastro-resistant capsules (DE Pharmaceuticals)
+5490911000001109,Lansoprazole 15mg gastro-resistant capsules (Dowelhurst Ltd)
+11016911000001101,Lansoprazole 15mg gastro-resistant capsules (Dr Reddy's Laboratories (UK) Ltd)
+10303011000001100,Lansoprazole 15mg gastro-resistant capsules (Focus Pharmaceuticals Ltd)
+9889511000001106,Lansoprazole 15mg gastro-resistant capsules (IVAX Pharmaceuticals UK Ltd)
+9480611000001105,Lansoprazole 15mg gastro-resistant capsules (Kent Pharmaceuticals Ltd)
+37096411000001106,Lansoprazole 15mg gastro-resistant capsules (Mawdsley-Brooks & Company Ltd)
+35246211000001105,Lansoprazole 15mg gastro-resistant capsules (Milpharm Ltd)
+9990711000001103,Lansoprazole 15mg gastro-resistant capsules (Mylan)
+10438911000001107,Lansoprazole 15mg gastro-resistant capsules (Niche Generics Ltd)
+37567311000001101,Lansoprazole 15mg gastro-resistant capsules (NorthStar Healthcare Unlimited Company)
+17934911000001105,Lansoprazole 15mg gastro-resistant capsules (Phoenix Healthcare Distribution Ltd)
+5380911000001100,Lansoprazole 15mg gastro-resistant capsules (PI) (Waymade Healthcare Plc)
+9846611000001106,Lansoprazole 15mg gastro-resistant capsules (PLIVA Pharma Ltd)
+10566811000001103,Lansoprazole 15mg gastro-resistant capsules (Ranbaxy (UK) Ltd)
+9904811000001103,Lansoprazole 15mg gastro-resistant capsules (Sandoz Ltd)
+15106311000001107,Lansoprazole 15mg gastro-resistant capsules (Sigma Pharmaceuticals Plc)
+17203211000001107,Lansoprazole 15mg gastro-resistant capsules (Sovereign Medical Ltd)
+9889911000001104,Lansoprazole 15mg gastro-resistant capsules (Teva UK Ltd)
+22060911000001103,Lansoprazole 15mg gastro-resistant capsules (Waymade Healthcare Plc)
+9869511000001109,Lansoprazole 15mg gastro-resistant capsules (Zentiva)
+765982009,Lansoprazole 15mg gastro-resistant oral capsule
+407859008,Lansoprazole 15mg gastro-resistant tablet
+34665111000001107,Lansoprazole 15mg oral powder sachets
+34651511000001108,Lansoprazole 15mg oral powder sachets (Special Order)
+4053411000001103,Lansoprazole 15mg orodispersible tablets
+22680211000001102,Lansoprazole 15mg orodispersible tablets (A A H Pharmaceuticals Ltd)
+22672811000001106,Lansoprazole 15mg orodispersible tablets (Alliance Healthcare (Distribution) Ltd)
+30060811000001100,Lansoprazole 15mg orodispersible tablets (DE Pharmaceuticals)
+27957311000001103,Lansoprazole 15mg orodispersible tablets (Lupin Healthcare (UK) Ltd)
+30218411000001108,Lansoprazole 15mg orodispersible tablets (Mawdsley-Brooks & Company Ltd)
+33591711000001100,Lansoprazole 15mg orodispersible tablets (Mylan)
+23166511000001107,Lansoprazole 15mg orodispersible tablets (Ranbaxy (UK) Ltd)
+29883611000001106,Lansoprazole 15mg orodispersible tablets (Sigma Pharmaceuticals Plc)
+22428411000001109,Lansoprazole 15mg orodispersible tablets (Teva UK Ltd)
+15536711000001106,Lansoprazole 15mg/5ml oral solution
+15536411000001100,Lansoprazole 15mg/5ml oral solution (Special Order)
+15632711000001100,Lansoprazole 15mg/5ml oral suspension
+15619411000001109,Lansoprazole 15mg/5ml oral suspension (Drug Tariff Special Order)
+15533911000001102,Lansoprazole 20mg/5ml oral solution
+15528511000001102,Lansoprazole 20mg/5ml oral solution (Special Order)
+15534011000001104,Lansoprazole 20mg/5ml oral suspension
+15528811000001104,Lansoprazole 20mg/5ml oral suspension (Special Order)
+32877811000001103,Lansoprazole 22.5mg/5ml oral suspension
+32875011000001102,Lansoprazole 22.5mg/5ml oral suspension (Special Order)
+16109711000001104,Lansoprazole 22mg/5ml oral solution
+16107011000001105,Lansoprazole 22mg/5ml oral solution (Special Order)
+16109811000001107,Lansoprazole 22mg/5ml oral suspension
+16107311000001108,Lansoprazole 22mg/5ml oral suspension (Special Order)
+36904011000001103,Lansoprazole 3.75mg/5ml oral solution
+36878011000001106,Lansoprazole 3.75mg/5ml oral solution (Special Order)
+766689007,Lansoprazole 30 mg granules for gastro-resistant oral suspension sachet
+317309001,Lansoprazole 30mg gastro-resistant capsules
+10131811000001109,Lansoprazole 30mg gastro-resistant capsules (A A H Pharmaceuticals Ltd)
+9908311000001102,Lansoprazole 30mg gastro-resistant capsules (Actavis UK Ltd)
+9905511000001100,Lansoprazole 30mg gastro-resistant capsules (Alliance Healthcare (Distribution) Ltd)
+17973511000001103,Lansoprazole 30mg gastro-resistant capsules (Almus Pharmaceuticals Ltd)
+10436311000001107,Lansoprazole 30mg gastro-resistant capsules (Arrow Generics Ltd)
+24389511000001107,Lansoprazole 30mg gastro-resistant capsules (Bristol Laboratories Ltd)
+10289311000001106,Lansoprazole 30mg gastro-resistant capsules (Consilient Health Ltd)
+24355411000001103,Lansoprazole 30mg gastro-resistant capsules (DE Pharmaceuticals)
+5491511000001109,Lansoprazole 30mg gastro-resistant capsules (Dowelhurst Ltd)
+11016711000001103,Lansoprazole 30mg gastro-resistant capsules (Dr Reddy's Laboratories (UK) Ltd)
+10302811000001103,Lansoprazole 30mg gastro-resistant capsules (Focus Pharmaceuticals Ltd)
+9889711000001101,Lansoprazole 30mg gastro-resistant capsules (IVAX Pharmaceuticals UK Ltd)
+9480911000001104,Lansoprazole 30mg gastro-resistant capsules (Kent Pharmaceuticals Ltd)
+37097611000001106,Lansoprazole 30mg gastro-resistant capsules (Mawdsley-Brooks & Company Ltd)
+35246411000001109,Lansoprazole 30mg gastro-resistant capsules (Milpharm Ltd)
+9991011000001109,Lansoprazole 30mg gastro-resistant capsules (Mylan)
+10439411000001107,Lansoprazole 30mg gastro-resistant capsules (Niche Generics Ltd)
+37568011000001103,Lansoprazole 30mg gastro-resistant capsules (NorthStar Healthcare Unlimited Company)
+17935111000001106,Lansoprazole 30mg gastro-resistant capsules (Phoenix Healthcare Distribution Ltd)
+9846411000001108,Lansoprazole 30mg gastro-resistant capsules (PLIVA Pharma Ltd)
+10567011000001107,Lansoprazole 30mg gastro-resistant capsules (Ranbaxy (UK) Ltd)
+9905011000001108,Lansoprazole 30mg gastro-resistant capsules (Sandoz Ltd)
+15106711000001106,Lansoprazole 30mg gastro-resistant capsules (Sigma Pharmaceuticals Plc)
+17203411000001106,Lansoprazole 30mg gastro-resistant capsules (Sovereign Medical Ltd)
+9890111000001108,Lansoprazole 30mg gastro-resistant capsules (Teva UK Ltd)
+22061311000001109,Lansoprazole 30mg gastro-resistant capsules (Waymade Healthcare Plc)
+9869711000001104,Lansoprazole 30mg gastro-resistant capsules (Zentiva)
+36037911000001105,Lansoprazole 30mg gastro-resistant granules sachets
+766006001,Lansoprazole 30mg gastro-resistant oral capsule
+407860003,Lansoprazole 30mg gastro-resistant tablet
+4053511000001104,Lansoprazole 30mg orodispersible tablets
+22680411000001103,Lansoprazole 30mg orodispersible tablets (A A H Pharmaceuticals Ltd)
+22673011000001109,Lansoprazole 30mg orodispersible tablets (Alliance Healthcare (Distribution) Ltd)
+23260911000001101,Lansoprazole 30mg orodispersible tablets (AM Distributions (Yorkshire) Ltd)
+22834311000001101,Lansoprazole 30mg orodispersible tablets (Colorama Pharmaceuticals Ltd)
+22649211000001101,Lansoprazole 30mg orodispersible tablets (DE Pharmaceuticals)
+23218111000001103,Lansoprazole 30mg orodispersible tablets (J M McGill Ltd)
+27957511000001109,Lansoprazole 30mg orodispersible tablets (Lupin Healthcare (UK) Ltd)
+37097811000001105,Lansoprazole 30mg orodispersible tablets (Mawdsley-Brooks & Company Ltd)
+33591911000001103,Lansoprazole 30mg orodispersible tablets (Mylan)
+23166711000001102,Lansoprazole 30mg orodispersible tablets (Ranbaxy (UK) Ltd)
+29883811000001105,Lansoprazole 30mg orodispersible tablets (Sigma Pharmaceuticals Plc)
+22428611000001107,Lansoprazole 30mg orodispersible tablets (Teva UK Ltd)
+425579002,Lansoprazole 30mg powder for injection solution vial
+14014211000001107,Lansoprazole 30mg/5ml oral solution
+13984311000001108,Lansoprazole 30mg/5ml oral solution (Special Order)
+14014311000001104,Lansoprazole 30mg/5ml oral suspension
+13985011000001109,Lansoprazole 30mg/5ml oral suspension (Drug Tariff Special Order)
+15648811000001106,Lansoprazole 3mg/5ml oral solution
+15635611000001100,Lansoprazole 3mg/5ml oral solution (Special Order)
+15632811000001108,Lansoprazole 3mg/5ml oral suspension
+15619711000001103,Lansoprazole 3mg/5ml oral suspension (Special Order)
+15535411000001109,Lansoprazole 40mg/5ml oral solution
+15532011000001105,Lansoprazole 40mg/5ml oral solution (Special Order)
+15535511000001108,Lansoprazole 40mg/5ml oral suspension
+15532811000001104,Lansoprazole 40mg/5ml oral suspension (Special Order)
+15648911000001101,Lansoprazole 4mg/5ml oral solution
+15635911000001106,Lansoprazole 4mg/5ml oral solution (Special Order)
+15649011000001105,Lansoprazole 4mg/5ml oral suspension
+15636211000001108,Lansoprazole 4mg/5ml oral suspension (Special Order)
+29669711000001105,Lansoprazole 50mg/5ml oral suspension
+29578511000001106,Lansoprazole 50mg/5ml oral suspension (Special Order)
+13821811000001104,Lansoprazole 5mg/5ml oral solution
+13821111000001106,Lansoprazole 5mg/5ml oral solution (Special Order)
+13821911000001109,Lansoprazole 5mg/5ml oral suspension
+13820811000001107,Lansoprazole 5mg/5ml oral suspension (Drug Tariff Special Order)
+15649111000001106,Lansoprazole 60mg/5ml oral solution
+15636811000001109,Lansoprazole 60mg/5ml oral solution (Special Order)
+15649211000001100,Lansoprazole 60mg/5ml oral suspension
+15636511000001106,Lansoprazole 60mg/5ml oral suspension (Special Order)
+14796611000001101,Lansoprazole 7.5mg/5ml oral solution
+14782211000001103,Lansoprazole 7.5mg/5ml oral solution (Special Order)
+14796711000001105,Lansoprazole 7.5mg/5ml oral suspension
+14782511000001100,Lansoprazole 7.5mg/5ml oral suspension (Special Order)
+35611111000001101,Lansoprazole 8mg/5ml oral suspension
+35603211000001108,Lansoprazole 8mg/5ml oral suspension (Special Order)
+437961004,Lansoprazole in oral dosage form
+437976007,Lansoprazole in parenteral dosage form
+19279011000001101,Lloydspharmacy Heartburn & Indigestion Relief tablets (Lloyds Pharmacy Ltd)
+7939211000001103,Lloydspharmacy Indigestion Relief 75mg tablets (Lloyds Pharmacy Ltd)
+7940111000001100,Lloydspharmacy Ranitidine Indigestion Relief and Prevention 75mg tablets (Lloyds Pharmacy Ltd)
+64411000001103,Losec 10mg gastro-resistant capsules (AstraZeneca UK Ltd)
+13926011000001108,Losec 10mg gastro-resistant capsules (DE Pharmaceuticals)
+5617411000001101,Losec 10mg gastro-resistant capsules (Dowelhurst Ltd)
+19967111000001100,Losec 10mg gastro-resistant capsules (Lexon (UK) Ltd)
+16512211000001108,Losec 10mg gastro-resistant capsules (Mawdsley-Brooks & Company Ltd)
+18494311000001108,Losec 10mg gastro-resistant capsules (Necessity Supplies Ltd)
+14332711000001102,Losec 10mg gastro-resistant capsules (Sigma Pharmaceuticals Plc)
+5385211000001100,Losec 10mg gastro-resistant capsules (Waymade Healthcare Plc)
+923011000001105,Losec 20mg gastro-resistant capsules (AstraZeneca UK Ltd)
+13926311000001106,Losec 20mg gastro-resistant capsules (DE Pharmaceuticals)
+5557111000001105,Losec 20mg gastro-resistant capsules (Dowelhurst Ltd)
+19967311000001103,Losec 20mg gastro-resistant capsules (Lexon (UK) Ltd)
+16513311000001105,Losec 20mg gastro-resistant capsules (Mawdsley-Brooks & Company Ltd)
+18494511000001102,Losec 20mg gastro-resistant capsules (Necessity Supplies Ltd)
+37673411000001101,Losec 20mg gastro-resistant capsules (Pilsco Ltd)
+14335611000001102,Losec 20mg gastro-resistant capsules (Sigma Pharmaceuticals Plc)
+5385411000001101,Losec 20mg gastro-resistant capsules (Waymade Healthcare Plc)
+935511000001100,Losec 40mg gastro-resistant capsules (AstraZeneca UK Ltd)
+9832811000001108,Losec I.V. 40mg powder and solvent for solution for injection vials (AstraZeneca UK Ltd)
+4370611000001108,Losec Infusion 40mg powder for solution for infusion vials (AstraZeneca UK Ltd)
+749811000001106,Losec MUPS 10mg gastro-resistant tablets (AstraZeneca UK Ltd)
+13926511000001100,Losec MUPS 10mg gastro-resistant tablets (DE Pharmaceuticals)
+13175311000001100,Losec MUPS 10mg gastro-resistant tablets (Dowelhurst Ltd)
+19967511000001109,Losec MUPS 10mg gastro-resistant tablets (Lexon (UK) Ltd)
+17514811000001104,Losec MUPS 10mg gastro-resistant tablets (Mawdsley-Brooks & Company Ltd)
+18494711000001107,Losec MUPS 10mg gastro-resistant tablets (Necessity Supplies Ltd)
+14336711000001103,Losec MUPS 10mg gastro-resistant tablets (Sigma Pharmaceuticals Plc)
+10544411000001102,Losec MUPS 10mg gastro-resistant tablets (Waymade Healthcare Plc)
+427311000001104,Losec MUPS 20mg gastro-resistant tablets (AstraZeneca UK Ltd)
+13926711000001105,Losec MUPS 20mg gastro-resistant tablets (DE Pharmaceuticals)
+13175511000001106,Losec MUPS 20mg gastro-resistant tablets (Dowelhurst Ltd)
+19967711000001104,Losec MUPS 20mg gastro-resistant tablets (Lexon (UK) Ltd)
+17515011000001109,Losec MUPS 20mg gastro-resistant tablets (Mawdsley-Brooks & Company Ltd)
+18494911000001109,Losec MUPS 20mg gastro-resistant tablets (Necessity Supplies Ltd)
+14366011000001109,Losec MUPS 20mg gastro-resistant tablets (Sigma Pharmaceuticals Plc)
+10835311000001108,Losec MUPS 20mg gastro-resistant tablets (Waymade Healthcare Plc)
+691311000001102,Losec MUPS 40mg gastro-resistant tablets (AstraZeneca UK Ltd)
+38147011000001108,Losec MUPS 40mg gastro-resistant tablets (DE Pharmaceuticals)
+19968011000001100,Losec MUPS 40mg gastro-resistant tablets (Lexon (UK) Ltd)
+17515311000001107,Losec MUPS 40mg gastro-resistant tablets (Mawdsley-Brooks & Company Ltd)
+17571811000001105,Losec MUPS 40mg gastro-resistant tablets (Necessity Supplies Ltd)
+14367211000001102,Losec MUPS 40mg gastro-resistant tablets (Sigma Pharmaceuticals Plc)
+11385311000001108,Losec MUPS 40mg gastro-resistant tablets (Waymade Healthcare Plc)
+422009002,Magnesium hydroxide and omeprazole and sodium bicarbonate
+10820511000001105,Mepradec 10mg gastro-resistant capsules (Discovery Pharmaceuticals)
+10820111000001101,Mepradec 20mg gastro-resistant capsules (Discovery Pharmaceuticals)
+18503211000001105,Mezzopram 10mg dispersible gastro-resistant tablets (Sandoz Ltd)
+18503311000001102,Mezzopram 20mg dispersible gastro-resistant tablets (Sandoz Ltd)
+18503411000001109,Mezzopram 40mg dispersible gastro-resistant tablets (Sandoz Ltd)
+18245811000001107,Naproxen 500mg / Esomeprazole 20mg modified-release tablets
+16116611000001103,Nexium 10mg gastro-resistant granules sachets (AstraZeneca UK Ltd)
+36818211000001107,Nexium 10mg gastro-resistant granules sachets (Originalis B.V.)
+22380011000001104,Nexium 20mg gastro-resistant tablets (Arrow Generics Ltd)
+154111000001106,Nexium 20mg gastro-resistant tablets (AstraZeneca UK Ltd)
+37416111000001106,Nexium 20mg gastro-resistant tablets (CST Pharma Ltd)
+13936611000001104,Nexium 20mg gastro-resistant tablets (DE Pharmaceuticals)
+13178711000001108,Nexium 20mg gastro-resistant tablets (Dowelhurst Ltd)
+16563111000001107,Nexium 20mg gastro-resistant tablets (Mawdsley-Brooks & Company Ltd)
+17598611000001109,Nexium 20mg gastro-resistant tablets (Necessity Supplies Ltd)
+14369211000001108,Nexium 20mg gastro-resistant tablets (Sigma Pharmaceuticals Plc)
+10835511000001102,Nexium 20mg gastro-resistant tablets (Waymade Healthcare Plc)
+22380211000001109,Nexium 40mg gastro-resistant tablets (Arrow Generics Ltd)
+240211000001107,Nexium 40mg gastro-resistant tablets (AstraZeneca UK Ltd)
+13936811000001100,Nexium 40mg gastro-resistant tablets (DE Pharmaceuticals)
+13179211000001106,Nexium 40mg gastro-resistant tablets (Dowelhurst Ltd)
+16563411000001102,Nexium 40mg gastro-resistant tablets (Mawdsley-Brooks & Company Ltd)
+17599811000001101,Nexium 40mg gastro-resistant tablets (Necessity Supplies Ltd)
+14370311000001102,Nexium 40mg gastro-resistant tablets (Sigma Pharmaceuticals Plc)
+10542411000001109,Nexium 40mg gastro-resistant tablets (Waymade Healthcare Plc)
+35585411000001101,Nexium Control 20mg gastro-resistant capsules (Pfizer Consumer Healthcare Ltd)
+28939811000001109,Nexium Control 20mg gastro-resistant tablets (Pfizer Consumer Healthcare Ltd)
+7320811000001104,Nexium I.V 40mg powder for solution for injection vials (AstraZeneca UK Ltd)
+769936009,Nizatidine 100 mg/4 mL solution for injection ampoule
+36032111000001105,Nizatidine 100mg/4ml solution for infusion ampoules
+317280001,Nizatidine 150mg capsules
+720111000001107,Nizatidine 150mg capsules (A A H Pharmaceuticals Ltd)
+144211000001102,Nizatidine 150mg capsules (Actavis UK Ltd)
+705011000001106,Nizatidine 150mg capsules (Alliance Healthcare (Distribution) Ltd)
+9799511000001105,Nizatidine 150mg capsules (Almus Pharmaceuticals Ltd)
+10399611000001106,Nizatidine 150mg capsules (Arrow Generics Ltd)
+37461411000001108,Nizatidine 150mg capsules (DE Pharmaceuticals)
+5498011000001107,Nizatidine 150mg capsules (Dowelhurst Ltd)
+11015311000001107,Nizatidine 150mg capsules (Dr Reddy's Laboratories (UK) Ltd)
+19305311000001102,Nizatidine 150mg capsules (Flynn Pharma Ltd)
+626711000001101,Nizatidine 150mg capsules (IVAX Pharmaceuticals UK Ltd)
+124311000001107,Nizatidine 150mg capsules (Kent Pharmaceuticals Ltd)
+30851711000001107,Nizatidine 150mg capsules (Mawdsley-Brooks & Company Ltd)
+21409511000001107,Nizatidine 150mg capsules (Medreich Plc)
+171611000001103,Nizatidine 150mg capsules (Mylan)
+10440811000001104,Nizatidine 150mg capsules (Niche Generics Ltd)
+17947111000001103,Nizatidine 150mg capsules (Phoenix Healthcare Distribution Ltd)
+4474511000001108,Nizatidine 150mg capsules (Sandoz Ltd)
+15111711000001103,Nizatidine 150mg capsules (Sigma Pharmaceuticals Plc)
+4117111000001101,Nizatidine 150mg capsules (Teva UK Ltd)
+10542611000001107,Nizatidine 150mg capsules (Waymade Healthcare Plc)
+21815511000001101,Nizatidine 150mg capsules (Waymade Healthcare Plc)
+12937511000001109,Nizatidine 150mg/5ml oral solution
+12923811000001104,Nizatidine 150mg/5ml oral solution (Special Order)
+12937611000001108,Nizatidine 150mg/5ml oral suspension
+12923511000001102,Nizatidine 150mg/5ml oral suspension (Special Order)
+444595002,Nizatidine 15mg/mL oral solution
+317281002,Nizatidine 300mg capsules
+531411000001108,Nizatidine 300mg capsules (A A H Pharmaceuticals Ltd)
+236911000001104,Nizatidine 300mg capsules (Actavis UK Ltd)
+345011000001103,Nizatidine 300mg capsules (Alliance Healthcare (Distribution) Ltd)
+9800111000001106,Nizatidine 300mg capsules (Almus Pharmaceuticals Ltd)
+10399811000001105,Nizatidine 300mg capsules (Arrow Generics Ltd)
+37461611000001106,Nizatidine 300mg capsules (DE Pharmaceuticals)
+11015011000001109,Nizatidine 300mg capsules (Dr Reddy's Laboratories (UK) Ltd)
+19305511000001108,Nizatidine 300mg capsules (Flynn Pharma Ltd)
+365511000001100,Nizatidine 300mg capsules (IVAX Pharmaceuticals UK Ltd)
+810811000001106,Nizatidine 300mg capsules (Kent Pharmaceuticals Ltd)
+30851911000001109,Nizatidine 300mg capsules (Mawdsley-Brooks & Company Ltd)
+21409711000001102,Nizatidine 300mg capsules (Medreich Plc)
+882411000001107,Nizatidine 300mg capsules (Mylan)
+14107511000001107,Nizatidine 300mg capsules (Niche Generics Ltd)
+17947311000001101,Nizatidine 300mg capsules (Phoenix Healthcare Distribution Ltd)
+4474911000001101,Nizatidine 300mg capsules (Sandoz Ltd)
+15111911000001101,Nizatidine 300mg capsules (Sigma Pharmaceuticals Plc)
+4117311000001104,Nizatidine 300mg capsules (Teva UK Ltd)
+5395511000001101,Nizatidine 300mg capsules (Waymade Healthcare Plc)
+21815911000001108,Nizatidine 300mg capsules (Waymade Healthcare Plc)
+414857007,Nizatidine 75 mg oral tablet
+765698004,Omeprazole (as omeprazole magnesium) 20 mg gastro-resistant oral tablet
+765518008,Omeprazole (as omeprazole magnesium) 40 mg gastro-resistant oral tablet
+766146009,Omeprazole (as omeprazole sodium) 40 mg powder for solution for injection vial
+420878004,Omeprazole + sodium bicarbonate
+317305007,Omeprazole 10 mg oral tablet
+13254601000001108,Omeprazole 10mg dispersible gastro-resistant tablets
+398942003,Omeprazole 10mg dispersible gastro-resistant tablets
+32440211000001109,Omeprazole 10mg dispersible gastro-resistant tablets (Kent Pharmaceuticals Ltd)
+317297007,Omeprazole 10mg gastro-resistant capsules
+254411000001103,Omeprazole 10mg gastro-resistant capsules (A A H Pharmaceuticals Ltd)
+863411000001100,Omeprazole 10mg gastro-resistant capsules (Actavis UK Ltd)
+546111000001106,Omeprazole 10mg gastro-resistant capsules (Alliance Healthcare (Distribution) Ltd)
+10686911000001101,Omeprazole 10mg gastro-resistant capsules (Almus Pharmaceuticals Ltd)
+19510711000001108,Omeprazole 10mg gastro-resistant capsules (Bristol Laboratories Ltd)
+30066711000001106,Omeprazole 10mg gastro-resistant capsules (DE Pharmaceuticals)
+11552511000001104,Omeprazole 10mg gastro-resistant capsules (Dexcel-Pharma Ltd)
+5617211000001100,Omeprazole 10mg gastro-resistant capsules (Dowelhurst Ltd)
+11014711000001107,Omeprazole 10mg gastro-resistant capsules (Dr Reddy's Laboratories (UK) Ltd)
+10300811000001104,Omeprazole 10mg gastro-resistant capsules (Focus Pharmaceuticals Ltd)
+215811000001108,Omeprazole 10mg gastro-resistant capsules (IVAX Pharmaceuticals UK Ltd)
+536711000001108,Omeprazole 10mg gastro-resistant capsules (Kent Pharmaceuticals Ltd)
+37124611000001102,Omeprazole 10mg gastro-resistant capsules (Mawdsley-Brooks & Company Ltd)
+638011000001101,Omeprazole 10mg gastro-resistant capsules (Mylan)
+37590211000001107,Omeprazole 10mg gastro-resistant capsules (NorthStar Healthcare Unlimited Company)
+17947811000001105,Omeprazole 10mg gastro-resistant capsules (Phoenix Healthcare Distribution Ltd)
+9377211000001109,Omeprazole 10mg gastro-resistant capsules (PLIVA Pharma Ltd)
+80311000001100,Omeprazole 10mg gastro-resistant capsules (Ranbaxy (UK) Ltd)
+3753411000001102,Omeprazole 10mg gastro-resistant capsules (Sandoz Ltd)
+15112711000001105,Omeprazole 10mg gastro-resistant capsules (Sigma Pharmaceuticals Plc)
+584711000001107,Omeprazole 10mg gastro-resistant capsules (Sterwin Medicines)
+385811000001100,Omeprazole 10mg gastro-resistant capsules (Teva UK Ltd)
+32556611000001103,Omeprazole 10mg gastro-resistant capsules (Tillomed Laboratories Ltd)
+21824711000001103,Omeprazole 10mg gastro-resistant capsules (Waymade Healthcare Plc)
+340711000001106,Omeprazole 10mg gastro-resistant capsules (Wockhardt UK Ltd)
+9559411000001103,Omeprazole 10mg gastro-resistant capsules (Zentiva)
+765935002,Omeprazole 10mg gastro-resistant oral capsule
+407846000,Omeprazole 10mg gastro-resistant tablets
+765514005,Omeprazole 10mg gastro-resistant tablets
+3192511000001105,Omeprazole 10mg gastro-resistant tablets (A A H Pharmaceuticals Ltd)
+3192911000001103,Omeprazole 10mg gastro-resistant tablets (Actavis UK Ltd)
+3198311000001101,Omeprazole 10mg gastro-resistant tablets (Alliance Healthcare (Distribution) Ltd)
+10687311000001104,Omeprazole 10mg gastro-resistant tablets (Almus Pharmaceuticals Ltd)
+30067311000001105,Omeprazole 10mg gastro-resistant tablets (DE Pharmaceuticals)
+11551911000001100,Omeprazole 10mg gastro-resistant tablets (Dexcel-Pharma Ltd)
+3195411000001103,Omeprazole 10mg gastro-resistant tablets (Kent Pharmaceuticals Ltd)
+3193711000001108,Omeprazole 10mg gastro-resistant tablets (Mylan)
+17948111000001102,Omeprazole 10mg gastro-resistant tablets (Phoenix Healthcare Distribution Ltd)
+3197411000001109,Omeprazole 10mg gastro-resistant tablets (Ranbaxy (UK) Ltd)
+3196811000001109,Omeprazole 10mg gastro-resistant tablets (Sandoz Ltd)
+29972411000001102,Omeprazole 10mg gastro-resistant tablets (Sigma Pharmaceuticals Plc)
+3197711000001103,Omeprazole 10mg gastro-resistant tablets (Sterwin Medicines)
+3194711000001105,Omeprazole 10mg gastro-resistant tablets (Teva UK Ltd)
+21825611000001108,Omeprazole 10mg gastro-resistant tablets (Waymade Healthcare Plc)
+24351311000001108,Omeprazole 10mg/5ml oral solution
+24328911000001104,Omeprazole 10mg/5ml oral solution (Special Order)
+8670511000001102,Omeprazole 10mg/5ml oral suspension
+8643311000001103,Omeprazole 10mg/5ml oral suspension (Drug Tariff Special Order)
+38072111000001103,Omeprazole 10mg/5ml oral suspension sugar free
+38313211000001109,Omeprazole 10mg/5ml oral suspension sugar free (A A H Pharmaceuticals Ltd)
+38216111000001100,Omeprazole 10mg/5ml oral suspension sugar free (Alliance Healthcare (Distribution) Ltd)
+38011811000001105,Omeprazole 10mg/5ml oral suspension sugar free (Rosemont Pharmaceuticals Ltd)
+13000811000001102,Omeprazole 12.5mg/5ml oral solution
+12959711000001106,Omeprazole 12.5mg/5ml oral solution (Special Order)
+13000911000001107,Omeprazole 12.5mg/5ml oral suspension
+12958811000001105,Omeprazole 12.5mg/5ml oral suspension (Special Order)
+13001011000001104,Omeprazole 15.5mg/5ml oral solution
+12961711000001104,Omeprazole 15.5mg/5ml oral solution (Special Order)
+13001111000001103,Omeprazole 15.5mg/5ml oral suspension
+12960911000001109,Omeprazole 15.5mg/5ml oral suspension (Special Order)
+14159911000001103,Omeprazole 15mg/5ml oral solution
+14090111000001109,Omeprazole 15mg/5ml oral solution (Special Order)
+14160011000001101,Omeprazole 15mg/5ml oral suspension
+14090711000001105,Omeprazole 15mg/5ml oral suspension (Special Order)
+8670611000001103,Omeprazole 2.5mg/5ml oral suspension
+8643811000001107,Omeprazole 2.5mg/5ml oral suspension (Special Order)
+422066007,Omeprazole 20 mg and sodium bicarbonate 1100 mg/1 each oral capsule
+317306008,Omeprazole 20 mg oral tablet
+444938007,Omeprazole 20mg + sodium bicarbonate 750mg + magnesium hydroxide 343 mg tablet
+13254501000001109,Omeprazole 20mg dispersible gastro-resistant tablets
+398905005,Omeprazole 20mg dispersible gastro-resistant tablets
+32440511000001107,Omeprazole 20mg dispersible gastro-resistant tablets (Kent Pharmaceuticals Ltd)
+317291008,Omeprazole 20mg gastro-resistant capsules
+1111000001108,Omeprazole 20mg gastro-resistant capsules (A A H Pharmaceuticals Ltd)
+263411000001108,Omeprazole 20mg gastro-resistant capsules (Actavis UK Ltd)
+7011000001102,Omeprazole 20mg gastro-resistant capsules (Alliance Healthcare (Distribution) Ltd)
+10687111000001101,Omeprazole 20mg gastro-resistant capsules (Almus Pharmaceuticals Ltd)
+13766811000001101,Omeprazole 20mg gastro-resistant capsules (Apotex UK Ltd)
+13413811000001102,Omeprazole 20mg gastro-resistant capsules (Arrow Generics Ltd)
+19511111000001101,Omeprazole 20mg gastro-resistant capsules (Bristol Laboratories Ltd)
+14125511000001108,Omeprazole 20mg gastro-resistant capsules (Consilient Health Ltd)
+30066911000001108,Omeprazole 20mg gastro-resistant capsules (DE Pharmaceuticals)
+11552711000001109,Omeprazole 20mg gastro-resistant capsules (Dexcel-Pharma Ltd)
+5497311000001109,Omeprazole 20mg gastro-resistant capsules (Dowelhurst Ltd)
+11014211000001100,Omeprazole 20mg gastro-resistant capsules (Dr Reddy's Laboratories (UK) Ltd)
+10300411000001101,Omeprazole 20mg gastro-resistant capsules (Focus Pharmaceuticals Ltd)
+21304911000001105,Omeprazole 20mg gastro-resistant capsules (Genesis Pharmaceuticals Ltd)
+140611000001107,Omeprazole 20mg gastro-resistant capsules (IVAX Pharmaceuticals UK Ltd)
+852311000001105,Omeprazole 20mg gastro-resistant capsules (Kent Pharmaceuticals Ltd)
+37124811000001103,Omeprazole 20mg gastro-resistant capsules (Mawdsley-Brooks & Company Ltd)
+35247411000001106,Omeprazole 20mg gastro-resistant capsules (Milpharm Ltd)
+568311000001100,Omeprazole 20mg gastro-resistant capsules (Mylan)
+37590411000001106,Omeprazole 20mg gastro-resistant capsules (NorthStar Healthcare Unlimited Company)
+17947911000001100,Omeprazole 20mg gastro-resistant capsules (Phoenix Healthcare Distribution Ltd)
+11409811000001106,Omeprazole 20mg gastro-resistant capsules (PLIVA Pharma Ltd)
+185011000001103,Omeprazole 20mg gastro-resistant capsules (Ranbaxy (UK) Ltd)
+3753611000001104,Omeprazole 20mg gastro-resistant capsules (Sandoz Ltd)
+15057211000001101,Omeprazole 20mg gastro-resistant capsules (Sigma Pharmaceuticals Plc)
+9756711000001103,Omeprazole 20mg gastro-resistant capsules (Somex Pharma)
+71711000001100,Omeprazole 20mg gastro-resistant capsules (Sterwin Medicines)
+40911000001106,Omeprazole 20mg gastro-resistant capsules (Teva UK Ltd)
+32557811000001102,Omeprazole 20mg gastro-resistant capsules (Tillomed Laboratories Ltd)
+21824911000001101,Omeprazole 20mg gastro-resistant capsules (Waymade Healthcare Plc)
+282211000001100,Omeprazole 20mg gastro-resistant capsules (Wockhardt UK Ltd)
+16064411000001102,Omeprazole 20mg gastro-resistant capsules (Zanza Specials International Ltd)
+9559611000001100,Omeprazole 20mg gastro-resistant capsules (Zentiva)
+765870004,Omeprazole 20mg gastro-resistant oral capsule
+407847009,Omeprazole 20mg gastro-resistant tablets
+3199111000001105,Omeprazole 20mg gastro-resistant tablets (A A H Pharmaceuticals Ltd)
+3200111000001100,Omeprazole 20mg gastro-resistant tablets (Actavis UK Ltd)
+3203011000001106,Omeprazole 20mg gastro-resistant tablets (Alliance Healthcare (Distribution) Ltd)
+10320711000001102,Omeprazole 20mg gastro-resistant tablets (Almus Pharmaceuticals Ltd)
+30067511000001104,Omeprazole 20mg gastro-resistant tablets (DE Pharmaceuticals)
+11552111000001108,Omeprazole 20mg gastro-resistant tablets (Dexcel-Pharma Ltd)
+3201111000001106,Omeprazole 20mg gastro-resistant tablets (IVAX Pharmaceuticals UK Ltd)
+3201411000001101,Omeprazole 20mg gastro-resistant tablets (Kent Pharmaceuticals Ltd)
+3200611000001108,Omeprazole 20mg gastro-resistant tablets (Mylan)
+17948211000001108,Omeprazole 20mg gastro-resistant tablets (Phoenix Healthcare Distribution Ltd)
+3202411000001106,Omeprazole 20mg gastro-resistant tablets (Ranbaxy (UK) Ltd)
+3202011000001102,Omeprazole 20mg gastro-resistant tablets (Sandoz Ltd)
+29972811000001100,Omeprazole 20mg gastro-resistant tablets (Sigma Pharmaceuticals Plc)
+3202611000001109,Omeprazole 20mg gastro-resistant tablets (Sterwin Medicines)
+5027211000001103,Omeprazole 20mg gastro-resistant tablets (Teva UK Ltd)
+21825811000001107,Omeprazole 20mg gastro-resistant tablets (Waymade Healthcare Plc)
+24351411000001101,Omeprazole 20mg/5ml oral solution
+24329411000001104,Omeprazole 20mg/5ml oral solution (Special Order)
+8670711000001107,Omeprazole 20mg/5ml oral suspension
+8644211000001109,Omeprazole 20mg/5ml oral suspension (Drug Tariff Special Order)
+38072211000001109,Omeprazole 20mg/5ml oral suspension sugar free
+38316811000001101,Omeprazole 20mg/5ml oral suspension sugar free (A A H Pharmaceuticals Ltd)
+38216411000001105,Omeprazole 20mg/5ml oral suspension sugar free (Alliance Healthcare (Distribution) Ltd)
+38012111000001108,Omeprazole 20mg/5ml oral suspension sugar free (Rosemont Pharmaceuticals Ltd)
+414934002,Omeprazole 20mg/sodium bicarbonate 1680mg powder for oral suspension
+422053007,Omeprazole 20mg/sodium bicarbonate 600mg/magnesium hydroxide 700mg chewable tablet
+13001211000001109,Omeprazole 25mg/5ml oral solution
+12965311000001101,Omeprazole 25mg/5ml oral solution (Special Order)
+13001311000001101,Omeprazole 25mg/5ml oral suspension
+12963111000001104,Omeprazole 25mg/5ml oral suspension (Special Order)
+13001411000001108,Omeprazole 2mg/5ml oral solution
+12967411000001102,Omeprazole 2mg/5ml oral solution (Special Order)
+13001511000001107,Omeprazole 2mg/5ml oral suspension
+12966811000001102,Omeprazole 2mg/5ml oral suspension (Special Order)
+34683711000001105,Omeprazole 3.5mg/5ml oral suspension
+34675111000001104,Omeprazole 3.5mg/5ml oral suspension (Special Order)
+36775611000001107,Omeprazole 30mg/5ml oral suspension
+36771511000001105,Omeprazole 30mg/5ml oral suspension (Special Order)
+15437511000001105,Omeprazole 35mg/5ml oral solution
+15430911000001104,Omeprazole 35mg/5ml oral solution (Special Order)
+15437611000001109,Omeprazole 35mg/5ml oral suspension
+15431211000001102,Omeprazole 35mg/5ml oral suspension (Special Order)
+13001611000001106,Omeprazole 3mg/5ml oral solution
+12969111000001101,Omeprazole 3mg/5ml oral solution (Special Order)
+13001711000001102,Omeprazole 3mg/5ml oral suspension
+12968311000001105,Omeprazole 3mg/5ml oral suspension (Special Order)
+422341002,Omeprazole 40 mg and sodium bicarbonate 1100 mg/1 each oral capsule
+317307004,Omeprazole 40 mg oral tablet
+444939004,Omeprazole 40mg + sodium bicarbonate 750mg + magnesium hydroxide 343 mg tablet
+13254201000001106,Omeprazole 40mg dispersible gastro-resistant tablets
+398787005,Omeprazole 40mg dispersible gastro-resistant tablets
+32441811000001102,Omeprazole 40mg dispersible gastro-resistant tablets (Kent Pharmaceuticals Ltd)
+317295004,Omeprazole 40mg gastro-resistant capsules
+919311000001103,Omeprazole 40mg gastro-resistant capsules (A A H Pharmaceuticals Ltd)
+23639311000001100,Omeprazole 40mg gastro-resistant capsules (Actavis UK Ltd)
+147611000001106,Omeprazole 40mg gastro-resistant capsules (Alliance Healthcare (Distribution) Ltd)
+13414611000001103,Omeprazole 40mg gastro-resistant capsules (Almus Pharmaceuticals Ltd)
+19511411000001106,Omeprazole 40mg gastro-resistant capsules (Bristol Laboratories Ltd)
+30067011000001107,Omeprazole 40mg gastro-resistant capsules (DE Pharmaceuticals)
+11013911000001107,Omeprazole 40mg gastro-resistant capsules (Dr Reddy's Laboratories (UK) Ltd)
+10299911000001106,Omeprazole 40mg gastro-resistant capsules (Focus Pharmaceuticals Ltd)
+32807211000001105,Omeprazole 40mg gastro-resistant capsules (Genesis Pharmaceuticals Ltd)
+414711000001103,Omeprazole 40mg gastro-resistant capsules (IVAX Pharmaceuticals UK Ltd)
+251411000001100,Omeprazole 40mg gastro-resistant capsules (Kent Pharmaceuticals Ltd)
+37125011000001108,Omeprazole 40mg gastro-resistant capsules (Mawdsley-Brooks & Company Ltd)
+412411000001102,Omeprazole 40mg gastro-resistant capsules (Mylan)
+37590611000001109,Omeprazole 40mg gastro-resistant capsules (NorthStar Healthcare Unlimited Company)
+17948011000001103,Omeprazole 40mg gastro-resistant capsules (Phoenix Healthcare Distribution Ltd)
+9377411000001108,Omeprazole 40mg gastro-resistant capsules (PLIVA Pharma Ltd)
+349911000001102,Omeprazole 40mg gastro-resistant capsules (Ranbaxy (UK) Ltd)
+3753811000001100,Omeprazole 40mg gastro-resistant capsules (Sandoz Ltd)
+15112911000001107,Omeprazole 40mg gastro-resistant capsules (Sigma Pharmaceuticals Plc)
+372711000001109,Omeprazole 40mg gastro-resistant capsules (Sterwin Medicines)
+789711000001109,Omeprazole 40mg gastro-resistant capsules (Teva UK Ltd)
+32558611000001102,Omeprazole 40mg gastro-resistant capsules (Tillomed Laboratories Ltd)
+21825211000001106,Omeprazole 40mg gastro-resistant capsules (Waymade Healthcare Plc)
+40511000001104,Omeprazole 40mg gastro-resistant capsules (Wockhardt UK Ltd)
+9559811000001101,Omeprazole 40mg gastro-resistant capsules (Zentiva)
+765909003,Omeprazole 40mg gastro-resistant oral capsule
+407848004,Omeprazole 40mg gastro-resistant tablets
+3204211000001103,Omeprazole 40mg gastro-resistant tablets (A A H Pharmaceuticals Ltd)
+3204711000001105,Omeprazole 40mg gastro-resistant tablets (Actavis UK Ltd)
+3209611000001102,Omeprazole 40mg gastro-resistant tablets (Alliance Healthcare (Distribution) Ltd)
+10687511000001105,Omeprazole 40mg gastro-resistant tablets (Almus Pharmaceuticals Ltd)
+30067711000001109,Omeprazole 40mg gastro-resistant tablets (DE Pharmaceuticals)
+11552311000001105,Omeprazole 40mg gastro-resistant tablets (Dexcel-Pharma Ltd)
+3206311000001100,Omeprazole 40mg gastro-resistant tablets (Kent Pharmaceuticals Ltd)
+3205211000001102,Omeprazole 40mg gastro-resistant tablets (Mylan)
+17948311000001100,Omeprazole 40mg gastro-resistant tablets (Phoenix Healthcare Distribution Ltd)
+3207911000001101,Omeprazole 40mg gastro-resistant tablets (Ranbaxy (UK) Ltd)
+3207111000001104,Omeprazole 40mg gastro-resistant tablets (Sandoz Ltd)
+29973011000001102,Omeprazole 40mg gastro-resistant tablets (Sigma Pharmaceuticals Plc)
+3208811000001105,Omeprazole 40mg gastro-resistant tablets (Sterwin Medicines)
+3205811000001101,Omeprazole 40mg gastro-resistant tablets (Teva UK Ltd)
+21826211000001100,Omeprazole 40mg gastro-resistant tablets (Waymade Healthcare Plc)
+36022211000001101,Omeprazole 40mg powder and solvent for solution for injection vials
+36022311000001109,Omeprazole 40mg powder for solution for infusion vials
+11535811000001107,Omeprazole 40mg powder for solution for infusion vials (A A H Pharmaceuticals Ltd)
+34754811000001102,Omeprazole 40mg powder for solution for infusion vials (Bowmed Ibisqus Ltd)
+35775411000001106,Omeprazole 40mg powder for solution for infusion vials (Mylan)
+11144411000001102,Omeprazole 40mg powder for solution for infusion vials (PLIVA Pharma Ltd)
+31685111000001103,Omeprazole 40mg powder for solution for infusion vials (Sandoz Ltd)
+15028911000001107,Omeprazole 40mg powder for solution for infusion vials (Teva UK Ltd)
+13001811000001105,Omeprazole 40mg/5ml oral solution
+12969711000001100,Omeprazole 40mg/5ml oral solution (Special Order)
+13001911000001100,Omeprazole 40mg/5ml oral suspension
+12969411000001106,Omeprazole 40mg/5ml oral suspension (Drug Tariff Special Order)
+414935001,Omeprazole 40mg/sodium bicarbonate 1680mg powder for oral suspension
+420649002,Omeprazole 40mg/sodium bicarbonate 600mg/magnesium hydroxide 700mg chewable tablet
+13002011000001107,Omeprazole 4mg/5ml oral solution
+12971511000001100,Omeprazole 4mg/5ml oral solution (Special Order)
+13002111000001108,Omeprazole 4mg/5ml oral suspension
+12970611000001106,Omeprazole 4mg/5ml oral suspension (Special Order)
+13002211000001102,Omeprazole 500micrograms/5ml oral solution
+12974011000001106,Omeprazole 500micrograms/5ml oral solution (Special Order)
+13002311000001105,Omeprazole 500micrograms/5ml oral suspension
+12973011000001109,Omeprazole 500micrograms/5ml oral suspension (Special Order)
+13002411000001103,Omeprazole 50mg/5ml oral solution
+12975411000001101,Omeprazole 50mg/5ml oral solution (Special Order)
+13002511000001104,Omeprazole 50mg/5ml oral suspension
+12974811000001100,Omeprazole 50mg/5ml oral suspension (Special Order)
+34683811000001102,Omeprazole 5mg/5ml oral solution
+34675411000001109,Omeprazole 5mg/5ml oral solution (Special Order)
+8670811000001104,Omeprazole 5mg/5ml oral suspension
+8644711000001102,Omeprazole 5mg/5ml oral suspension (Drug Tariff Special Order)
+15915011000001101,Omeprazole 6.8mg/5ml oral solution
+15894611000001104,Omeprazole 6.8mg/5ml oral solution (Special Order)
+15915111000001100,Omeprazole 6.8mg/5ml oral suspension
+15895411000001101,Omeprazole 6.8mg/5ml oral suspension (Special Order)
+32750211000001103,Omeprazole 7mg/5ml oral suspension
+32707511000001105,Omeprazole 7mg/5ml oral suspension (Special Order)
+15124911000001106,Omeprazole 8.5mg/5ml oral solution
+15117411000001101,Omeprazole 8.5mg/5ml oral solution (Special Order)
+15125011000001106,Omeprazole 8.5mg/5ml oral suspension
+15117711000001107,Omeprazole 8.5mg/5ml oral suspension (Special Order)
+13002611000001100,Omeprazole 8mg/5ml oral solution
+12976511000001109,Omeprazole 8mg/5ml oral solution (Special Order)
+13002711000001109,Omeprazole 8mg/5ml oral suspension
+12975911000001109,Omeprazole 8mg/5ml oral suspension (Special Order)
+713990009,Omeprazole in oral dosage form
+713988008,Omeprazole in parenteral dosage form
+3632811000001101,Omeran 10mg gastro-resistant tablets (Ranbaxy (UK) Ltd)
+3633211000001108,Omeran 20mg gastro-resistant tablets (Ranbaxy (UK) Ltd)
+3633611000001105,Omeran 40mg gastro-resistant tablets (Ranbaxy (UK) Ltd)
+17011211000001100,Pantoloc Control 20mg gastro-resistant tablets (GlaxoSmithKline Consumer Healthcare)
+317322009,Pantoprazole 20mg gastro-resistant tablets
+15609411000001106,Pantoprazole 20mg gastro-resistant tablets (A A H Pharmaceuticals Ltd)
+15453711000001109,Pantoprazole 20mg gastro-resistant tablets (Accord Healthcare Ltd)
+15608811000001101,Pantoprazole 20mg gastro-resistant tablets (Alliance Healthcare (Distribution) Ltd)
+18681511000001102,Pantoprazole 20mg gastro-resistant tablets (Almus Pharmaceuticals Ltd)
+17661311000001101,Pantoprazole 20mg gastro-resistant tablets (Arrow Generics Ltd)
+32492411000001104,Pantoprazole 20mg gastro-resistant tablets (Brown & Burk UK Ltd)
+17217711000001108,Pantoprazole 20mg gastro-resistant tablets (Consilient Health Ltd)
+13944211000001105,Pantoprazole 20mg gastro-resistant tablets (DE Pharmaceuticals)
+30071411000001100,Pantoprazole 20mg gastro-resistant tablets (DE Pharmaceuticals)
+13186211000001108,Pantoprazole 20mg gastro-resistant tablets (Dowelhurst Ltd)
+18478011000001109,Pantoprazole 20mg gastro-resistant tablets (Dr Reddy's Laboratories (UK) Ltd)
+32442111000001104,Pantoprazole 20mg gastro-resistant tablets (Kent Pharmaceuticals Ltd)
+16224111000001108,Pantoprazole 20mg gastro-resistant tablets (Lexon (UK) Ltd)
+31062811000001107,Pantoprazole 20mg gastro-resistant tablets (Macleods Pharma UK Ltd)
+30843811000001102,Pantoprazole 20mg gastro-resistant tablets (Mawdsley-Brooks & Company Ltd)
+35174611000001102,Pantoprazole 20mg gastro-resistant tablets (Milpharm Ltd)
+15517511000001106,Pantoprazole 20mg gastro-resistant tablets (Mylan)
+16569611000001102,Pantoprazole 20mg gastro-resistant tablets (Niche Generics Ltd)
+17951911000001106,Pantoprazole 20mg gastro-resistant tablets (Phoenix Healthcare Distribution Ltd)
+16213211000001109,Pantoprazole 20mg gastro-resistant tablets (Ranbaxy (UK) Ltd)
+21993411000001105,Pantoprazole 20mg gastro-resistant tablets (Sandoz Ltd)
+14707611000001102,Pantoprazole 20mg gastro-resistant tablets (Sigma Pharmaceuticals Plc)
+29975411000001105,Pantoprazole 20mg gastro-resistant tablets (Sigma Pharmaceuticals Plc)
+16742111000001109,Pantoprazole 20mg gastro-resistant tablets (Takeda UK Ltd)
+15510711000001102,Pantoprazole 20mg gastro-resistant tablets (Teva UK Ltd)
+36819911000001106,Pantoprazole 20mg gastro-resistant tablets (Torrent Pharma (UK) Ltd)
+10534611000001103,Pantoprazole 20mg gastro-resistant tablets (Waymade Healthcare Plc)
+21834611000001105,Pantoprazole 20mg gastro-resistant tablets (Waymade Healthcare Plc)
+17958211000001106,Pantoprazole 20mg gastro-resistant tablets (Wockhardt UK Ltd)
+15448811000001108,Pantoprazole 20mg gastro-resistant tablets (Zentiva)
+18520011000001104,Pantoprazole 20mg/5ml oral suspension
+18516611000001104,Pantoprazole 20mg/5ml oral suspension (Special Order)
+317318004,Pantoprazole 40mg gastro-resistant tablets
+15609611000001109,Pantoprazole 40mg gastro-resistant tablets (A A H Pharmaceuticals Ltd)
+15453911000001106,Pantoprazole 40mg gastro-resistant tablets (Accord Healthcare Ltd)
+15609011000001102,Pantoprazole 40mg gastro-resistant tablets (Alliance Healthcare (Distribution) Ltd)
+18681711000001107,Pantoprazole 40mg gastro-resistant tablets (Almus Pharmaceuticals Ltd)
+17661511000001107,Pantoprazole 40mg gastro-resistant tablets (Arrow Generics Ltd)
+32492611000001101,Pantoprazole 40mg gastro-resistant tablets (Brown & Burk UK Ltd)
+17217911000001105,Pantoprazole 40mg gastro-resistant tablets (Consilient Health Ltd)
+38418911000001104,Pantoprazole 40mg gastro-resistant tablets (Crescent Pharma Ltd)
+13944411000001109,Pantoprazole 40mg gastro-resistant tablets (DE Pharmaceuticals)
+30071611000001102,Pantoprazole 40mg gastro-resistant tablets (DE Pharmaceuticals)
+5499911000001103,Pantoprazole 40mg gastro-resistant tablets (Dowelhurst Ltd)
+18478211000001104,Pantoprazole 40mg gastro-resistant tablets (Dr Reddy's Laboratories (UK) Ltd)
+37799111000001107,Pantoprazole 40mg gastro-resistant tablets (Ennogen Healthcare Ltd)
+32442411000001109,Pantoprazole 40mg gastro-resistant tablets (Kent Pharmaceuticals Ltd)
+16224311000001105,Pantoprazole 40mg gastro-resistant tablets (Lexon (UK) Ltd)
+29819111000001102,Pantoprazole 40mg gastro-resistant tablets (Macleods Pharma UK Ltd)
+30844011000001105,Pantoprazole 40mg gastro-resistant tablets (Mawdsley-Brooks & Company Ltd)
+35174811000001103,Pantoprazole 40mg gastro-resistant tablets (Milpharm Ltd)
+15517711000001101,Pantoprazole 40mg gastro-resistant tablets (Mylan)
+16569811000001103,Pantoprazole 40mg gastro-resistant tablets (Niche Generics Ltd)
+17952111000001103,Pantoprazole 40mg gastro-resistant tablets (Phoenix Healthcare Distribution Ltd)
+16213411000001108,Pantoprazole 40mg gastro-resistant tablets (Ranbaxy (UK) Ltd)
+20318611000001102,Pantoprazole 40mg gastro-resistant tablets (Sandoz Ltd)
+14708011000001105,Pantoprazole 40mg gastro-resistant tablets (Sigma Pharmaceuticals Plc)
+29975611000001108,Pantoprazole 40mg gastro-resistant tablets (Sigma Pharmaceuticals Plc)
+16741811000001106,Pantoprazole 40mg gastro-resistant tablets (Takeda UK Ltd)
+15510911000001100,Pantoprazole 40mg gastro-resistant tablets (Teva UK Ltd)
+36820311000001106,Pantoprazole 40mg gastro-resistant tablets (Torrent Pharma (UK) Ltd)
+5397411000001106,Pantoprazole 40mg gastro-resistant tablets (Waymade Healthcare Plc)
+21835111000001103,Pantoprazole 40mg gastro-resistant tablets (Waymade Healthcare Plc)
+17958411000001105,Pantoprazole 40mg gastro-resistant tablets (Wockhardt UK Ltd)
+15449111000001108,Pantoprazole 40mg gastro-resistant tablets (Zentiva)
+317320001,Pantoprazole 40mg powder for solution for injection vials
+18276611000001102,Pantoprazole 40mg powder for solution for injection vials (A A H Pharmaceuticals Ltd)
+18165811000001102,Pantoprazole 40mg powder for solution for injection vials (Actavis UK Ltd)
+34755011000001107,Pantoprazole 40mg powder for solution for injection vials (Bowmed Ibisqus Ltd)
+19720111000001100,Pantoprazole 40mg powder for solution for injection vials (Martindale Pharmaceuticals Ltd)
+36868311000001103,Pantoprazole 40mg powder for solution for injection vials (Reig Jofre UK Ltd)
+24014611000001108,Pantoprazole 40mg powder for solution for injection vials (Sandoz Ltd)
+21507211000001106,Pantoprazole 40mg powder for solution for injection vials (Sun Pharmaceutical Industries Europe B.V.)
+18520111000001103,Pantoprazole 40mg/5ml oral suspension
+18516911000001105,Pantoprazole 40mg/5ml oral suspension (Special Order)
+432409000,Pantoprazole 40mg/packet enteric coated granules for oral suspension
+767768002,Pantoprazole in oral dosage form
+373960005,Pantoprazole sodium 40 mg oral tablet
+13944611000001107,Pariet 10mg gastro-resistant tablets (DE Pharmaceuticals)
+5570111000001106,Pariet 10mg gastro-resistant tablets (Dowelhurst Ltd)
+228611000001109,Pariet 10mg gastro-resistant tablets (Eisai Ltd)
+17618511000001101,Pariet 10mg gastro-resistant tablets (Necessity Supplies Ltd)
+19697211000001107,Pariet 10mg gastro-resistant tablets (Sigma Pharmaceuticals Plc)
+5399511000001103,Pariet 10mg gastro-resistant tablets (Waymade Healthcare Plc)
+13944811000001106,Pariet 20mg gastro-resistant tablets (DE Pharmaceuticals)
+5571111000001100,Pariet 20mg gastro-resistant tablets (Dowelhurst Ltd)
+43811000001108,Pariet 20mg gastro-resistant tablets (Eisai Ltd)
+19858711000001100,Pariet 20mg gastro-resistant tablets (Lexon (UK) Ltd)
+17618711000001106,Pariet 20mg gastro-resistant tablets (Necessity Supplies Ltd)
+17588211000001108,Pariet 20mg gastro-resistant tablets (Sigma Pharmaceuticals Plc)
+5399811000001100,Pariet 20mg gastro-resistant tablets (Waymade Healthcare Plc)
+460211000001103,Pepcid 20mg tablets (Merck Sharp & Dohme Ltd)
+272311000001101,Pepcid 40mg tablets (Merck Sharp & Dohme Ltd)
+297811000001102,Pepcid AC Indigestion 10mg tablets (McNeil Products Ltd)
+4343411000001101,Pepcidtwo chewable tablets (McNeil Products Ltd)
+684811000001107,Peptimax 200 tablets (Ashbourne Pharmaceuticals Ltd)
+45911000001102,Peptimax 400 tablets (Ashbourne Pharmaceuticals Ltd)
+13948911000001108,Protium 20mg gastro-resistant tablets (DE Pharmaceuticals)
+13187411000001109,Protium 20mg gastro-resistant tablets (Dowelhurst Ltd)
+16228811000001109,Protium 20mg gastro-resistant tablets (Lexon (UK) Ltd)
+160711000001109,Protium 20mg gastro-resistant tablets (Nycomed UK Ltd)
+14344911000001105,Protium 20mg gastro-resistant tablets (Sigma Pharmaceuticals Plc)
+5482211000001103,Protium 20mg gastro-resistant tablets (Waymade Healthcare Plc)
+13949111000001103,Protium 40mg gastro-resistant tablets (DE Pharmaceuticals)
+13187711000001103,Protium 40mg gastro-resistant tablets (Dowelhurst Ltd)
+16229011000001108,Protium 40mg gastro-resistant tablets (Lexon (UK) Ltd)
+922011000001101,Protium 40mg gastro-resistant tablets (Nycomed UK Ltd)
+14345611000001103,Protium 40mg gastro-resistant tablets (Sigma Pharmaceuticals Plc)
+5403511000001106,Protium 40mg gastro-resistant tablets (Waymade Healthcare Plc)
+540211000001102,Protium I.V. 40mg powder for solution for injection vials (Takeda UK Ltd)
+672711000001104,Pylorid 400mg tablets (GlaxoSmithKline UK Ltd)
+317324005,Rabeprazole 10mg gastro-resistant tablets
+21548611000001100,Rabeprazole 10mg gastro-resistant tablets (A A H Pharmaceuticals Ltd)
+21662511000001100,Rabeprazole 10mg gastro-resistant tablets (Accord Healthcare Ltd)
+21553411000001106,Rabeprazole 10mg gastro-resistant tablets (Alliance Healthcare (Distribution) Ltd)
+36601411000001106,Rabeprazole 10mg gastro-resistant tablets (Bristol Laboratories Ltd)
+21684811000001105,Rabeprazole 10mg gastro-resistant tablets (Consilient Health Ltd)
+33432211000001102,Rabeprazole 10mg gastro-resistant tablets (Creo Pharma Ltd)
+36439811000001101,Rabeprazole 10mg gastro-resistant tablets (Crescent Pharma Ltd)
+30827911000001100,Rabeprazole 10mg gastro-resistant tablets (DE Pharmaceuticals)
+37137411000001107,Rabeprazole 10mg gastro-resistant tablets (Mawdsley-Brooks & Company Ltd)
+21554411000001109,Rabeprazole 10mg gastro-resistant tablets (Milpharm Ltd)
+33612211000001109,Rabeprazole 10mg gastro-resistant tablets (Mylan)
+21661511000001108,Rabeprazole 10mg gastro-resistant tablets (Teva UK Ltd)
+36828111000001106,Rabeprazole 10mg gastro-resistant tablets (Torrent Pharma (UK) Ltd)
+21877311000001107,Rabeprazole 10mg gastro-resistant tablets (Waymade Healthcare Plc)
+36501111000001108,Rabeprazole 10mg gastro-resistant tablets (Xiromed)
+22102211000001101,Rabeprazole 10mg gastro-resistant tablets (Zentiva)
+317325006,Rabeprazole 20mg gastro-resistant tablets
+21548811000001101,Rabeprazole 20mg gastro-resistant tablets (A A H Pharmaceuticals Ltd)
+27843011000001102,Rabeprazole 20mg gastro-resistant tablets (Accord Healthcare Ltd)
+21663211000001109,Rabeprazole 20mg gastro-resistant tablets (Actavis UK Ltd)
+21553611000001109,Rabeprazole 20mg gastro-resistant tablets (Alliance Healthcare (Distribution) Ltd)
+36601611000001109,Rabeprazole 20mg gastro-resistant tablets (Bristol Laboratories Ltd)
+21686311000001107,Rabeprazole 20mg gastro-resistant tablets (Consilient Health Ltd)
+33569211000001105,Rabeprazole 20mg gastro-resistant tablets (Creo Pharma Ltd)
+36440011000001100,Rabeprazole 20mg gastro-resistant tablets (Crescent Pharma Ltd)
+30828411000001107,Rabeprazole 20mg gastro-resistant tablets (DE Pharmaceuticals)
+37137611000001105,Rabeprazole 20mg gastro-resistant tablets (Mawdsley-Brooks & Company Ltd)
+21554211000001105,Rabeprazole 20mg gastro-resistant tablets (Milpharm Ltd)
+33612411000001108,Rabeprazole 20mg gastro-resistant tablets (Mylan)
+21661711000001103,Rabeprazole 20mg gastro-resistant tablets (Teva UK Ltd)
+36828311000001108,Rabeprazole 20mg gastro-resistant tablets (Torrent Pharma (UK) Ltd)
+21877511000001101,Rabeprazole 20mg gastro-resistant tablets (Waymade Healthcare Plc)
+36501311000001105,Rabeprazole 20mg gastro-resistant tablets (Xiromed)
+22102511000001103,Rabeprazole 20mg gastro-resistant tablets (Zentiva)
+767771005,Rabeprazole in oral dosage form
+687311000001107,Raciran 150 tablets (Opus Pharmaceuticals Ltd)
+169211000001109,Raciran 300 tablets (Opus Pharmaceuticals Ltd)
+25321611000001107,Ranicalm 75mg tablets (Bristol Laboratories Ltd)
+825111000001102,Ranitic 150mg tablets (Tillomed Laboratories Ltd)
+791611000001100,Ranitic 300mg tablets (Tillomed Laboratories Ltd)
+769277004,Ranitidine (as ranitidine hydrochloride) 15 mg/mL oral solution
+770013009,Ranitidine (as ranitidine hydrochloride) 50 mg/2 mL solution for injection ampoule
+13013511000001109,Ranitidine 1.5mg/5ml oral solution
+12994411000001105,Ranitidine 1.5mg/5ml oral solution (Special Order)
+13013611000001108,Ranitidine 1.5mg/5ml oral suspension
+12993811000001109,Ranitidine 1.5mg/5ml oral suspension (Special Order)
+13013711000001104,Ranitidine 1.8mg/5ml oral solution
+12996011000001106,Ranitidine 1.8mg/5ml oral solution (Special Order)
+13013811000001107,Ranitidine 1.8mg/5ml oral suspension
+12995311000001104,Ranitidine 1.8mg/5ml oral suspension (Special Order)
+13013911000001102,Ranitidine 10mg/5ml oral solution
+12997511000001101,Ranitidine 10mg/5ml oral solution (Special Order)
+13014011000001104,Ranitidine 10mg/5ml oral suspension
+12996811000001100,Ranitidine 10mg/5ml oral suspension (Special Order)
+16075111000001103,Ranitidine 11.4mg/5ml oral solution
+16042111000001106,Ranitidine 11.4mg/5ml oral solution (Special Order)
+16075211000001109,Ranitidine 11.4mg/5ml oral suspension
+16042711000001107,Ranitidine 11.4mg/5ml oral suspension (Special Order)
+15880511000001108,Ranitidine 12mg/5ml oral solution
+15867311000001103,Ranitidine 12mg/5ml oral solution (Special Order)
+15880611000001107,Ranitidine 12mg/5ml oral suspension
+15867611000001108,Ranitidine 12mg/5ml oral suspension (Special Order)
+317238000,Ranitidine 150mg effervescent tablets
+553711000001102,Ranitidine 150mg effervescent tablets (A A H Pharmaceuticals Ltd)
+669911000001104,Ranitidine 150mg effervescent tablets (Actavis UK Ltd)
+670411000001109,Ranitidine 150mg effervescent tablets (Alliance Healthcare (Distribution) Ltd)
+37780811000001105,Ranitidine 150mg effervescent tablets (DE Pharmaceuticals)
+871111000001100,Ranitidine 150mg effervescent tablets (Kent Pharmaceuticals Ltd)
+37138111000001101,Ranitidine 150mg effervescent tablets (Mawdsley-Brooks & Company Ltd)
+18025211000001102,Ranitidine 150mg effervescent tablets (Phoenix Healthcare Distribution Ltd)
+870911000001109,Ranitidine 150mg effervescent tablets (Sandoz Ltd)
+17205011000001101,Ranitidine 150mg effervescent tablets (Sovereign Medical Ltd)
+23613911000001108,Ranitidine 150mg effervescent tablets (Teva UK Ltd)
+317249006,Ranitidine 150mg tablets
+114111000001103,Ranitidine 150mg tablets (A A H Pharmaceuticals Ltd)
+18465811000001101,Ranitidine 150mg tablets (Accord Healthcare Ltd)
+559011000001101,Ranitidine 150mg tablets (Actavis UK Ltd)
+250611000001107,Ranitidine 150mg tablets (Alliance Healthcare (Distribution) Ltd)
+10413411000001100,Ranitidine 150mg tablets (Arrow Generics Ltd)
+14783311000001101,Ranitidine 150mg tablets (Boston Healthcare Ltd)
+16065811000001104,Ranitidine 150mg tablets (Bristol Laboratories Ltd)
+30088411000001101,Ranitidine 150mg tablets (DE Pharmaceuticals)
+13254811000001109,Ranitidine 150mg tablets (Dowelhurst Ltd)
+35995911000001104,Ranitidine 150mg tablets (Ennogen Pharma Ltd)
+36879211000001106,Ranitidine 150mg tablets (Flamingo Pharma (UK) Ltd)
+163711000001100,Ranitidine 150mg tablets (IVAX Pharmaceuticals UK Ltd)
+316411000001109,Ranitidine 150mg tablets (Kent Pharmaceuticals Ltd)
+21410611000001103,Ranitidine 150mg tablets (Medreich Plc)
+3310811000001102,Ranitidine 150mg tablets (Mercury Pharma Group Ltd)
+19196411000001108,Ranitidine 150mg tablets (Milpharm Ltd)
+160911000001106,Ranitidine 150mg tablets (Mylan)
+36728811000001101,Ranitidine 150mg tablets (Noumed Life Sciences Ltd)
+17924111000001105,Ranitidine 150mg tablets (Phoenix Healthcare Distribution Ltd)
+400411000001100,Ranitidine 150mg tablets (Ranbaxy (UK) Ltd)
+36924211000001101,Ranitidine 150mg tablets (Relonchem Ltd)
+247211000001106,Ranitidine 150mg tablets (Sandoz Ltd)
+128411000001109,Ranitidine 150mg tablets (Sterwin Medicines)
+126211000001109,Ranitidine 150mg tablets (Teva UK Ltd)
+801511000001104,Ranitidine 150mg tablets (The Boots Company Plc)
+21879611000001107,Ranitidine 150mg tablets (Waymade Healthcare Plc)
+15975111000001109,Ranitidine 150mg tablets (Zanza Specials International Ltd)
+11590711000001104,Ranitidine 150mg tablets (Zentiva)
+34908411000001107,Ranitidine 150mg/5ml oral solution sugar free
+34968111000001103,Ranitidine 150mg/5ml oral solution sugar free (A A H Pharmaceuticals Ltd)
+35039111000001103,Ranitidine 150mg/5ml oral solution sugar free (Alliance Healthcare (Distribution) Ltd)
+34891311000001103,Ranitidine 150mg/5ml oral solution sugar free (Creo Pharma Ltd)
+13014111000001103,Ranitidine 16mg/5ml oral solution
+12999311000001102,Ranitidine 16mg/5ml oral solution (Special Order)
+13014211000001109,Ranitidine 16mg/5ml oral suspension
+12998911000001109,Ranitidine 16mg/5ml oral suspension (Special Order)
+13060511000001104,Ranitidine 18mg/5ml oral solution
+13046511000001105,Ranitidine 18mg/5ml oral solution (Special Order)
+13060611000001100,Ranitidine 18mg/5ml oral suspension
+13043011000001105,Ranitidine 18mg/5ml oral suspension (Special Order)
+34684011000001105,Ranitidine 1mg/5ml oral solution
+34676511000001101,Ranitidine 1mg/5ml oral solution (Special Order)
+15649711000001107,Ranitidine 20mg/5ml oral solution
+15640311000001104,Ranitidine 20mg/5ml oral solution (Special Order)
+15649811000001104,Ranitidine 20mg/5ml oral suspension
+15640611000001109,Ranitidine 20mg/5ml oral suspension (Special Order)
+410921005,Ranitidine 25mg effervescent tablet
+13060711000001109,Ranitidine 25mg/5ml oral solution
+13048411000001107,Ranitidine 25mg/5ml oral solution (Special Order)
+13060811000001101,Ranitidine 25mg/5ml oral suspension
+13048111000001102,Ranitidine 25mg/5ml oral suspension (Special Order)
+317239008,Ranitidine 300mg effervescent tablets
+124611000001102,Ranitidine 300mg effervescent tablets (A A H Pharmaceuticals Ltd)
+765611000001100,Ranitidine 300mg effervescent tablets (Actavis UK Ltd)
+930011000001102,Ranitidine 300mg effervescent tablets (Alliance Healthcare (Distribution) Ltd)
+37781011000001108,Ranitidine 300mg effervescent tablets (DE Pharmaceuticals)
+651511000001103,Ranitidine 300mg effervescent tablets (Kent Pharmaceuticals Ltd)
+37138311000001104,Ranitidine 300mg effervescent tablets (Mawdsley-Brooks & Company Ltd)
+18025411000001103,Ranitidine 300mg effervescent tablets (Phoenix Healthcare Distribution Ltd)
+376011000001106,Ranitidine 300mg effervescent tablets (Sandoz Ltd)
+15185511000001109,Ranitidine 300mg effervescent tablets (Sigma Pharmaceuticals Plc)
+17205211000001106,Ranitidine 300mg effervescent tablets (Sovereign Medical Ltd)
+23614111000001107,Ranitidine 300mg effervescent tablets (Teva UK Ltd)
+317251005,Ranitidine 300mg tablets
+222211000001105,Ranitidine 300mg tablets (A A H Pharmaceuticals Ltd)
+18466011000001103,Ranitidine 300mg tablets (Accord Healthcare Ltd)
+306811000001109,Ranitidine 300mg tablets (Actavis UK Ltd)
+64911000001106,Ranitidine 300mg tablets (Alliance Healthcare (Distribution) Ltd)
+10413611000001102,Ranitidine 300mg tablets (Arrow Generics Ltd)
+14783511000001107,Ranitidine 300mg tablets (Boston Healthcare Ltd)
+16066011000001101,Ranitidine 300mg tablets (Bristol Laboratories Ltd)
+30088611000001103,Ranitidine 300mg tablets (DE Pharmaceuticals)
+13255111000001103,Ranitidine 300mg tablets (Dowelhurst Ltd)
+35996211000001102,Ranitidine 300mg tablets (Ennogen Pharma Ltd)
+36879411000001105,Ranitidine 300mg tablets (Flamingo Pharma (UK) Ltd)
+447411000001109,Ranitidine 300mg tablets (IVAX Pharmaceuticals UK Ltd)
+534811000001107,Ranitidine 300mg tablets (Kent Pharmaceuticals Ltd)
+21410811000001104,Ranitidine 300mg tablets (Medreich Plc)
+3311111000001103,Ranitidine 300mg tablets (Mercury Pharma Group Ltd)
+19196811000001105,Ranitidine 300mg tablets (Milpharm Ltd)
+346711000001109,Ranitidine 300mg tablets (Mylan)
+36729811000001108,Ranitidine 300mg tablets (Noumed Life Sciences Ltd)
+17924311000001107,Ranitidine 300mg tablets (Phoenix Healthcare Distribution Ltd)
+280411000001102,Ranitidine 300mg tablets (Ranbaxy (UK) Ltd)
+36924411000001102,Ranitidine 300mg tablets (Relonchem Ltd)
+777111000001109,Ranitidine 300mg tablets (Sandoz Ltd)
+15185111000001100,Ranitidine 300mg tablets (Sigma Pharmaceuticals Plc)
+319911000001105,Ranitidine 300mg tablets (Sterwin Medicines)
+425911000001108,Ranitidine 300mg tablets (Teva UK Ltd)
+173411000001102,Ranitidine 300mg tablets (The Boots Company Plc)
+21879811000001106,Ranitidine 300mg tablets (Waymade Healthcare Plc)
+15974911000001108,Ranitidine 300mg tablets (Zanza Specials International Ltd)
+13258211000001102,Ranitidine 300mg tablets (Zentiva)
+13079711000001106,Ranitidine 30mg/5ml oral solution
+13049411000001104,Ranitidine 30mg/5ml oral solution (Special Order)
+13079811000001103,Ranitidine 30mg/5ml oral suspension
+13048911000001104,Ranitidine 30mg/5ml oral suspension (Special Order)
+13079911000001108,Ranitidine 31mg/5ml oral solution
+13050511000001106,Ranitidine 31mg/5ml oral solution (Special Order)
+13080011000001109,Ranitidine 31mg/5ml oral suspension
+13049911000001107,Ranitidine 31mg/5ml oral suspension (Special Order)
+36596011000001103,Ranitidine 37.5mg/5ml oral solution
+36583111000001108,Ranitidine 37.5mg/5ml oral solution (Special Order)
+13080111000001105,Ranitidine 3mg/5ml oral solution
+13051411000001103,Ranitidine 3mg/5ml oral solution (Special Order)
+13080211000001104,Ranitidine 3mg/5ml oral suspension
+13051111000001108,Ranitidine 3mg/5ml oral suspension (Special Order)
+13080311000001107,Ranitidine 40mg/5ml oral solution
+13052611000001106,Ranitidine 40mg/5ml oral solution (Special Order)
+13080411000001100,Ranitidine 40mg/5ml oral suspension
+13052011000001104,Ranitidine 40mg/5ml oral suspension (Special Order)
+13080511000001101,Ranitidine 4mg/5ml oral solution
+13053611000001101,Ranitidine 4mg/5ml oral solution (Special Order)
+13080611000001102,Ranitidine 4mg/5ml oral suspension
+13052911000001100,Ranitidine 4mg/5ml oral suspension (Special Order)
+35933911000001107,Ranitidine 50mg/2ml solution for injection ampoules
+21732711000001108,Ranitidine 50mg/2ml solution for injection ampoules (A A H Pharmaceuticals Ltd)
+9325311000001105,Ranitidine 50mg/2ml solution for injection ampoules (Advanz Pharma)
+32907911000001109,Ranitidine 50mg/2ml solution for injection ampoules (Alliance Healthcare (Distribution) Ltd)
+16163611000001105,Ranitidine 50mg/2ml solution for injection ampoules (Alliance Pharmaceuticals Ltd)
+21506311000001101,Ranitidine 50mg/50ml infusion bags
+21506711000001102,Ranitidine 50mg/50ml infusion bags (Special Order)
+13080711000001106,Ranitidine 50mg/5ml oral solution
+13055011000001109,Ranitidine 50mg/5ml oral solution (Special Order)
+13080811000001103,Ranitidine 50mg/5ml oral suspension
+13054211000001100,Ranitidine 50mg/5ml oral suspension (Special Order)
+13080911000001108,Ranitidine 5mg/5ml oral solution
+13057111000001101,Ranitidine 5mg/5ml oral solution (Drug Tariff Special Order)
+13081011000001100,Ranitidine 5mg/5ml oral suspension
+13055611000001102,Ranitidine 5mg/5ml oral suspension (Drug Tariff Special Order)
+32879611000001107,Ranitidine 6mg/5ml oral solution
+32865711000001105,Ranitidine 6mg/5ml oral solution (Special Order)
+13081111000001104,Ranitidine 70mg/5ml oral solution
+13065911000001102,Ranitidine 70mg/5ml oral solution (Special Order)
+13081211000001105,Ranitidine 70mg/5ml oral suspension
+13057711000001100,Ranitidine 70mg/5ml oral suspension (Special Order)
+408038002,Ranitidine 75mg effervescent tablet
+4389711000001104,Ranitidine 75mg effervescent tablets sugar free
+354011009,Ranitidine 75mg tablets
+22680911000001106,Ranitidine 75mg tablets (A A H Pharmaceuticals Ltd)
+32475911000001105,"Ranitidine 75mg tablets (Bell,Sons & Co (Druggists) Ltd)"
+16065611000001103,Ranitidine 75mg tablets (Bristol Laboratories Ltd)
+22607411000001103,Ranitidine 75mg tablets (Colorama Pharmaceuticals Ltd)
+21843911000001100,Ranitidine 75mg tablets (Cubic Pharmaceuticals Ltd)
+24119611000001102,Ranitidine 75mg tablets (DE Pharmaceuticals)
+26855811000001108,Ranitidine 75mg tablets (Ennogen Healthcare Ltd)
+36879611000001108,Ranitidine 75mg tablets (Flamingo Pharma (UK) Ltd)
+9881511000001105,Ranitidine 75mg tablets (Galpharm International Ltd)
+35995811000001109,Ranitidine 75mg tablets (Herbal Concepts Ltd)
+26400811000001103,Ranitidine 75mg tablets (Icarus Pharmaceuticals Ltd)
+23219711000001106,Ranitidine 75mg tablets (J M McGill Ltd)
+29005411000001107,Ranitidine 75mg tablets (Kent Pharmaceuticals Ltd)
+24578111000001103,Ranitidine 75mg tablets (Mawdsley-Brooks & Company Ltd)
+21413811000001106,Ranitidine 75mg tablets (Medreich Plc)
+22213511000001105,Ranitidine 75mg tablets (MedRx Developments Ltd)
+23960411000001108,Ranitidine 75mg tablets (Niche Pharma Ltd)
+37908711000001105,Ranitidine 75mg tablets (Noumed Life Sciences Ltd)
+10070511000001105,Ranitidine 75mg tablets (Nucare Plc)
+28137711000001107,Ranitidine 75mg tablets (Pharma-z Ltd)
+21266411000001101,Ranitidine 75mg tablets (Sigma Pharmaceuticals Plc)
+15592411000001105,Ranitidine 75mg tablets (Vantage)
+13085011000001103,Ranitidine 75mg/5ml oral solution
+13067311000001106,Ranitidine 75mg/5ml oral solution (Special Order)
+13135301000001104,Ranitidine 75mg/5ml oral solution sugar free
+317248003,Ranitidine 75mg/5ml oral solution sugar free
+926811000001108,Ranitidine 75mg/5ml oral solution sugar free (A A H Pharmaceuticals Ltd)
+15861511000001103,Ranitidine 75mg/5ml oral solution sugar free (Actavis UK Ltd)
+19839711000001105,Ranitidine 75mg/5ml oral solution sugar free (Advanz Pharma)
+549411000001108,Ranitidine 75mg/5ml oral solution sugar free (Alliance Healthcare (Distribution) Ltd)
+17963411000001106,Ranitidine 75mg/5ml oral solution sugar free (Almus Pharmaceuticals Ltd)
+37782511000001108,Ranitidine 75mg/5ml oral solution sugar free (DE Pharmaceuticals)
+10578711000001101,Ranitidine 75mg/5ml oral solution sugar free (Orbis Consumer Products Ltd)
+219911000001101,Ranitidine 75mg/5ml oral solution sugar free (Rosemont Pharmaceuticals Ltd)
+15216311000001107,Ranitidine 75mg/5ml oral solution sugar free (Sigma Pharmaceuticals Plc)
+12610411000001101,Ranitidine 75mg/5ml oral solution sugar free (Teva UK Ltd)
+13085111000001102,Ranitidine 75mg/5ml oral suspension
+13066711000001107,Ranitidine 75mg/5ml oral suspension (Special Order)
+13085311000001100,Ranitidine 8mg/5ml oral solution
+13068911000001108,Ranitidine 8mg/5ml oral solution (Special Order)
+13085211000001108,Ranitidine 8mg/5ml oral suspension
+13068211000001104,Ranitidine 8mg/5ml oral suspension (Special Order)
+317315001,Ranitidine bismuth citrate 400mg tablets
+349800008,Ranitidine in oral dosage form
+349801007,Ranitidine in parenteral dosage form
+688311000001108,Ranitil 150mg tablets (Tillomed Laboratories Ltd)
+728711000001105,Ranitil 300mg tablets (Tillomed Laboratories Ltd)
+692611000001101,Rantec 150 tablets (Teva UK Ltd)
+226711000001104,Rantec 300 tablets (Teva UK Ltd)
+443411000001102,Ranzac 75mg tablets (Boston Healthcare Ltd)
+506211000001106,Tagadine 400mg tablets (Kent Pharmaceuticals Ltd)
+8077311000001102,Tagamet 100 tablets (Accura Health Ltd)
+419211000001109,Tagamet 200mg tablets (Chemidex Pharma Ltd)
+306211000001108,Tagamet 200mg/2ml solution for injection ampoules (GlaxoSmithKline UK Ltd)
+772711000001108,Tagamet 200mg/5ml syrup (Essential Pharma Ltd)
+3075411000001104,Tagamet 400mg effervescent tablets (GlaxoSmithKline UK Ltd)
+496411000001100,Tagamet 400mg tablets (Chemidex Pharma Ltd)
+10468711000001104,Tagamet 400mg tablets (Dowelhurst Ltd)
+317011000001102,Tagamet 800mg tablets (Chemidex Pharma Ltd)
+614311000001100,Ultec 400mg tablets (Teva UK Ltd)
+556811000001101,Ultra Heartburn Relief 10mg tablets (Galpharm International Ltd)
+33664711000001106,Ventra 20mg gastro-resistant capsules (Ethypharm UK Ltd)
+33665211000001103,Ventra 40mg gastro-resistant capsules (Ethypharm UK Ltd)
+18233711000001101,Vimovo 500mg/20mg modified-release tablets (AstraZeneca UK Ltd)
+428511000001109,Vivatak Indigestion Relief 75mg tablets (Lexon (UK) Ltd)
+598711000001103,Zaedoc 150 tablets (Ashbourne Pharmaceuticals Ltd)
+7316211000001108,Zanprol 10mg gastro-resistant tablets (Omega Pharma Ltd)
+278311000001103,Zantac 150mg effervescent tablets (GlaxoSmithKline UK Ltd)
+10464911000001109,Zantac 150mg tablets (Dowelhurst Ltd)
+513011000001106,Zantac 150mg tablets (GlaxoSmithKline UK Ltd)
+5427611000001108,Zantac 150mg tablets (Waymade Healthcare Plc)
+354411000001108,Zantac 150mg/10ml syrup (GlaxoSmithKline UK Ltd)
+830911000001106,Zantac 300mg effervescent tablets (GlaxoSmithKline UK Ltd)
+130911000001100,Zantac 300mg tablets (GlaxoSmithKline UK Ltd)
+342411000001104,Zantac 50mg/2ml solution for injection ampoules (GlaxoSmithKline UK Ltd)
+4372111000001101,Zantac 75 Dissolve tablets (GlaxoSmithKline Consumer Healthcare)
+4372311000001104,Zantac 75 Relief Dissolve tablets (Omega Pharma Ltd)
+843111000001100,Zantac 75 Relief tablets (Omega Pharma Ltd)
+907911000001106,Zantac 75 tablets (Omega Pharma Ltd)
+688111000001106,Zinga 150mg capsules (Ashbourne Pharmaceuticals Ltd)
+45411000001105,Zinga 300mg capsules (Ashbourne Pharmaceuticals Ltd)
+751311000001103,Zita 400mg tablets (LPC Medical (UK) Ltd)
+5603811000001107,Zoton 15mg gastro-resistant capsules (Dowelhurst Ltd)
+5431411000001104,Zoton 15mg gastro-resistant capsules (Waymade Healthcare Plc)
+29411000001106,Zoton 15mg gastro-resistant capsules (Wyeth Pharmaceuticals)
+5604611000001106,Zoton 30mg gastro-resistant capsules (Dowelhurst Ltd)
+5432011000001100,Zoton 30mg gastro-resistant capsules (Waymade Healthcare Plc)
+217611000001102,Zoton 30mg gastro-resistant capsules (Wyeth Pharmaceuticals)
+3261211000001101,Zoton 30mg gastro-resistant granules sachets (Wyeth Pharmaceuticals)
+13996811000001105,Zoton FasTab 15mg (DE Pharmaceuticals)
+17482911000001105,Zoton FasTab 15mg (Mawdsley-Brooks & Company Ltd)
+4040911000001100,Zoton FasTab 15mg (Pfizer Ltd)
+17598911000001103,Zoton FasTab 15mg (Sigma Pharmaceuticals Plc)
+16204011000001104,Zoton FasTab 15mg (Waymade Healthcare Plc)
+13997011000001101,Zoton FasTab 30mg (DE Pharmaceuticals)
+18176911000001105,Zoton FasTab 30mg (Mawdsley-Brooks & Company Ltd)
+4041711000001105,Zoton FasTab 30mg (Pfizer Ltd)
+14190811000001109,Zoton FasTab 30mg (Waymade Healthcare Plc)


### PR DESCRIPTION
This PR attempts to recreate [the cohort-extractor-v1 med safety study][1] within Data Builder. As with previous translation studies, most of the missing functionality relates to practice IDs and arithmetic on instances of `BoolSeries`. However, I was also unclear about hospital admissions.

As a small aside, there is some behaviour I can't fathom:

https://github.com/opensafely-core/databuilder/blob/072ebe679da64929f9ddf4670c46d9d0b1f91530/tests/acceptance/test_med_safety_dsl.py#L111-L115

[1]: https://github.com/opensafely/med-safety-PoC/blob/main/analysis/study_definition_ce1.py