### PR TITLE
Add type validation to Query Model

### DIFF
--- a/databuilder/query_engines/query_model_convert_to_old.py
+++ b/databuilder/query_engines/query_model_convert_to_old.py
@@ -182,7 +182,11 @@ def convert_categorise(node: new.Categorise):
         convert_value(key): convert_node(value)
         for key, value in node.categories.items()
     }
-    return old.ValueFromCategory(definitions, convert_value(node.default))
+    if node.default is not None:
+        default = convert_value(node.default)
+    else:
+        default = None
+    return old.ValueFromCategory(definitions, default)
 
 
 def convert_function(node):

--- a/databuilder/query_model.py
+++ b/databuilder/query_model.py
@@ -1,4 +1,5 @@
 import dataclasses
+from collections.abc import Mapping, Set
 from datetime import date
 from enum import Enum
 from functools import singledispatch
@@ -198,7 +199,7 @@ class AggregateByPatient:
     # produces is a set-like object containing all of its input values. This enables
     # them to be used as arguments to the In/NotIn fuctions which require something
     # set-like as their RHS argument.
-    class CombineAsSet(OneRowPerPatientSeries[set[T]]):
+    class CombineAsSet(OneRowPerPatientSeries[Set[T]]):
         source: Series[T]
 
 
@@ -288,11 +289,11 @@ class Function:
     # use the `CombineAsSet` aggregation.
     class In(Series[bool]):
         lhs: Series[T]
-        rhs: Series[set[T]]
+        rhs: Series[Set[T]]
 
 
 class Categorise(Series[T]):
-    categories: dict[Series[T], Series[bool]]
+    categories: Mapping[Series[T], Series[bool]]
     default: Series[T]
 
     def __hash__(self):

--- a/databuilder/query_model.py
+++ b/databuilder/query_model.py
@@ -294,7 +294,7 @@ class Function:
 
 class Categorise(Series[T]):
     categories: Mapping[Series[T], Series[bool]]
-    default: Series[T]
+    default: Series[Optional[T]]
 
     def __hash__(self):
         # `categories` is a dict and so not hashable by default, but we treat it as

--- a/databuilder/query_model.py
+++ b/databuilder/query_model.py
@@ -47,7 +47,7 @@ class Position(Enum):
     FIRST = "first"
     LAST = "last"
 
-    def __repr__(self):  # pragma: no cover
+    def __repr__(self):
         # Gives us `self == eval(repr(self))` as for dataclasses
         return f"{self.__class__.__name__}.{self.name}"
 

--- a/databuilder/query_model.py
+++ b/databuilder/query_model.py
@@ -301,7 +301,7 @@ class Function:
 
 class Categorise(Series[T]):
     categories: Mapping[Series[T], Series[bool]]
-    default: Series[Optional[T]]
+    default: Optional[Series[T]]
 
     def __hash__(self):
         # `categories` is a dict and so not hashable by default, but we treat it as
@@ -546,4 +546,7 @@ def get_input_nodes(node):
 # nested inside a dict object
 @get_input_nodes.register(Categorise)
 def get_input_nodes_for_categorise(node):
-    return [*node.categories.keys(), *node.categories.values(), node.default]
+    inputs = [*node.categories.keys(), *node.categories.values()]
+    if node.default is not None:
+        inputs.append(node.default)
+    return inputs

--- a/databuilder/query_model.py
+++ b/databuilder/query_model.py
@@ -387,4 +387,4 @@ def get_input_nodes(node):
 # nested inside a dict object
 @get_input_nodes.register(Categorise)
 def get_input_nodes_for_categorise(node):
-    return node.categories.values()
+    return [*node.categories.keys(), *node.categories.values(), node.default]

--- a/databuilder/query_model.py
+++ b/databuilder/query_model.py
@@ -1,14 +1,17 @@
 import dataclasses
+import typing
 from collections.abc import Mapping, Set
 from datetime import date
 from enum import Enum
