### PR TITLE
Set up databuilder-in-docker Tests

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -142,11 +142,11 @@ test-unit *ARGS: devenv
     $BIN/python -m pytest -m "not integration" {{ ARGS }}
 
 # run the integration tests only. Optional args are passed to pytest
-test-integration *ARGS: devenv build-databuilder
+test-integration *ARGS: devenv
     $BIN/python -m pytest -m integration {{ ARGS }}
 
 # run the integration tests only, excluding spark tests which are slow. Optional args are passed to pytest
-test-integration-no-spark *ARGS: devenv build-databuilder
+test-integration-no-spark *ARGS: devenv
     $BIN/python -m pytest -m "integration and not spark" {{ ARGS }}
 
 # run the run-databuilder-in-docker tests only

--- a/Justfile
+++ b/Justfile
@@ -149,6 +149,10 @@ test-integration *ARGS: devenv build-databuilder
 test-integration-no-spark *ARGS: devenv build-databuilder
     $BIN/python -m pytest -m "integration and not spark" {{ ARGS }}
 
+# run the run-databuilder-in-docker tests only
+test-docker *ARGS: devenv build-databuilder
+    $BIN/python -m pytest tests/docker  {{ ARGS }}
+
 # run all tests including integration tests. Optional args are passed to pytest
 test-all *ARGS=test_args: devenv build-databuilder
     #!/usr/bin/env bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ omit = [
     "tests/acceptance/test_long_covid_dsl.py",
     "tests/acceptance/test_med_safety_dsl.py",
     "tests/acceptance/test_sro_measures_dsl.py",
+    "tests/docker/dataset_definition.py",
 ]
 
 [tool.coverage.report]

--- a/tests/docker/conftest.py
+++ b/tests/docker/conftest.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def run_in_container(tmpdir, containers):
+    workspace = Path(tmpdir.mkdir("workspace"))
+
+    def run(command, study=None):
+        return containers.run_fg(
+            image="databuilder:latest",
+            command=command,
+            volumes={workspace: {"bind": "/workspace", "mode": "rw"}},
+        )
+
+    return run

--- a/tests/docker/conftest.py
+++ b/tests/docker/conftest.py
@@ -7,11 +7,16 @@ import pytest
 def run_in_container(tmpdir, containers):
     workspace = Path(tmpdir.mkdir("workspace"))
 
