### PR TITLE
doc: Specify image version in Docker command

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,7 @@ as described in the [documentation](https://docs.opensafely.org/getting-started/
 If running it directly, it should be run from within the research repository.
 To run the latest version via Docker and access its full help:
 
-    docker run --rm ghcr.io/opensafely-core/databuilder --help
-
+    docker run --rm ghcr.io/opensafely-core/databuilder:v0 --help
 
 # For developers
 


### PR DESCRIPTION
We deliberately don't have a `latest` tag for the `databuilder` image.
Without a tag, Docker will try and fetch `latest`, which doesn't exist,
so the command as written will error.