-from functools import singledispatch
-from typing import Any, Optional, TypeVar
+from functools import cache, singledispatch
+from typing import Any, GenericAlias, Optional, TypeVar
+
+from .typing_utils import get_typespec, get_typevars, type_matches
 
 # mypy: ignore-errors
 
 
-# The below classes are the public API surface of the query model
+# The below classes and methods are the public API surface of the query model
 __all__ = [
     "SelectTable",
     "SelectPatientTable",
@@ -23,6 +26,8 @@ __all__ = [
     "TableSchema",
     "Code",
     "DomainMismatchError",
+    "has_one_row_per_patient",
+    "get_series_type",
 ]
 
 
@@ -100,12 +105,14 @@ class Frame(Node):
 
 
 class Series(Node):
+    # Series have an "inner" type denoting the type of value they contain e.g
+    # `Series[int]`. The below method generates generic aliases for these types when
+    # they are referenced. We cache them so that multiple references always return the
+    # same type object.
+    @classmethod
+    @cache
     def __class_getitem__(cls, type_):
-        # Series have an "inner" type denoting the type of value they contain e.g
-        # `Series[int]`. This is the method which makes that syntax work. At the moment
-        # we don't do anything with this type, we just return the original class
-        # unmodified. Later we will handle this properly and validate the types.
-        return cls
+        return GenericAlias(cls, (type_,))
 
 
 class OneRowPerPatientFrame(Frame):
@@ -313,6 +320,22 @@ class Categorise(Series[T]):
 #     rhs: Frame
 
 
+# PUBLIC HELPER FUNCTIONS
+#
+
+
+def has_one_row_per_patient(node):
+    "Return whether a Frame or Series has at most one row per patient"
+    return get_domains(node) == {PATIENT_DOMAIN}
+
+
+def get_series_type(series):
+    "Return the type contained within a Series"
+    assert isinstance(series, Series)
+    typespec = get_typespec(series)
+    return typing.get_args(typespec)[0]
+
+
 # VALIDATION
 #
 
@@ -324,23 +347,45 @@ class DomainMismatchError(Exception):
 
 
 def validate_node(node):
-    # TODO: Runtime type validation (i.e. only acceptable types are passed in), possibly
-    # using something like pydantic.
-
-    # TODO: Validation of the "inner" types i.e. a series may contain date values and we
-    # want to make it an error if you try to compare these to an int. And there are
-    # several places (e.g. a Filter condition) where we require suppied series to have
-    # boolean type. We'll need the DSL to get these types from the schema and pass them
-    # in somehow.
-
-    # The main thing we need to validate here is the "domain constraint". Frames and series
-    # which are in one-row-per-patient form can be combined arbitrarily because we can JOIN
-    # using the patient_id and be sure that we're not creating new rows. But for operations
-    # involving many-rows-per-patient inputs we need to ensure that they are all drawn from
-    # the same underlying table. (We call this the "domain" for set theoretic reasons which
-    # the margin of this comment are too small to contain.) Note that when we add a Join
-    # operation that will be the one explicit exception to this rule.
+    # Check that the types supplied match the types specified
+    validate_types(node)
+    # As well as types we need to validate the "domain constraint". Frames and series
+    # which are in one-row-per-patient form can be combined arbitrarily because we can
+    # JOIN using the patient_id and be sure that we're not creating new rows. But for
+    # operations involving many-rows-per-patient inputs we need to ensure that they are
+    # all drawn from the same underlying table. (We call this the "domain" for set
+    # theoretic reasons which the margin of this comment are too small to contain.) Note
+    # that when we add a Join operation that will be the one explicit exception to this
+    # rule.
     validate_inputs_have_common_domain(node)
+
+
+def validate_types(node):
+    # Within the context of this node, any TypeVars evaluated must take consistent
+    # values so we created a single context object to share between all fields
+    typevar_context = {}
+    for field in dataclasses.fields(node):
+        value = getattr(node, field.name)
+        # This might look a bit backward: instead of checking whether the value is of
+        # the expected type, we convert the value to a type specification and check that
+        # it matches the required specification. We do this because although Series
+        # objects are parameterized with the type of thing they represent (e.g.
+        # Series[int]) they don't actually contain any instances of these values (there
+        # are no ints sitting around to be checked). So the standard, "isinstance()",
+        # approach to type checking doesn't work. There may well be a more elegant
+        # alternative approach here, but this works for now.
+        typespec = get_typespec(value)
+        target_typespec = field.type
+        if not type_matches(typespec, target_typespec, typevar_context):
+            # TODO: Raise more helpful errors here. In particular the error you get from
+            # inconsistent use of type variables is not very obvious. Ideally, we raise
+            # exceptions with more structured information so that DSL layers can catch
+            # them and translate them into something more meaningful in their context.
+            raise TypeError(
+                f"{node.__class__.__name__}.{field.name} requires '{target_typespec}'"
+                f" but got '{typespec}'"
+                f"\nIn node:\n{node}"
+            )
 
 
 def validate_inputs_have_common_domain(node):
@@ -351,6 +396,119 @@ def validate_inputs_have_common_domain(node):
             f"Attempt to combine multiple domains:\n{non_patient_domains}"
             f"\nIn node:\n{node}"
         )
