### PR TITLE
Tighten domain constraint

### DIFF
--- a/databuilder/query_model.py
+++ b/databuilder/query_model.py
@@ -329,7 +329,7 @@ class Categorise(Series[T]):
 
 def has_one_row_per_patient(node):
     "Return whether a Frame or Series has at most one row per patient"
-    return get_domains(node) == {PATIENT_DOMAIN}
+    return get_domain(node) == PATIENT_DOMAIN
 
 
 def get_series_type(series):
@@ -346,15 +346,9 @@ def get_series_type(series):
 def validate_node(node):
     # Check that the types supplied match the types specified
     validate_types(node)
-    # As well as types we need to validate the "domain constraint". Frames and series
-    # which are in one-row-per-patient form can be combined arbitrarily because we can
-    # JOIN using the patient_id and be sure that we're not creating new rows. But for
-    # operations involving many-rows-per-patient inputs we need to ensure that they are
-    # all drawn from the same underlying table. (We call this the "domain" for set
-    # theoretic reasons which the margins of this comment are too small to contain.)
-    # Note that when we add a Join operation that will be the one explicit exception to
-    # this rule.
-    validate_inputs_have_common_domain(node)
+    # As well as types we need to validate the "domain constraint" which specifies how
+    # Frames and Series, potentially drawn from different tables, can be combined
+    validate_input_domains(node)
 
 
 # DOMAIN VALIDATION
@@ -365,38 +359,103 @@ class DomainMismatchError(Exception):
     ...
 
 
-PATIENT_DOMAIN = object()
+def validate_input_domains(node):
+    # The domain of a Frame or Series can be thought of as the set of its primary keys.
+    # This determines which other Frames or Series it can be validly composed with. The
+    # rules we want to enforce are:
+    #
+    #  * One-row-per-patient data can be composed with anything: by design every table
+    #    has a patient_id column and so data defined purely in terms of patient_id
+    #    can be joined with anything.
+    #
+    #  * Many-rows-per-patient data drawn from different tables can never be combined
+    #    — at least, not until we add an explicit JOIN operation.
+    #
+    #  * Many-rows-per-patient data drawn from a single underlying table can be combined
+    #    as long as any filters applied to the data can be arranged in a linear
+    #    sequence. That is, it's legal to combine `Table A -> Filter B -> Filter C` and
+    #    `Table A -> Filter B`. But it's not legal to combine `Table A -> Filter D` and
+    #    `Table A -> Filter E`. There's never a need to use such constructions and they
+    #    will almost always be the result of user error. It's better to reject them
+    #    immediately than give the user unexpected results at query time.
+    #
+    #    As an example, the below ehrQL would produce an invalid construct:
+    #
+    #        foo_events = events.filter(code="foo")
+    #        bar_events = events.filter(code="bar")
+    #        bar_dates = bar_events.date
+    #        foobar_events = events.filter(foo_events.date == bar_dates)
+    #
+    #    Were we to allow this, it could be executed but it would always return empty
+    #    results because it involves the condition `code = 'foo' AND code = 'bar'`. In
+    #    this case, what the user should have written is:
+    #
+    #        foobar_events = events.filter(foo_events.date.isin(bar_dates))
+    #
+    # We enforce this by modelling domains as a hierarchy. At the root is the patient
+    # domain, each table has an unique domain descending from this, and each filter
+    # operation creates a new domain descending from the domain of its source. A valid
+    # operation is one where the domains of its inputs are "nested" in the sense that
+    # each domain is an ancestor or descendant of every other.
+    #
+    # We use sets to implement this hierarchy: we start with the patient domain as a set
+    # containing a single unique value, and we create descendent domains by forming the
+    # union of the parent domain with a new unqiue value. The `issubset()` relation then
+    # gives us the "is domain ancestor" semantics we want.
+    #
+    # Another way of expressing the "nested" condition above is that the input domains
+    # must be totally ordered by ancestory. We can check this by sorting them (sets
+    # naturally sort by subset-hood in Python) and then confirming that the ordering is
+    # total by testing that each adjacent pair has the required subset relation.
+    domains = sorted(get_input_domains(node))
+    for a, b in zip(domains, domains[1:]):
+        if not a.issubset(b):
+            raise DomainMismatchError(
+                f"Attempt to combine unrelated domains:\n{a} and {b}"
+                f"\nIn node:\n{node}"
+            )
 
 
-def validate_inputs_have_common_domain(node):
-    domains = get_domains(node)
-    non_patient_domains = domains - {PATIENT_DOMAIN}
-    if len(non_patient_domains) > 1:
-        raise DomainMismatchError(
-            f"Attempt to combine multiple domains:\n{non_patient_domains}"
-            f"\nIn node:\n{node}"
-        )
+def get_input_domains(node):
+    return {get_domain(input_node) for input_node in get_input_nodes(node)}
 
 
-# For most operations, their domain is the just the domains of all their inputs
+# We use an arbitrary unique object to represent the patient domain
+PATIENT_DOMAIN = frozenset([object()])
+
+
 @singledispatch
-def get_domains(node):
-    return set().union(
-        *[get_domains(input_node) for input_node in get_input_nodes(node)]
-    )
+def get_domain(node):
+    assert False, f"Unhandled node type: {type(node)}"
 
 
-# But these operations create new domains
-@get_domains.register(SelectTable)
-def get_domain_roots(node):
-    return {node}
+# Selecting a many-rows-per-patient table creates a new domain which descends from the
+# patient domain
+@get_domain.register(SelectTable)
+def get_domain_for_table(node):
+    return PATIENT_DOMAIN | {node}
 
 
-# And these operations are guaranteed to produce output in the patient domain
-@get_domains.register(OneRowPerPatientFrame)
-@get_domains.register(OneRowPerPatientSeries)
+# Filtering a Frame creates a new domain which descends from the domain of the original
+# source Frame
+@get_domain.register(Filter)
+def get_domain_for_filter(node):
+    return get_domain(node.source) | {node}
+
+
+# Operations of these types are guaranteed to produce output in the patient domain
+@get_domain.register(OneRowPerPatientFrame)
+@get_domain.register(OneRowPerPatientSeries)
 def get_domains_for_one_row_per_patient_operations(node):
-    return {PATIENT_DOMAIN}
+    return PATIENT_DOMAIN
+
+
+# For the remaining operations, their domain is the "smallest" of the domains of their
+# inputs i.e. the one furthest from the root
+@get_domain.register(Series)
+@get_domain.register(Sort)
+def get_domain_from_inputs(node):
+    return sorted(get_input_domains(node))[-1]
 
 
 # Quick and lazy way of getting input nodes using dataclass introspection


### PR DESCRIPTION
The practical effect of this PR is to add a single extra condition to the domain constraint validation: it is now no longer possible to combine the results of two divergent filter operations, even if they operate on the same underlying table. This isn't the sort of thing you should ever _want_ to do (an equivalent operation can be expressed using a linear chain of filters) but it's the sort of thing you might accidentally end up doing if you got confused and we'd like to be able to reject such constructs immediately rather than waiting for them to return unexpected results in production.

Enforcing this check doesn't introduce much additional code, and I think the code is _arguably_ a bit less ad-hoc than what went before. But maybe I've just been thinking about it too long.