### PR TITLE
Update Docs Generation

### DIFF
--- a/databuilder/__main__.py
+++ b/databuilder/__main__.py
@@ -58,7 +58,7 @@ def main(args=None):
             url=options.url,
         )
     elif options.which == "generate_docs":
-        generate_docs()
+        generate_docs(location=options.location)
     elif options.which == "print_help":
         parser.print_help()
     else:
@@ -160,6 +160,11 @@ def build_parser():
         help="Generate a JSON representation of the data needed for the public documentation of Backends and Contracts",
     )
     generate_docs.set_defaults(which="generate_docs")
+    generate_docs.add_argument(
+        "--location",
+        type=Path,
+        help="Optional location to write documentation data to.  Uses current working directory otherwise.",
+    )
 
     return parser
 

--- a/databuilder/docs.py
+++ b/databuilder/docs.py
@@ -46,13 +46,17 @@ def _reformat_docstring(d):
     return [line.strip() for line in docstring.split("\n")]
 
 
-def generate_docs():
+def generate_docs(location=None):
     data = {
         "backends": list(_build_backends()),
         "contracts": list(_build_contracts()),
     }
 
-    with open("public_docs.json", "w") as f:
+    path = "public_docs.json"  # default to cwd
+    if location is not None:
+        path = location / path
+
+    with open(path, "w") as f:
         json.dump(data, f, indent=2)
 
     print("Generated data for documentation")

--- a/databuilder/docs.py
+++ b/databuilder/docs.py
@@ -48,11 +48,11 @@ def _reformat_docstring(d):
 
 def generate_docs():
     data = {
-        "contracts": list(_build_contracts()),
         "backends": list(_build_backends()),
+        "contracts": list(_build_contracts()),
     }
 
-    with open("backend_docs.json", "w") as f:
+    with open("public_docs.json", "w") as f:
         json.dump(data, f, indent=2)
 
-    print("Generated data for backends")
+    print("Generated data for documentation")

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -32,3 +32,20 @@ def test_generate_docs():
 
     names = {contract["name"] for contract in data["contracts"]}
     assert "PatientDemographics" in names
+
+
+def test_generate_docs_with_path(tmp_path):
+    path = tmp_path / "test"
+    path.mkdir()
+
+    generate_docs(path)
+
+    with open(path / "public_docs.json") as f:
+        data = json.load(f)
+
+    expected = {"DatabricksBackend", "GraphnetBackend", "TPPBackend"}
+    output = {b["name"] for b in data["backends"]}
+    assert expected <= output
+
+    names = {contract["name"] for contract in data["contracts"]}
+    assert "PatientDemographics" in names

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -23,7 +23,7 @@ def test_reformat_docstring():
 def test_generate_docs():
     generate_docs()
 
-    with open("backend_docs.json") as f:
+    with open("public_docs.json") as f:
         data = json.load(f)
 
     expected = {"DatabricksBackend", "GraphnetBackend", "TPPBackend"}


### PR DESCRIPTION
This updates the filename for the JSON we produce to be less specific to one part of databuilder, and lets us pass a location to make its use in the docs repo easier.

The docs repo installs databuilder in a subdirectory but we want the JSON that `generate_docs()` produces to be in the top level repo, so the addition of a location flag lets us do that without more justfile config in that repo.