+
+
+# See the `get_typespec` function in `typing_utils.py` for a description of what this
+# function does in general. Here we're teaching it how to destructure a Series object to
+# work out what kind of thing it contains.
+@get_typespec.register(Series)
+def get_typespec_for_series(series):
+    """
+    Given a Series object, work out what type of thing it contains so we can return a
+    type like `Series[int]` or `Series[bool]`
+    """
+    inner_type = get_inner_type(series)
+    typevars = get_typevars(inner_type)
+    # The easy case is when the series type specification doesn't contain any TypeVars.
+    if not typevars:
+        # In this case there's no resolving to be done and the resolved type just *is*
+        # the type we started with
+        resolved_type = inner_type
+    # If the specification does contain TypeVars then we need to resolve these against
+    # the types used in the inputs and substitute these resolved values back in
+    else:
+        # We assume just one TypeVar; we could probably make this work with multiple if
+        # we needed to, but I can't see why we ever would
+        assert len(typevars) == 1
+        typevar = list(typevars)[0]
+        # Get the value implied by the input types
+        typevar_value = resolve_typevar_from_inputs(series, typevar)
+        if inner_type is typevar:
+            # If what we started with was a plain TypeVar (not nested inside any more
+            # complex structure) then our resolved value is just the value of the
+            # TypeVar
+            resolved_type = typevar_value
+        else:
+            # Otherwise we have to parameterize the type using the value of the TypeVar
+            resolved_type = inner_type[typevar_value]
+    return Series[resolved_type]
+
+
+def get_inner_type(series):
+    # A bit of typing magic: given an instance of a class like `Count`
+    #
+    #     class Count(Series[int]):
+    #         ...
+    #
+    # we want to get back the `int` bit, and below is the incantation to do so.
+    #
+    # Here `Series[int]` is a generic alias and so doesn't appear in the normal class
+    # hierachy. Instead we access it via the `__orig_bases__` attribute. We want the
+    # first such generic and, having found it, we want to extract its arguments using
+    # `get_args` and take what we know to be the one and only argument.
+    return typing.get_args(series.__orig_bases__[0])[0]
+
+
+def resolve_typevar_from_inputs(node, typevar):
+    # Walk over all the inputs to an operation, matching their actual type against their
+    # specified field type; this is not with the intention of validating those types but
+    # rather of resolving the values of any type variables included. As soon as we
+    # resolve the typevar we're after, we return it.
+    #
+    # For example, suppose we have an operation like this:
+    #
+    #   class Add(Series[T]):
+    #       lhs: Series[T]
+    #       rhs: Series[T]
+    #
+    # To determine what type of Series this operation returns we need to determine the
+    # value of T. If we have an instance of `Add` constructed like this:
+    #
+    #     add = Add(some_int_series, another_int_series)
+    #
+    # We can walk over its attributes and match their types against the types in the
+    # signature. So `add.lhs` has type `Series[int]` which matches `Series[T]` and in
+    # the process tells us that `T == int` by setting `T` in the `typevar_context`
+    #
+    # As soon as we've resolved the value of T we return it. (Ensuring T is consistent
+    # over all the inputs is a separate validation problem handled elsewhere.)
+    typevar_context = {}
+    for field in dataclasses.fields(node):
+        value = getattr(node, field.name)
+        typespec = get_typespec(value)
+        type_matches(typespec, field.type, typevar_context)
+        # We happen to always hit this on the first pass, hence the "no cover"
+        if typevar in typevar_context:  # pragma: no cover
+            return typevar_context[typevar]
+    else:
+        # If we get here then we've mucked up our Query Model classes somehow: we've
+        # included a TypeVar in an operation signature which doesn't itself appear in
+        # the signatures for any of its inputs.
+        assert False, f"Could not match TypeVar {typevar} in {node}"
+
+
+@get_typespec.register(SelectColumn)
+def get_typespec_for_select_column(column):
+    # Find the table from which this SelectColumn operation draws
+    root = get_root_frame(column.source)
+    # If it has a schema then that gives us the type of the resulting Series
+    if root.schema:
+        type_ = root.schema[column.name]
+    # Otherwise use the default type Any
+    else:
+        type_ = Any
+    return Series[type_]
+
+
+@singledispatch
+def get_root_frame(frame):
+    return get_root_frame(frame.source)
+
+
+@get_root_frame.register(SelectTable)
+@get_root_frame.register(SelectPatientTable)
+def get_root_frame_for_table(frame):
+    return frame
 
 
 # For most operations, their domain is the just the domains of all their inputs

