### PR TITLE
Rename Terms in CLI

### DIFF
--- a/databuilder/__main__.py
+++ b/databuilder/__main__.py
@@ -24,7 +24,7 @@ def main(args=None):
 
     options = parser.parse_args(args)
 
-    if options.which == "generate_cohort":
+    if options.which == "generate_dataset":
         if not (options.dummy_data_file or os.environ.get("DATABASE_URL")):
             parser.error(
                 "error: either --dummy-data-file or DATABASE_URL environment variable is required"
@@ -72,21 +72,21 @@ def build_parser():
     parser.set_defaults(which="print_help")
     subparsers = parser.add_subparsers(help="sub-command help")
 
-    generate_cohort_parser = subparsers.add_parser(
-        "generate_cohort", help="Generate a dataset"
+    generate_dataset_parser = subparsers.add_parser(
+        "generate_dataset", help="Generate a dataset"
     )
-    generate_cohort_parser.set_defaults(which="generate_cohort")
-    generate_cohort_parser.add_argument(
+    generate_dataset_parser.set_defaults(which="generate_dataset")
+    generate_dataset_parser.add_argument(
         "--cohort-definition",
         help="The path of the file where the cohort is defined",
         type=existing_python_file,
     )
-    generate_cohort_parser.add_argument(
+    generate_dataset_parser.add_argument(
         "--output",
         help="Path and filename (or pattern) of the file(s) where the output will be written",
         type=Path,
     )
-    generate_cohort_parser.add_argument(
+    generate_dataset_parser.add_argument(
         "--dummy-data-file",
         help="Provide dummy data from a file to be validated and used as output",
         type=Path,

--- a/databuilder/__main__.py
+++ b/databuilder/__main__.py
@@ -32,8 +32,8 @@ def main(args=None):
 
         run_cohort_action(
             generate_cohort,
-            definition_path=options.cohort_definition,
-            output_file=options.output,
+            definition_path=options.dataset_definition,
+            output_file=options.dataset,
             db_url=os.environ.get("DATABASE_URL"),
             backend_id=os.environ.get("OPENSAFELY_BACKEND"),
             dummy_data_file=options.dummy_data_file,
@@ -77,13 +77,13 @@ def build_parser():
     )
     generate_dataset_parser.set_defaults(which="generate_dataset")
     generate_dataset_parser.add_argument(
-        "--cohort-definition",
-        help="The path of the file where the cohort is defined",
+        "--dataset-definition",
+        help="The path of the file where the dataset is defined",
         type=existing_python_file,
     )
     generate_dataset_parser.add_argument(
-        "--output",
-        help="Path and filename (or pattern) of the file(s) where the output will be written",
+        "--dataset",
+        help="Path and filename (or pattern) of the file(s) where the dataset will be written",
         type=Path,
     )
     generate_dataset_parser.add_argument(

--- a/databuilder/__main__.py
+++ b/databuilder/__main__.py
@@ -48,9 +48,9 @@ def main(args=None):
         )
     elif options.which == "generate_measures":
         generate_measures(
-            definition_path=options.cohort_definition,
+            definition_path=options.dataset_definition,
             input_file=options.input,
-            output_file=options.output,
+            output_file=options.dataset,
         )
     elif options.which == "test_connection":
         test_connection(
@@ -126,13 +126,13 @@ def build_parser():
         type=Path,
     )
     generate_measures_parser.add_argument(
-        "--output",
-        help="Path and filename (or pattern) of the file(s) where the output will be written",
+        "--dataset",
+        help="Path and filename (or pattern) of the file(s) where the dataset will be written",
         type=Path,
     )
     generate_measures_parser.add_argument(
-        "--cohort-definition",
-        help="The path of the file where the cohort is defined",
+        "--dataset-definition",
+        help="The path of the file where the dataset is defined",
         type=existing_python_file,
     )
 

--- a/databuilder/__main__.py
+++ b/databuilder/__main__.py
@@ -42,8 +42,8 @@ def main(args=None):
     elif options.which == "validate_dataset_definition":
         run_cohort_action(
             validate_cohort,
-            definition_path=options.cohort_definition,
-            output_file=options.output,
+            definition_path=options.dataset_definition,
+            output_file=options.dataset,
             backend_id=options.backend,
         )
     elif options.which == "generate_measures":
@@ -104,13 +104,13 @@ def build_parser():
         choices=BACKENDS,  # allow all registered backend subclasses
     )
     validate_dataset_definition_parser.add_argument(
-        "--cohort-definition",
-        help="The path of the file where the cohort is defined",
+        "--dataset-definition",
+        help="The path of the file where the dataset is defined",
         type=existing_python_file,
     )
     validate_dataset_definition_parser.add_argument(
-        "--output",
-        help="Path and filename (or pattern) of the file(s) where the output will be written",
+        "--dataset",
+        help="Path and filename (or pattern) of the file(s) where the dataset will be written",
         type=Path,
     )
 

--- a/databuilder/__main__.py
+++ b/databuilder/__main__.py
@@ -73,7 +73,7 @@ def build_parser():
     subparsers = parser.add_subparsers(help="sub-command help")
 
     generate_cohort_parser = subparsers.add_parser(
-        "generate_cohort", help="Generate cohort"
+        "generate_cohort", help="Generate a dataset"
     )
     generate_cohort_parser.set_defaults(which="generate_cohort")
     generate_cohort_parser.add_argument(
@@ -94,7 +94,7 @@ def build_parser():
 
     validate_cohort_parser = subparsers.add_parser(
         "validate_cohort",
-        help="Validate the cohort definition against the specified backend",
+        help="Validate the dataset definition against the specified backend",
     )
     validate_cohort_parser.set_defaults(which="validate_cohort")
 
@@ -115,7 +115,7 @@ def build_parser():
     )
 
     generate_measures_parser = subparsers.add_parser(
-        "generate_measures", help="Generate measures from cohort data"
+        "generate_measures", help="Generate measures from a dataset"
     )
     generate_measures_parser.set_defaults(which="generate_measures")
 

--- a/databuilder/__main__.py
+++ b/databuilder/__main__.py
@@ -39,7 +39,7 @@ def main(args=None):
             dummy_data_file=options.dummy_data_file,
             temporary_database=os.environ.get("TEMP_DATABASE_NAME"),
         )
-    elif options.which == "validate_cohort":
+    elif options.which == "validate_dataset_definition":
         run_cohort_action(
             validate_cohort,
             definition_path=options.cohort_definition,
@@ -92,23 +92,23 @@ def build_parser():
         type=Path,
     )
 
-    validate_cohort_parser = subparsers.add_parser(
-        "validate_cohort",
+    validate_dataset_definition_parser = subparsers.add_parser(
+        "validate_dataset_definition",
         help="Validate the dataset definition against the specified backend",
     )
-    validate_cohort_parser.set_defaults(which="validate_cohort")
+    validate_dataset_definition_parser.set_defaults(which="validate_dataset_definition")
 
-    validate_cohort_parser.add_argument(
+    validate_dataset_definition_parser.add_argument(
         "backend",
         type=str,
         choices=BACKENDS,  # allow all registered backend subclasses
     )
-    validate_cohort_parser.add_argument(
+    validate_dataset_definition_parser.add_argument(
         "--cohort-definition",
         help="The path of the file where the cohort is defined",
         type=existing_python_file,
     )
-    validate_cohort_parser.add_argument(
+    validate_dataset_definition_parser.add_argument(
         "--output",
         help="Path and filename (or pattern) of the file(s) where the output will be written",
         type=Path,

--- a/tests/end_to_end/conftest.py
+++ b/tests/end_to_end/conftest.py
@@ -38,9 +38,9 @@ def cohort_extractor_in_container(tmpdir, database, containers):
 
         command = [
             "generate_dataset",
-            "--cohort-definition",
+            "--dataset-definition",
             str(definition_path),
-            "--output",
+            "--dataset",
             str(output_rel_dir / study.output_file_name),
         ]
         if use_dummy_data:

--- a/tests/end_to_end/conftest.py
+++ b/tests/end_to_end/conftest.py
@@ -37,7 +37,7 @@ def cohort_extractor_in_container(tmpdir, database, containers):
         definition_path = Path("analysis") / study.definition().name
 
         command = [
-            "generate_cohort",
+            "generate_dataset",
             "--cohort-definition",
             str(definition_path),
             "--output",

--- a/tests/end_to_end/conftest.py
+++ b/tests/end_to_end/conftest.py
@@ -81,11 +81,11 @@ def cohort_extractor_generate_measures_in_container(tmpdir, database, containers
 
         command = [
             "generate_measures",
-            "--cohort-definition",
+            "--dataset-definition",
             str(definition_path),
             "--input",
             str(input_path),
-            "--output",
+            "--dataset",
             str(output_rel_path),
         ]
 

--- a/tests/test___main__.py
+++ b/tests/test___main__.py
@@ -76,13 +76,13 @@ def test_generate_docs(mocker):
     patched.assert_called_once()
 
 
-def test_validate_cohort(mocker, tmp_path):
-    # Verify that the validate_cohort subcommand can be invoked.
+def test_validate_dataset_definition(mocker, tmp_path):
+    # Verify that the validate_dataset_definition subcommand can be invoked.
     patched = mocker.patch("databuilder.__main__.run_cohort_action")
     cohort_definition_path = tmp_path / "cohort.py"
     cohort_definition_path.touch()
     argv = [
-        "validate_cohort",
+        "validate_dataset_definition",
         "--cohort-definition",
         str(cohort_definition_path),
         "tpp",

--- a/tests/test___main__.py
+++ b/tests/test___main__.py
@@ -83,7 +83,7 @@ def test_validate_dataset_definition(mocker, tmp_path):
     cohort_definition_path.touch()
     argv = [
         "validate_dataset_definition",
-        "--cohort-definition",
+        "--dataset-definition",
         str(cohort_definition_path),
         "tpp",
     ]

--- a/tests/test___main__.py
+++ b/tests/test___main__.py
@@ -10,15 +10,15 @@ def test_no_args(capsys):
     assert "usage: databuilder" in captured.out
 
 
-def test_generate_cohort_with_database_url(mocker, monkeypatch, tmp_path):
-    # Verify that the generate_cohort subcommand can be invoked when DATABASE_URL is
-    # set.
+def test_generate_dataset_with_database_url(mocker, monkeypatch, tmp_path):
+    # Verify that the generate_dataset subcommand can be invoked when
+    # DATABASE_URL is set.
     patched = mocker.patch("databuilder.__main__.run_cohort_action")
     monkeypatch.setenv("DATABASE_URL", "scheme:path")
     cohort_definition_path = tmp_path / "cohort.py"
     cohort_definition_path.touch()
     argv = [
-        "generate_cohort",
+        "generate_dataset",
         "--cohort-definition",
         str(cohort_definition_path),
     ]
@@ -26,16 +26,16 @@ def test_generate_cohort_with_database_url(mocker, monkeypatch, tmp_path):
     patched.assert_called_once()
 
 
-def test_generate_cohort_with_dummy_data(mocker, tmp_path):
-    # Verify that the generate_cohort subcommand can be invoked when --dummy-data-file
-    # is provided.
+def test_generate_dataset_with_dummy_data(mocker, tmp_path):
+    # Verify that the generate_dataset subcommand can be invoked when
+    # --dummy-data-file is provided.
     patched = mocker.patch("databuilder.__main__.run_cohort_action")
     cohort_definition_path = tmp_path / "cohort.py"
     cohort_definition_path.touch()
     dummy_data_path = tmp_path / "dummy-data.csv"
     dummy_data_path.touch()
     argv = [
-        "generate_cohort",
+        "generate_dataset",
         "--cohort-definition",
         str(cohort_definition_path),
         "--dummy-data-file",
@@ -45,13 +45,14 @@ def test_generate_cohort_with_dummy_data(mocker, tmp_path):
     patched.assert_called_once()
 
 
-def test_generate_cohort_without_database_url_or_dummy_data(capsys, tmp_path):
-    # Verify that a helpful message is shown when the generate_cohort subcommand is
-    # invoked but DATABASE_URL is not set and --dummy-data-file is not provided.
+def test_generate_dataset_without_database_url_or_dummy_data(capsys, tmp_path):
+    # Verify that a helpful message is shown when the generate_dataset
+    # subcommand is invoked but DATABASE_URL is not set and --dummy-data-file
+    # is not provided.
     cohort_definition_path = tmp_path / "cohort.py"
     cohort_definition_path.touch()
     argv = [
-        "generate_cohort",
+        "generate_dataset",
         "--cohort-definition",
         str(cohort_definition_path),
     ]
@@ -109,7 +110,7 @@ def test_existing_python_file_missing_file(capsys, tmp_path):
     # file that should exist but doesn't.
     cohort_definition_path = tmp_path / "cohort.py"
     argv = [
-        "generate_cohort",
+        "generate_dataset",
         "--cohort-definition",
         str(cohort_definition_path),
     ]
@@ -125,7 +126,7 @@ def test_existing_python_file_unpythonic_file(capsys, tmp_path):
     cohort_definition_path = tmp_path / "cohort.cpp"
     cohort_definition_path.touch()
     argv = [
-        "generate_cohort",
+        "generate_dataset",
         "--cohort-definition",
         str(cohort_definition_path),
     ]

--- a/tests/test___main__.py
+++ b/tests/test___main__.py
@@ -19,7 +19,7 @@ def test_generate_dataset_with_database_url(mocker, monkeypatch, tmp_path):
     cohort_definition_path.touch()
     argv = [
         "generate_dataset",
-        "--cohort-definition",
+        "--dataset-definition",
         str(cohort_definition_path),
     ]
     main(argv)
@@ -36,7 +36,7 @@ def test_generate_dataset_with_dummy_data(mocker, tmp_path):
     dummy_data_path.touch()
     argv = [
         "generate_dataset",
-        "--cohort-definition",
+        "--dataset-definition",
         str(cohort_definition_path),
         "--dummy-data-file",
         str(dummy_data_path),
@@ -53,7 +53,7 @@ def test_generate_dataset_without_database_url_or_dummy_data(capsys, tmp_path):
     cohort_definition_path.touch()
     argv = [
         "generate_dataset",
-        "--cohort-definition",
+        "--dataset-definition",
         str(cohort_definition_path),
     ]
     with pytest.raises(SystemExit):
@@ -111,7 +111,7 @@ def test_existing_python_file_missing_file(capsys, tmp_path):
     cohort_definition_path = tmp_path / "cohort.py"
     argv = [
         "generate_dataset",
-        "--cohort-definition",
+        "--dataset-definition",
         str(cohort_definition_path),
     ]
     with pytest.raises(SystemExit):
@@ -127,7 +127,7 @@ def test_existing_python_file_unpythonic_file(capsys, tmp_path):
     cohort_definition_path.touch()
     argv = [
         "generate_dataset",
-        "--cohort-definition",
+        "--dataset-definition",
         str(cohort_definition_path),
     ]
     with pytest.raises(SystemExit):

--- a/tests/test___main__.py
+++ b/tests/test___main__.py
@@ -98,7 +98,7 @@ def test_generate_measures(mocker, tmp_path):
     cohort_definition_path.touch()
     argv = [
         "generate_measures",
-        "--cohort-definition",
+        "--dataset-definition",
         str(cohort_definition_path),
     ]
     main(argv)


### PR DESCRIPTION
This removes the use of `cohort` and `output` in the CLI commands and help text.