### PR TITLE
chore: Run `pre-commit autoupdate`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 22.1.0
+    rev: 22.3.0
     hooks:
     - id: black
       language_version: python3.9
@@ -22,12 +22,12 @@ repos:
       language_version: python3.9
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.31.0
+    rev: v2.32.0
     hooks:
     -   id: pyupgrade
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.2.0
+    rev: v4.2.0
     hooks:
     - id: trailing-whitespace
     - id: end-of-file-fixer


### PR DESCRIPTION
This gets us off a broken version of Black (see
https://github.com/psf/black/issues/2964).

I guess this problem wasn't showing up in CI because CI was used a
cached environment which had an older, non-problematic version of Click
installed.

To my mind this highlights a deficiency in pre-commit that it doesn't
pin transitive dependencies and so it's a lucky dip as to what versions
you get when you install a hook.

Someone else has raised this issue but the reception was ... a little
frosty:
https://github.com/pre-commit/pre-commit/issues/2310

It looks like we could fully pin dependencies for each hook using the
[additional_dependencies][1] config option, but we'd have to do that
manually which would be extremely tedious.

Ideally I'd just like to tell pre-commit "use the version of Black we
already have installed in this environment here", rather than have two
entirely seperately managed installations. But I don't know if it's
possible to do that.

[1]: https://pre-commit.com/#config-additional_dependencies