--- a/databuilder/typing_utils.py
+++ b/databuilder/typing_utils.py
@@ -1,0 +1,143 @@
+"""
+This module contains some utilities for doing runtime type-checking. It is in no sense
+complete in that there are large areas of Python's type system which it doesn't attempt
+to handle. Its aim is to implement just enough behaviour to provide the validation
+needed by the Query Model.
+"""
+import typing
+from collections.abc import Mapping, Set
+from functools import singledispatch
+
+
+def get_typevars(typespec):
+    "Return set of all TypeVars nested anywhere inside `typespec`"
+    if isinstance(typespec, typing.TypeVar):
+        return {typespec}
+    else:
+        return set().union(*[get_typevars(arg) for arg in typing.get_args(typespec)])
+
+
+def type_matches(type_, spec, typevar_context):
+    """
+    Checks that the type given by `type_` matches the specification given by `spec`
+
+    For example:
+
+        `dict[str, FileNotFoundError]` matches `dict[Any, OSError]`
+
+    Because `str` matches `Any` and `FileNotFoundError` is a subclass of `OSError`.
+
+    The specification may contain TypeVars. The first match for each variable will bind
+    its value, recording it in the `typevar_context` dict. Subsequent uses of the
+    variable will fail to match if they don't have the same type. By sharing the
+    `typevar_context` dict across different calls to this function you can enforce
+    consistent interpretation of the TypeVar.
+
+    For example, both the below calls will match:
+
+        T = TypeVar("T")
+        type_matches(dict[int, int], dict[T, T], {})
+        type_matches(dict[str, str], dict[T, T], {})
+
+    But these will fail:
+
+        ctx = {}
+        type_matches(dict[int, bool], dict[T, T], ctx)
+        type_matches(dict[str, str], dict[T, T], ctx)
+
+    The first because the value of T is internally inconsistent; the second because
+    although it is internally consistent it is inconsistent with the previous example
+    whose context it shares.
+    """
+    # If `spec` is a type variable
+    if isinstance(spec, typing.TypeVar):
+        # Check the type constraints are met, if any
+        if spec.__constraints__:
+            if not any(
+                type_matches(type_, subspec, typevar_context)
+                for subspec in spec.__constraints__
+            ):
+                return False
+        # If we've already assigned a value for this variable (and it wasn't the Any
+        # type) then check it matches
+        if spec in typevar_context and typevar_context[spec] != typing.Any:
+            if typevar_context[spec] != type_:
+                return False
+        # Otherwise record this value as the value of the TypeVar
+        else:
+            typevar_context[spec] = type_
+        return True
+
+    # `Any` is the easy case: it just matches everything
+    if type_ is typing.Any or spec is typing.Any:
+        return True
+
+    spec_origin = typing.get_origin(spec)
+    spec_args = typing.get_args(spec)
+
+    # If there's no origin type that means `spec` is an ordinary class
+    if spec_origin is None:
+        return type_ is not None and issubclass(type_, spec)
+    elif spec_origin is typing.Union:
+        # For union types we just need to match one of the arguments
+        return any(type_matches(type_, arg, typevar_context) for arg in spec_args)
+    else:
+        # Otherwise we get origin and args for `type_` and check that each element
+        # matches
+        type_origin = typing.get_origin(type_)
+        if not type_matches(type_origin, spec_origin, typevar_context):
+            return False
+        type_args = typing.get_args(type_)
+        for type_arg, spec_arg in zip(type_args, spec_args):
+            if not type_matches(type_arg, spec_arg, typevar_context):
+                return False
+        return True
+
+
+@singledispatch
+def get_typespec(value):
+    """
+    Return a type specification for the supplied value. In simple cases this is just
+    like `type()` e.g.
+
+        get_typespec(1) == int
+
+    But this function knows how to destructure some container types so that e.g.
+
+        get_typespec({1, 2, 3}) == Set[int]
+
+    Additionally, through the magic of singledispatch, it can be taught to destructure
+    other container types it doesn't yet know about.
+    """
+    return type(value)
+
+
+@get_typespec.register(Set)
+def get_typespec_for_set(value):
+    member_types = {get_typespec(i) for i in value}
+    if len(member_types) > 1:
+        raise TypeError(f"Sets must be of homogeneous type: {value!r}")
+    elif member_types:
+        member_type = list(member_types)[0]
+    else:
+        # Allow empty sets
+        member_type = typing.Any
+    return type(value)[member_type]
+
+
+@get_typespec.register(Mapping)
+def get_typespec_for_mapping(value):
+    key_types = {get_typespec(i) for i in value.keys()}
+    value_types = {get_typespec(i) for i in value.values()}
+    if len(key_types) > 1:
+        raise TypeError(f"Mappings must be of homogeneous key type: {value!r}")
+    elif len(value_types) > 1:
+        raise TypeError(f"Mappings must be of homogeneous value type: {value!r}")
+    elif key_types and value_types:
+        key_type = list(key_types)[0]
+        value_type = list(value_types)[0]
+    else:
+        # Allow empty mappings
+        key_type = typing.Any
+        value_type = typing.Any
+    return type(value)[key_type, value_type]

