### PR TITLE
refactor: Better approach to executable TableSchema reprs

### DIFF
--- a/tests/unit/test_query_language.py
+++ b/tests/unit/test_query_language.py
@@ -60,7 +60,7 @@ def test_dataset():
 # instantiated isn't important.
 qm_table = SelectTable(
     name="table",
-    schema=TableSchema("schema", int_column=int, date_column=date),
+    schema=TableSchema(int_column=int, date_column=date),
 )
 qm_int_series = SelectColumn(source=qm_table, name="int_column")
 qm_date_series = SelectColumn(source=qm_table, name="date_column")

--- a/tests/unit/test_query_model.py
+++ b/tests/unit/test_query_model.py
@@ -24,9 +24,7 @@ from databuilder.query_model import (
     has_one_row_per_patient,
 )
 
-EVENTS_SCHEMA = TableSchema(
-    "EVENTS_SCHEMA", patient_id=int, date=datetime.date, code=str
-)
+EVENTS_SCHEMA = TableSchema(patient_id=int, date=datetime.date, code=str)
 
 
 # TEST BASIC QUERY MODEL PROPERTIES


### PR DESCRIPTION
Previously we required each schema to have a name which played no other
role than to provide the repr. This alternative approach gives us
executable reprs without such tricks.