-    def run(command, study=None):
-        return containers.run_fg(
+    def run(command):
+        output = containers.run_fg(
             image="databuilder:latest",
             command=command,
             volumes={workspace: {"bind": "/workspace", "mode": "rw"}},
         )
+
+        return {
+            "container_response": output,
+            "workspace_dir": workspace,
+        }
 
     return run

--- a/tests/docker/dataset_definition.py
+++ b/tests/docker/dataset_definition.py
@@ -1,0 +1,9 @@
+from databuilder.definition import register
+from databuilder.query_language import Dataset
+from databuilder.tables import patients
+
+dataset = Dataset()
+year = patients.date_of_birth.year
+dataset.set_population(year >= 1900)
+dataset.year = year
+register(dataset)

--- a/tests/docker/test_cli.py
+++ b/tests/docker/test_cli.py
@@ -1,0 +1,53 @@
+def test_generate_dataset_in_container(run_in_container):
+    output = run_in_container(
+        [
+            "generate_dataset",
+            "--help",
+        ]
+    )
+
+    assert output
+
+
+def test_validate_dataset_definition_in_container(run_in_container):
+    output = run_in_container(
+        [
+            "validate_dataset_definition",
+            "--help",
+        ]
+    )
+
+    assert output
+
+
+def test_generate_measures_in_container(run_in_container):
+    output = run_in_container(
+        [
+            "generate_measures",
+            "--help",
+        ]
+    )
+
+    assert output
+
+
+def test_test_connection_in_container(run_in_container):
+    output = run_in_container(
+        [
+            "test_connection",
+            "--help",
+        ]
+    )
+
+    assert output
+
+
+def test_generate_docs_in_container(run_in_container):
+    output = run_in_container(
+        [
+            "generate_docs",
+            "--help",
+        ]
+    )
+
+    assert output

--- a/tests/docker/test_cli.py
+++ b/tests/docker/test_cli.py
@@ -1,12 +1,52 @@
-def test_generate_dataset_in_container(run_in_container):
-    output = run_in_container(
-        [
-            "generate_dataset",
-            "--help",
-        ]
+import csv
+import shutil
+from datetime import datetime
+from pathlib import Path
+
+from tests.lib.tpp_schema import patient
+
+
+def test_generate_dataset_in_container(tmpdir, database, containers):
+    database.setup(patient(dob=datetime(1943, 5, 5)))
+
+    # create some relative paths
+    analysis_dir = Path("analysis")
+    definition = Path("dataset_definition.py")
+    outputs_dir = Path("outputs")
+    dataset = Path("dataset.csv")
+
+    # create the local workspace directory
+    workspace = Path(tmpdir.mkdir("workspace"))
+
+    # create the local analysis dir and copy in our definition
+    (workspace / analysis_dir).mkdir()
+    shutil.copy(Path(__file__).parent / definition, workspace / analysis_dir)
+
+    # create the local outputs dir
+    (workspace / outputs_dir).mkdir()
+
+    command = [
+        "generate_dataset",
+        "--dataset-definition",
+        str(Path("/workspace") / analysis_dir / definition),
+        "--dataset",
+        str(Path("/workspace") / outputs_dir / dataset),
+    ]
+
+    containers.run_fg(
+        image="databuilder:latest",
+        command=command,
+        environment={
+            "DATABASE_URL": database.container_url(),
+            "OPENSAFELY_BACKEND": "tpp",
+        },
+        volumes={workspace: {"bind": "/workspace", "mode": "rw"}},
     )
 
-    assert output
+    with open(workspace / outputs_dir / dataset) as f:
+        results = list(csv.DictReader(f))
+        assert len(results) == 1
+        assert results[0]["year"] == "1943"
 
 
 def test_validate_dataset_definition_in_container(run_in_container):

--- a/tests/docker/test_drivers.py
+++ b/tests/docker/test_drivers.py
@@ -1,0 +1,21 @@
+def test_driver_in_container(run_in_container, engine):
+    backends = {
+        "mssql": "tpp",
+        "spark": "databricks",
+    }
+
+    if engine.name not in backends:
+        assert False, f"no backend for database: {engine.name}"
+
+    backend = backends[engine.name]
+    url = engine.database.container_url()
+
+    run_in_container(
+        [
+            "test_connection",
+            "--backend",
+            backend,
+            "--url",
+            url,
+        ]
+    )

--- a/tests/lib/databases.py
+++ b/tests/lib/databases.py
@@ -224,12 +224,13 @@ def make_spark_container_database(containers):
             ports={spark_port: None},
         )
 
+    container_ip = containers.get_container_ip(container_name)
     host_spark_port = containers.get_mapped_port_for_host(container_name, spark_port)
 
     return DbDetails(
         protocol="spark",
         driver="pyhive+opensafely",
-        host_from_container=container_name,
+        host_from_container=container_ip,
         port_from_container=spark_port,
         host_from_host="localhost",
         port_from_host=host_spark_port,

--- a/tests/lib/databases.py
+++ b/tests/lib/databases.py
@@ -47,6 +47,9 @@ class DbDetails:
         self.query = query
         self.temp_db = temp_db
 
+    def container_url(self):
+        return self._url(self.host_from_container, self.port_from_container)
+
     def host_url(self):
         return self._url(self.host_from_host, self.port_from_host)
 

--- a/tests/lib/docker.py
+++ b/tests/lib/docker.py
@@ -1,5 +1,6 @@
-import docker
-import docker.errors
+import sys
+
+from docker.errors import ContainerError, NotFound
 
 
 class Containers:
@@ -13,7 +14,7 @@ class Containers:
         try:
             container = self.get_container(name)
             return container.status == "running"  # pragma: no cover
-        except docker.errors.NotFound:  # pragma: no cover
+        except NotFound:  # pragma: no cover
             return False
 
     def get_mapped_port_for_host(self, name, container_port):
@@ -41,15 +42,12 @@ class Containers:
 
     # All available arguments documented here:
     # https://docker-py.readthedocs.io/en/stable/containers.html#docker.models.containers.ContainerCollection.run
-    # Temporarily uncommenting rather than marking as "no cover" because a subsequent PR uses this and I
-    # don't want us to forget to remove the pragma.
-    # def run_fg(self, image, **kwargs):
-    #     try:
-    #         output = self._run(image=image, detach=False, stderr=True, **kwargs)
-    #         print(str(output, "utf-8"))
-    #     except ContainerError as e:  # pragma: no cover
-    #         print(str(e.stderr, "utf-8"), file=sys.stderr)
-    #         raise
+    def run_fg(self, image, **kwargs):
+        try:
+            return self._run(image=image, detach=False, stderr=True, **kwargs)
+        except ContainerError as e:  # pragma: no cover
+            print(str(e.stderr, "utf-8"), file=sys.stderr)
+            raise
 
     def _run(self, **kwargs):  # pragma: no cover
         return self._docker.containers.run(remove=True, **kwargs)


### PR DESCRIPTION
This adds a new tests package, `tests/docker`, for testing parts of databuilder via the docker image we build.  So far it documents that each of the CLI targets can render its help text, and each database is contactable, exercising that the drivers are correctly installed and configured within the image.