--- a/tests/lib/query_model_convert_to_new.py
+++ b/tests/lib/query_model_convert_to_new.py
@@ -137,7 +137,11 @@ def convert_value_from_category(node: old.ValueFromCategory):
         convert_value(key): convert_node(value)
         for key, value in node.definitions.items()
     }
-    return new.Categorise(definitions, convert_value(node.default))
+    if node.default is not None:
+        default = convert_value(node.default)
+    else:
+        default = None
+    return new.Categorise(definitions, default)
 
 
 @convert_node.register

--- a/tests/test_query_model.py
+++ b/tests/test_query_model.py
@@ -37,6 +37,11 @@ def test_queries_have_expected_types(queries):
     assert isinstance(queries.first_vaccination, OneRowPerPatientFrame)
 
 
+def test_queries_are_hashable(queries):
+    for query in vars(queries).values():
+        assert hash(query) is not None
+
+
 def test_mixing_domains_throws_error():
     events = SelectTable("events")
     vaccinations = SelectTable("vaccinations")

--- a/tests/test_query_model.py
+++ b/tests/test_query_model.py
@@ -42,6 +42,14 @@ def test_queries_are_hashable(queries):
         assert hash(query) is not None
 
 
+# We don't _have_ to maintain this property, but it's quite a convenient one to have and
+# if we're going to break it then let's at least do so deliberately
+def test_query_reprs_round_trip(queries):
+    # This relies on all public query model names being imported into local scope
+    for query in vars(queries).values():
+        assert eval(repr(query)) == query
+
+
 def test_mixing_domains_throws_error():
     events = SelectTable("events")
     vaccinations = SelectTable("vaccinations")

