### PR TITLE
Run test and check CI jobs in parallel

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,6 @@ jobs:
         run: just check
 
   test:
-    needs: [check]
     runs-on: ubuntu-latest
 
     steps:
@@ -53,7 +52,7 @@ jobs:
     # BREAKING CHANGE in footer -> major release
     #
     # anything else (docs, refactor, etc) does not create a release
-    needs: [test]
+    needs: [check, test]
     runs-on: ubuntu-latest
     outputs:
       tag: ${{ steps.tag.outputs.new_version }}


### PR DESCRIPTION
Check was originally a dependency of test to catch obvious linting
errors up front, but if one is waiting on tests to run then you pay
nearly 1m of time for check to run, and that seems unnecessary.