### PR TITLE
Test query language

### DIFF
--- a/databuilder/query_language.py
+++ b/databuilder/query_language.py
@@ -8,6 +8,8 @@ This contains just enough of ehrQL to be able to extract the following dataset:
 """
 from __future__ import annotations
 
+import dataclasses
+
 from .query_model import Function, Node, Value
 
 
@@ -31,9 +33,9 @@ class Dataset:
         return {name: variable.qm_node for name, variable in self.variables.items()}
 
 
+@dataclasses.dataclass(frozen=True)
 class Series:
-    def __init__(self, qm_node):
-        self.qm_node = qm_node
+    qm_node: Node
 
 
 class IdSeries(Series):


### PR DESCRIPTION
As part of [623][], @benbc, @inglesp and I have been thinking about how to test that operations on query language (QL) elements return the correct query model (QM) elements. Considerations:

* We like tests that emphasize what is being tested, and de-emphasize the scaffolding.
* We dislike test code that looks like production code.

This PR is one approach. Characteristics:
* The left-hand side of each assertion is the QL, the right-hand side is the QM
* The scaffolding can be used "as is" e.g. `qm_int_series` is a query model series of integers
* Forward and reverse operations are covered

[623]: https://app.shortcut.com/ebm-datalab/story/623/implement-just-enough-of-ehrql-to-run-a-simple-not-necessarily-realistic-study