### PR TITLE
Add Universal/Patients Contract

### DIFF
--- a/databuilder/backends/base.py
+++ b/databuilder/backends/base.py
@@ -108,10 +108,11 @@ class MappedTable(SQLTable):
 
 
 class QueryTable(SQLTable):
-    def __init__(self, query, columns, implements):
+    def __init__(self, query, columns, implements, implementation_notes=None):
         self.query = query
         self.columns = columns
         self.implements = implements
+        self.implementation_notes = implementation_notes or {}
 
     def learn_patient_join(self, source):
         if "patient_id" not in self.columns:

--- a/databuilder/backends/tpp.py
+++ b/databuilder/backends/tpp.py
@@ -1,6 +1,7 @@
-from ..contracts import contracts
+from ..contracts import contracts as old_contracts
+from ..contracts import universal
 from ..query_engines.mssql import MssqlQueryEngine
-from .base import BaseBackend, Column, MappedTable, QueryTable
+from .base import BaseBackend, Column, QueryTable
 
 
 def rtrim(ref, char):
@@ -72,24 +73,18 @@ class TPPBackend(BaseBackend):
     query_engine_class = MssqlQueryEngine
     patient_join_column = "Patient_ID"
 
-    patients = MappedTable(
-        implements=contracts.WIP_SimplePatientDemographics,
-        source="Patient",
-        columns=dict(
-            sex=Column("varchar", source="Sex"),
-            date_of_birth=Column("date", source="DateOfBirth"),
-        ),
-    )
-
-    patient_demographics = QueryTable(
-        implements=contracts.PatientDemographics,
+    patients = QueryTable(
+        implements=universal.Patients,
         columns=dict(
             sex=Column("varchar"),
             date_of_birth=Column("date"),
             date_of_death=Column("date"),
         ),
+        implementation_notes=dict(
+            sex="Sex assigned at birth.",
+        ),
         query="""
-            SELECT  Patient_ID as patient_id,
+            SELECT Patient_ID as patient_id,
                 DateOfBirth as date_of_birth,
                 CASE
                     WHEN DateOfDeath = '9999-12-31' THEN NULL
@@ -107,7 +102,7 @@ class TPPBackend(BaseBackend):
     )
 
     clinical_events = QueryTable(
-        implements=contracts.WIP_ClinicalEvents,
+        implements=old_contracts.WIP_ClinicalEvents,
         columns=dict(
             code=Column("varchar"),
             system=Column("varchar"),
@@ -122,7 +117,7 @@ class TPPBackend(BaseBackend):
     )
 
     practice_registrations = QueryTable(
-        implements=contracts.WIP_PracticeRegistrations,
+        implements=old_contracts.WIP_PracticeRegistrations,
         columns=dict(
             pseudo_id=Column("integer"),
             nuts1_region_name=Column("varchar"),
@@ -141,7 +136,7 @@ class TPPBackend(BaseBackend):
     )
 
     covid_test_results = QueryTable(
-        implements=contracts.WIP_CovidTestResults,
+        implements=old_contracts.WIP_CovidTestResults,
         columns=dict(
             date=Column("date"),
             positive_result=Column("boolean"),
@@ -154,7 +149,7 @@ class TPPBackend(BaseBackend):
     )
 
     hospitalizations = QueryTable(
-        implements=contracts.WIP_Hospitalizations,
+        implements=old_contracts.WIP_Hospitalizations,
         columns=dict(
             date=Column("date"),
             code=Column("varchar"),
@@ -171,7 +166,7 @@ class TPPBackend(BaseBackend):
     )
 
     patient_address = QueryTable(
-        implements=contracts.WIP_PatientAddress,
+        implements=old_contracts.WIP_PatientAddress,
         columns=dict(
             patientaddress_id=Column("integer"),
             date_start=Column("date"),

--- a/databuilder/contracts/base.py
+++ b/databuilder/contracts/base.py
@@ -1,16 +1,37 @@
 import dataclasses
 
-from .constraints import BaseConstraint, ChoiceConstraint
+from . import types
+from .constraints import (
+    BaseConstraint,
+    ChoiceConstraint,
+    NotNullConstraint,
+    UniqueConstraint,
+)
 from .types import BaseType, Choice
 
 
 @dataclasses.dataclass
 class Column:
-
     type: BaseType  # noqa: A003
     description: str = ""
-    help: str = ""  # noqa: A003
+    notes_for_implementors: str = ""
+    implementation_notes_to_add_to_description: str = ""
     constraints: list[BaseConstraint] = dataclasses.field(default_factory=list)
+    required: bool = True
+
+    # TODO: remove when all old contracts have gone away
+    help: str = ""  # noqa: A003
+
+
+# many contracts need this column so lets just define it once.
+PatientIDColumn = Column(
+    type=types.PseudoPatientId(),
+    description=(
+        "Patient's pseudonymous identifier, for linkage."
+        "This will not normally be output, or operated on by researchers."
+    ),
+    constraints=[NotNullConstraint(), UniqueConstraint()],
+)
 
 
 class BackendContractError(Exception):

--- a/databuilder/contracts/base.py
+++ b/databuilder/contracts/base.py
@@ -19,9 +19,6 @@ class Column:
     constraints: list[BaseConstraint] = dataclasses.field(default_factory=list)
     required: bool = True
 
-    # TODO: remove when all old contracts have gone away
-    help: str = ""  # noqa: A003
-
 
 # many contracts need this column so lets just define it once.
 PatientIDColumn = Column(

--- a/databuilder/contracts/contracts.py
+++ b/databuilder/contracts/contracts.py
@@ -14,29 +14,21 @@ class PatientDemographics(TableContract):
             "Patient's pseudonymous identifier, for linkage. You should not normally "
             "output or operate on this column"
         ),
-        help="",
         constraints=[NotNullConstraint(), UniqueConstraint()],
     )
     date_of_birth = Column(
         type=types.Date(),
         description="Patient's year and month of birth, provided in format YYYY-MM-01.",
-        help="The day will always be the first of the month. Must be present.",
         constraints=[NotNullConstraint(), FirstOfMonthConstraint()],
     )
     sex = Column(
         type=types.Choice("female", "male", "intersex", "unknown"),
         description="Patient's sex.",
-        help=(
-            "One of male, female, intersex or unknown (the last covers all other options,"
-            "including but not limited to 'rather not say' and empty/missing values). "
-            "Must be present."
-        ),
         constraints=[NotNullConstraint()],
     )
     date_of_death = Column(
         type=types.Date(),
         description="Patient's year and month of death, provided in format YYYY-MM-01.",
-        help="The day will always be the first of the month.",
         constraints=[FirstOfMonthConstraint()],
     )
 
@@ -54,31 +46,26 @@ class WIP_ClinicalEvents(TableContract):
     patient_id = Column(
         type=types.PseudoPatientId(),
         description="",
-        help="",
         constraints=[],
     )
     code = Column(
         type=types.Code(),
         description="",
-        help="",
         constraints=[],
     )
     system = Column(
         type=types.String(),
         description="",
-        help="",
         constraints=[],
     )
     date = Column(
         type=types.Date(),
         description="",
-        help="",
         constraints=[],
     )
     numeric_value = Column(
         type=types.Float(),
         description="",
-        help="",
         constraints=[],
     )
 
@@ -91,37 +78,31 @@ class WIP_HospitalAdmissions(TableContract):
     patient_id = Column(
         type=types.PseudoPatientId(),
         description="",
-        help="",
         constraints=[],
     )
     admission_date = Column(
         type=types.Date(),
         description="",
-        help="",
         constraints=[],
     )
     primary_diagnosis = Column(
         type=types.Code(),
         description="",
-        help="",
         constraints=[],
     )
     admission_method = Column(
         type=types.Integer(),
         description="",
-        help="",
         constraints=[],
     )
     episode_is_finished = Column(
         type=types.Boolean(),
         description="",
-        help="",
         constraints=[],
     )
     spell_id = Column(
         type=types.Integer(),
         description="",
-        help="",
         constraints=[],
     )
 
@@ -134,25 +115,21 @@ class WIP_Hospitalizations(TableContract):
     patient_id = Column(
         type=types.PseudoPatientId(),
         description="",
-        help="",
         constraints=[],
     )
     date = Column(
         type=types.Date(),
         description="",
-        help="",
         constraints=[],
     )
     code = Column(
         type=types.Code(),
         description="",
-        help="",
         constraints=[],
     )
     system = Column(
         type=types.String(),
         description="",
-        help="",
         constraints=[],
     )
 
@@ -165,13 +142,11 @@ class WIP_HospitalizationsWithoutSystem(TableContract):
     patient_id = Column(
         type=types.PseudoPatientId(),
         description="",
-        help="",
         constraints=[],
     )
     code = Column(
         type=types.Code(),
         description="",
-        help="",
         constraints=[],
     )
 
@@ -184,37 +159,31 @@ class WIP_PatientAddress(TableContract):
     patient_id = Column(
         type=types.PseudoPatientId(),
         description="",
-        help="",
         constraints=[],
     )
     patientaddress_id = Column(
         type=types.Integer(),
         description="",
-        help="",
         constraints=[],
     )
     date_start = Column(
         type=types.Date(),
         description="",
-        help="",
         constraints=[],
     )
     date_end = Column(
         type=types.Date(),
         description="",
-        help="",
         constraints=[],
     )
     index_of_multiple_deprivation_rounded = Column(
         type=types.Integer(),
         description="",
-        help="",
         constraints=[],
     )
     has_postcode = Column(
         type=types.Boolean(),
         description="",
-        help="",
         constraints=[],
     )
 
@@ -227,31 +196,26 @@ class WIP_PracticeRegistrations(TableContract):
     patient_id = Column(
         type=types.PseudoPatientId(),
         description="",
-        help="",
         constraints=[],
     )
     pseudo_id = Column(
         type=types.Integer(),
         description="",
-        help="",
         constraints=[],
     )
     nuts1_region_name = Column(
         type=types.String(),
         description="",
-        help="",
         constraints=[],
     )
     date_start = Column(
         type=types.Date(),
         description="",
-        help="",
         constraints=[],
     )
     date_end = Column(
         type=types.Date(),
         description="",
-        help="",
         constraints=[],
     )
 
@@ -264,19 +228,16 @@ class WIP_Prescriptions(TableContract):
     patient_id = Column(
         type=types.PseudoPatientId(),
         description="",
-        help="",
         constraints=[],
     )
     prescribed_dmd_code = Column(
         type=types.Code(),
         description="",
-        help="",
         constraints=[],
     )
     processing_date = Column(
         type=types.Date(),
         description="",
-        help="",
         constraints=[],
     )
 
@@ -289,19 +250,16 @@ class WIP_CovidTestResults(TableContract):
     patient_id = Column(
         type=types.PseudoPatientId(),
         description="",
-        help="",
         constraints=[],
     )
     date = Column(
         type=types.Date(),
         description="",
-        help="",
         constraints=[],
     )
     positive_result = Column(
         type=types.Boolean(),
         description="",
-        help="",
         constraints=[],
     )
 
@@ -314,12 +272,10 @@ class WIP_SimplePatientDemographics(TableContract):
     patient_id = Column(
         type=types.PseudoPatientId(),
         description="",
-        help="",
         constraints=[UniqueConstraint()],
     )
     date_of_birth = Column(
         type=types.Date(),
         description="",
-        help="",
         constraints=[],
     )

--- a/databuilder/contracts/universal.py
+++ b/databuilder/contracts/universal.py
@@ -1,0 +1,33 @@
+from . import types
+from .base import Column, PatientIDColumn, TableContract
+from .constraints import FirstOfMonthConstraint, NotNullConstraint
+
+
+class Patients(TableContract):
+    _name = "patients"
+
+    patient_id = PatientIDColumn
+    date_of_birth = Column(
+        type=types.Date(),
+        description=(
+            "Patient's year and month of birth, provided in format YYYY-MM-01. "
+            "The day will always be the first of the month."
+        ),
+        constraints=[FirstOfMonthConstraint(), NotNullConstraint()],
+    )
+    sex = Column(
+        type=types.Choice("female", "male", "intersex", "unknown"),
+        description="Patient's sex as defined by the options: male, female, intersex, unknown.",
+        implementation_notes_to_add_to_description=(
+            'Specify how this has been determined, e.g. "sex at birth", or "current sex".'
+        ),
+        constraints=[NotNullConstraint()],
+    )
+    date_of_death = Column(
+        type=types.Date(),
+        description=(
+            "Patient's year and month of death, provided in format YYYY-MM-01."
+            "The day will always be the first of the month."
+        ),
+        constraints=[NotNullConstraint()],
+    )

--- a/tests/acceptance/test_full_long_covid_study.py
+++ b/tests/acceptance/test_full_long_covid_study.py
@@ -205,7 +205,7 @@ def test_cohort(database):
     assert extract(Cohort, TPPBackend, database) == [
         dict(
             patient_id=1,
-            sex="F",
+            sex="female",
             age_group="25-34",
             practice_id=1,
             region="South",

--- a/tests/backends/test_tpp.py
+++ b/tests/backends/test_tpp.py
@@ -115,7 +115,7 @@ def test_patients_table(database):
         dob = _patients.get("date_of_birth")
 
     assert extract(Cohort, TPPBackend, database) == [
-        dict(patient_id=1, sex="F", dob=date(1950, 1, 1))
+        dict(patient_id=1, sex="female", dob=date(1950, 1, 1))
     ]
 
 
@@ -418,7 +418,7 @@ def test_patients_contract_table(database):
         patient(5, "X", "1990-01-01"),
     )
 
-    query = TPPBackend.patient_demographics.get_query()
+    query = TPPBackend.patients.get_query()
 
     results = list(run_query(database, query))
     assert results == [


### PR DESCRIPTION
This adds the Universal/Patients contract, and implements it in TPP.

I've left `WIP_SimplePatientDemographics` alone since DatabricksBackend still uses it.