--- a/tests/test_query_model.py
+++ b/tests/test_query_model.py
@@ -1,8 +1,9 @@
+from types import SimpleNamespace
+
 import pytest
 
 from databuilder.query_model import (
     AggregateByPatient,
-    Code,
     DomainMismatchError,
     Filter,
     Function,
@@ -13,18 +14,27 @@ from databuilder.query_model import (
     SelectColumn,
     SelectTable,
     Sort,
+    Value,
 )
 
 
-def test_construct_basic_query():
+@pytest.fixture
+def queries():
+    q = SimpleNamespace()
     events = SelectTable("events")
     code = SelectColumn(events, "code")
     date = SelectColumn(events, "date")
-    vaccinations = Filter(events, Function.EQ(code, Code("abc123", system="ctv3")))
-    has_vaccination = AggregateByPatient.Exists(vaccinations)
-    first_vaccination = PickOneRowPerPatient(Sort(vaccinations, date), Position.FIRST)
-    assert isinstance(has_vaccination, OneRowPerPatientSeries)
-    assert isinstance(first_vaccination, OneRowPerPatientFrame)
+    vaccinations = Filter(events, Function.EQ(code, Value("abc123")))
+    q.has_vaccination = AggregateByPatient.Exists(
+        SelectColumn(vaccinations, "patient_id")
+    )
+    q.first_vaccination = PickOneRowPerPatient(Sort(vaccinations, date), Position.FIRST)
+    return q
+
+
+def test_queries_have_expected_types(queries):
+    assert isinstance(queries.has_vaccination, OneRowPerPatientSeries)
+    assert isinstance(queries.first_vaccination, OneRowPerPatientFrame)
 
 
 def test_mixing_domains_throws_error():
@@ -32,4 +42,4 @@ def test_mixing_domains_throws_error():
     vaccinations = SelectTable("vaccinations")
     vaccine_code = SelectColumn(vaccinations, "code")
     with pytest.raises(DomainMismatchError):
-        Filter(events, Function.EQ(vaccine_code, Code("abc123", system="ctv3")))
+        Filter(events, Function.EQ(vaccine_code, Value("abc123")))

--- a/tests/test_typing_utils.py
+++ b/tests/test_typing_utils.py
@@ -1,0 +1,76 @@
+from typing import Any, TypeVar, Union
+
+import pytest
+
+from databuilder.typing_utils import get_typespec, get_typevars, type_matches
+
+
+def test_get_typevars():
+    T = TypeVar("T")
+    V = TypeVar("V")
+    assert get_typevars(T) == {T}
+    assert get_typevars(dict[T, list[set[V]]]) == {T, V}
+    assert get_typevars(dict[tuple[T], set[T]]) == {T}
+
+
+def test_get_typespec():
+    assert get_typespec("hello") == str
+    assert get_typespec({"hello", "there"}) == set[str]
+    assert get_typespec({1: "one", 2: "two"}) == dict[int, str]
+    assert get_typespec({1: {0.1, 0.2}, 2: {0.3, 0.4}}) == dict[int, set[float]]
+    assert get_typespec({}) == dict[Any, Any]
+    assert get_typespec(frozenset()) == frozenset[Any]
+
+
+def test_get_typespec_errors():
+    with pytest.raises(TypeError, match="homogeneous"):
+        get_typespec({1, "two"})
+    with pytest.raises(TypeError, match="homogeneous"):
+        get_typespec({1: "one", "two": "two"})
+    with pytest.raises(TypeError, match="homogeneous"):
+        get_typespec({1: "one", 2: 2.0})
+
+
+def test_type_matches():
+    assert type_matches(list[str], list[Union[int, str]], {})
+    assert type_matches(dict[str, FileNotFoundError], dict[Any, OSError], {})
+
+
+def test_type_matches_and_sets_typevar():
+    T = TypeVar("T")
+    Numeric = TypeVar("Numeric", int, float)
+    ctx = {}
+    assert type_matches(dict[str, str], dict[T, T], ctx)
+    assert type_matches(dict[int, int], dict[Numeric, Numeric], ctx)
+    assert ctx[T] == str
+    assert ctx[Numeric] == int
+
+
+def test_type_matches_and_sets_typevar_with_any():
+    T = TypeVar("T")
+    ctx = {}
+    assert type_matches(list[Any], list[T], ctx)
+    assert ctx[T] == Any
+
+
+def test_type_matches_and_sets_typevar_with_any_and_concrete_type():
+    T = TypeVar("T")
+    ctx = {}
+    assert type_matches(dict[Any, int], dict[T, T], ctx)
+    assert ctx[T] == int
+
+
+def test_type_matches_rejects_mismatch():
+    Numeric = TypeVar("Numeric", int, float)
+    assert not type_matches(list[str], list[int], {})
+    assert not type_matches(tuple[int], list[int], {})
+    assert not type_matches(list[str], list[Numeric], {})
+    assert not type_matches(list[float], list[Union[int, str]], {})
+    assert not type_matches(list, list[int], {})
+
+
+def test_type_matches_only_with_consistent_typevar():
+    T = TypeVar("T")
+    ctx = {}
+    assert not type_matches(dict[int, bool], dict[T, T], ctx)
+    assert not type_matches(dict[str, str], dict[T, T], ctx)

--- a/tests/test_typing_utils.py
+++ b/tests/test_typing_utils.py
@@ -31,6 +31,12 @@ def test_get_typespec_errors():
         get_typespec({1: "one", 2: 2.0})
 
 
+def test_get_typespec_errors_on_unhandled_container_type():
+    with pytest.raises(AssertionError):
+        # We haven't taught it how to destructure lists so this should error
+        get_typespec([1, 2, 3])
+
+
 def test_type_matches():
     assert type_matches(list[str], list[Union[int, str]], {})
     assert type_matches(dict[str, FileNotFoundError], dict[Any, OSError], {})


### PR DESCRIPTION
This PR adds runtime type validation to the Query Model so it should be impossible to construct nodes which don't respect their type hints.

Doing this for the full generality of Python's type system gets very complicated very fast, but we only need to support the relatively limited set of hints we use in the query model. Even so, this code is pretty horrendous. In its favour, it is all pretty self-contained and if someone comes up with a more elegant way of enforcing these constraints then we should be able to swap it out without affecting anything else.

As well as adding validation this PR adds two helper functions to the public API:
 * `has_one_row_per_patient(node)` takes a Frame or a Series and says whether it has only one-row-per-patient or many rows;
 * `get_series_type(series)`takes a Series and returns the type of thing it contains.

Most of the type checking code is added in a big commit towards the end of the sequence. It might be easiest to read it in the branch view:
https://github.com/opensafely-core/databuilder/blob/query-model-type-validation/databuilder/query_model.py#L363

And (here very much be dragons):
https://github.com/opensafely-core/databuilder/blob/query-model-type-validation/databuilder/typing_utils.py