### PR TITLE
fix: Change `Count` and `Exists` to operate on Frames

### DIFF
--- a/databuilder/query_engines/query_model_convert_to_old.py
+++ b/databuilder/query_engines/query_model_convert_to_old.py
@@ -165,9 +165,13 @@ def convert_combine_as_set(node: new.AggregateByPatient.CombineAsSet):
 
 def convert_aggregation(node):
     function = AGGREGATE_MAP[node.__class__]
-    assert isinstance(node.source, new.SelectColumn)
-    source_table = convert_node(node.source.source)
-    input_column = column_name(node.source.name)
+    if isinstance(node.source, new.Frame):
+        source = new.SelectColumn(node.source, "patient_id")
+    else:
+        source = node.source
+        assert isinstance(source, new.SelectColumn)
+    source_table = convert_node(source.source)
+    input_column = column_name(source.name)
     output_column = f"{input_column}_{function}"
     row = old.RowFromAggregate(source_table, function, input_column, output_column)
     return old.ValueFromAggregate(row, output_column)

--- a/databuilder/query_model.py
+++ b/databuilder/query_model.py
@@ -182,21 +182,21 @@ class PickOneRowPerPatient(OneRowPerPatientFrame):
     position: Position
 
 
-# An aggregation is any operation which accepts many-rows-per-patient series and returns
-# a one-row-per-patient series. Below are all available aggregations (using a class as a
-# namespace).
+# An aggregation is any operation which accepts many-rows-per-patient inputs (either
+# series or frames) and returns a one-row-per-patient series. Below are all available
+# aggregations (using a class as a namespace).
 class AggregateByPatient:
     class Exists(OneRowPerPatientSeries[bool]):
-        source: Series[Any]
+        source: ManyRowsPerPatientFrame
+
+    class Count(OneRowPerPatientSeries[int]):
+        source: ManyRowsPerPatientFrame
 
     class Min(OneRowPerPatientSeries[T]):
         source: Series[T]
 
     class Max(OneRowPerPatientSeries[T]):
         source: Series[T]
-
-    class Count(OneRowPerPatientSeries[int]):
-        source: Series[Any]
 
     class Sum(OneRowPerPatientSeries[Numeric]):
         source: Series[Numeric]

--- a/tests/legacy/query_model_convert_to_new.py
+++ b/tests/legacy/query_model_convert_to_new.py
@@ -50,6 +50,9 @@ AGGREGATE_MAP = {
 }
 
 
+AGGREGATIONS_ON_FRAMES = {new.AggregateByPatient.Exists, new.AggregateByPatient.Count}
+
+
 def convert(old_cohort):
     new_cohort = {column: convert_node(node) for column, node in old_cohort.items()}
     convert_node.cache_clear()
@@ -127,9 +130,10 @@ def convert_value_from_aggregate(node: old.ValueFromAggregate):
     old_aggregate = node.source
     assert isinstance(old_aggregate, old.RowFromAggregate)
     source = convert_node(old_aggregate.source)
-    column = select_column(source, old_aggregate.input_column)
     Aggregation = AGGREGATE_MAP[old_aggregate.function]
-    return Aggregation(column)
+    if Aggregation not in AGGREGATIONS_ON_FRAMES:
+        source = select_column(source, old_aggregate.input_column)
+    return Aggregation(source)
 
 
 @convert_node.register

--- a/tests/test_query_engine.py
+++ b/tests/test_query_engine.py
@@ -3,6 +3,7 @@ from databuilder.query_model import (
     Function,
     SelectColumn,
     SelectPatientTable,
+    SelectTable,
 )
 
 from .lib.mock_backend import patient
@@ -19,9 +20,10 @@ def test_year_from_date(engine):
     )
 
     patients = SelectPatientTable("patients")
+    registrations = SelectTable("practice_registrations")
 
     class DatasetDefinition:
-        population = AggregateByPatient.Exists(SelectColumn(patients, "patient_id"))
+        population = AggregateByPatient.Exists(registrations)
         year_of_birth = Function.YearFromDate(SelectColumn(patients, "date_of_birth"))
 
     assert engine.extract(DatasetDefinition) == [

--- a/tests/test_query_model.py
+++ b/tests/test_query_model.py
@@ -40,9 +40,7 @@ def queries():
         events, Function.In(code, Value(frozenset({"def456", "xyz789"})))
     )
 
-    q.vaccination_count = AggregateByPatient.Count(
-        SelectColumn(vaccinations, "patient_id")
-    )
+    q.vaccination_count = AggregateByPatient.Count(vaccinations)
     q.first_vaccination = PickOneRowPerPatient(Sort(vaccinations, date), Position.FIRST)
     q.vaccination_status = Categorise(
         {
@@ -58,9 +56,7 @@ def queries():
     q.anaphylaxis_co_occurance = Filter(
         anaphylaxis_events, Function.In(date, q.vaccination_days_set)
     )
-    q.had_anaphylaxis = AggregateByPatient.Exists(
-        SelectColumn(q.anaphylaxis_co_occurance, "patient_id")
-    )
+    q.had_anaphylaxis = AggregateByPatient.Exists(q.anaphylaxis_co_occurance)
 
     return q
 
@@ -166,10 +162,8 @@ def test_can_compare_columns_of_unknown_type():
 
 def test_infer_types_where_possible_even_without_schema():
     events = SelectTable("events")
-    date = SelectColumn(events, "date")
-    event_count = AggregateByPatient.Count(date)
-    # Even though we don't know what type "date" is we know that Count always returns an
-    # int
+    event_count = AggregateByPatient.Count(events)
+    # Even though we've got no schema we know that Count always returns an int
     assert get_series_type(event_count) == int
     # And therefore it should be an error to compare it to a string
     with pytest.raises(TypeError):


### PR DESCRIPTION
This better matches their actual semantics. Previously we were
arbitrarily selecting the `patient_id` column to pass in here, but that
was a hack that ehrQL was going to hide from the user; we're better off
not requiring it at all.

As discussed in Slack:
https://ebmdatalab.slack.com/archives/C02LEF2GC75/p1644586507472789