### PR TITLE
chore: Fail on warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,4 +113,5 @@ filterwarnings = [
     "ignore::DeprecationWarning:pytest_freezegun:17",
     "ignore::DeprecationWarning:docker.utils.utils:52",
     "ignore::DeprecationWarning:docker.utils.utils:53",
+    "ignore::DeprecationWarning:pyhive.common:248",
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,14 @@ from .lib.study import Study
 from .lib.util import extract
 
 
+# Fail the build if we see any warnings.
+def pytest_terminal_summary(terminalreporter, exitstatus, config):
+    if terminalreporter.stats.get("warnings"):  # pragma: no cover
+        print("ERROR: warnings detected")
+        if terminalreporter._session.exitstatus == 0:
+            terminalreporter._session.exitstatus = 13
+
+
 @pytest.fixture(scope="session")
 def containers():
     yield Containers()


### PR DESCRIPTION
Output when there's a warning looks like this:

```
> just test tests/legacy/test_query_engine_legacy.py::test_simple_filters
$BIN/python -m pytest tests/legacy/test_query_engine_legacy.py::test_simple_filters
========================================== test session starts ==========================================
platform linux -- Python 3.9.7, pytest-7.0.1, pluggy-1.0.0
rootdir: /home/benbc/src/opensafely-core/databuilder, configfile: pyproject.toml
plugins: subtests-0.7.0, cov-3.0.0, freezegun-0.4.2, mock-3.7.0
collected 28 items                                                                                      

tests/legacy/test_query_engine_legacy.py ............................                             [100%]

=========================================== warnings summary ============================================
tests/legacy/test_query_engine_legacy.py::test_simple_filters[spark-test multiple equals filter]
  /home/benbc/src/opensafely-core/databuilder/.venv/lib/python3.9/site-packages/pyhive/common.py:248: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.10 it will stop working
    elif isinstance(item, collections.Iterable):

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
ERROR: warnings detected
=============================== 28 passed, 1 warning in 83.22s (0:01:23) ================================
error: Recipe `test` failed on line 139 with exit code 13
```