### PR TITLE
Validate population definition

### DIFF
--- a/databuilder/population_validation.py
+++ b/databuilder/population_validation.py
@@ -1,0 +1,229 @@
+import dataclasses
+import datetime
+import operator
+from functools import singledispatch
+
+from databuilder.query_model import (
+    AggregateByPatient,
+    Categorise,
+    Function,
+    SelectColumn,
+    ValidationError,
+    Value,
+    get_series_type,
+    has_one_row_per_patient,
+)
+
+
+def validate_population_definition(population):
+    """
+    Test that a given Series is suitable for use as a population definition
+    """
+    if not has_one_row_per_patient(population) or get_series_type(population) != bool:
+        raise ValidationError(
+            "population definition must be a one-row-per-patient series of boolean type"
+        )
+    # We exclude population definitions which evaluate as True when all their inputs are
+    # NULL. Here's why.
+    #
+    # A population definition is a boolean series which is True for all patients who
+    # should be included in the population. In SQL terms, you can think of a boolean
+    # series as a function, or expression, which takes a row of patient values
+    # (potentially drawn from many different tables) and returns True, False or NULL.
+    #
+    # It is possible to construct definitions which take the value True when all their
+    # inputs are NULL. The most trivial example is:
+    #
+    #   Value(True)
+    #
+    # i.e. always, unconditionally True for everyone. This might seem silly, but we used
+    # to think if was a convenient way to say "just give me all the patients" in test
+    # cases.
+    #
+    # A slightly less trivial example is:
+    #
+    #   Function.Not(AggregateByPatient.Exists(SelectTable("ons_deaths")))
+    #
+    # i.e. give me all patients for whom we do not have a death record from ONS. Here
+    # the `Exists` aggregation returns False when there is no corresponding for in the
+    # `ons_deaths` table, and the `Not` function transforms that value into True.
+    #
+    # In both these cases, the expression can be True when evaluated on patients which
+    # do not exist in any of the tables referenced by the expression itself. This means
+    # that the population we end up with is sensitive to the "universe" of patients we
+    # decide to feed in. And some natural-sounding universes, e.g. the union of all
+    # patients featuring anywhere in the database, are awkward and expensive to compute.
+    #
+    # Excluding such definitions means that the minimum set of patients needed to
+    # evalute the expression (all patients featuring in tables referenced in the
+    # expression) gives the same results as with any larger set. So the question of
+    # exactly how we define the patient "universe" goes away.
+    #
+    # As well as simplifying the implementation there are also good scientific reasons
+    # to exclude these kinds of population definitions: a well constructed study should
+    # start with a positively defined population (e.g. all patients registered with a
+    # practice as of a certain date) from which some patients are then excluded. A
+    # population definition like "all patients who have not died" doesn't unambiguously
+    # define a universe of patients and so should not be allowed even if we could
+    # reliably interpret it.
+    #
+    # To determine whether a population definition meets this criterion we walk the tree
+    # of query model nodes and for each operation which would normally involve fetching
+    # data we substitute the result of that operation when given no data (this is often,
+    # but not always, NULL). The end result of the process will be either True, False or
+    # NULL. It is definitions which return True here that we reject.
+    if evaluate(population) is True:
+        # TODO: Wording could do with more thought here
+        raise ValidationError(
+            "population definition must not evaluate as True for NULL inputs"
+        )
+    return True
+
+
+@singledispatch
+def evaluate(node):
+    """
+    Given a Series node, return the value it would take if all its inputs were NULL
+    """
+    assert False, f"Unhandled node type: {type(node)}"
+
+
+@evaluate.register(Value)
+def evaluate_value(node):
+    return node.value
+
+
+@evaluate.register(SelectColumn)
+def evaluate_select_column(node):
+    return None
+
+
+@evaluate.register(AggregateByPatient.Exists)
+def evaluate_exists(node):
+    return False
+
+
+@evaluate.register(AggregateByPatient.Count)
+def evaluate_count(node):
+    return 0
+
+
+@evaluate.register(AggregateByPatient.CombineAsSet)
+def evaluate_combine_as_set(node):
+    return ()
+
+
+@evaluate.register(AggregateByPatient.Min)
+@evaluate.register(AggregateByPatient.Max)
+@evaluate.register(AggregateByPatient.Sum)
+def evaluate_aggregation(node):
+    return None
+
+
+@evaluate.register(Function.IsNull)
+def evaluate_is_null(node):
+    return evaluate(node.source) is None
+
+
+@evaluate.register(Function.And)
+def evaluate_and(node):
+    lhs = evaluate(node.lhs)
+    rhs = evaluate(node.rhs)
+    if lhs is True and rhs is True:
+        return True
+    elif lhs is False or rhs is False:
+        return False
+    else:
+        return None
+
+
+@evaluate.register(Function.Or)
+def evaluate_or(node):
+    lhs = evaluate(node.lhs)
+    rhs = evaluate(node.rhs)
+    if lhs is True or rhs is True:
+        return True
+    elif lhs is False and rhs is False:
+        return False
+    else:
+        return None
+
+
+@evaluate.register(Categorise)
+def evaluate_categorise(node):
+    for value, condition in node.categories.items():
+        if evaluate(condition) is True:
+            return evaluate(value)
+    if node.default is not None:
+        return evaluate(node.default)
+
+
+def register_op(cls):
+    """
+    Handle registration for any operations with the default NULL behaviour, which is
+    that they return NULL if any of their arguments are NULL
+    """
+    getters = [operator.attrgetter(field.name) for field in dataclasses.fields(cls)]
+
+    def register(function):
+        @evaluate.register(cls)
+        def apply(node):
+            args = [evaluate(get_arg(node)) for get_arg in getters]
+            if any(arg is None for arg in args):
+                return None
+            return function(*args)
+
+        return apply
+
+    return register
+
+
+@register_op(Function.RoundToFirstOfMonth)
+def round_to_first_of_month(date):
+    return datetime.date(date.year, date.month, 1)
+
+
+@register_op(Function.RoundToFirstOfYear)
+def round_to_first_of_year(date):
+    return datetime.date(date.year, 1, 1)
+
+
+@register_op(Function.YearFromDate)
+def year_from_date(date):
+    return date.year
+
+
+@register_op(Function.DateDifferenceInYears)
+def date_difference_in_years(start, end):
+    year_diff = end.year - start.year
+    if (end.month, end.day) < (start.month, start.day):
+        return year_diff - 1
+    else:
+        return year_diff
+
+
+@register_op(Function.In)
+def in_(lhs, rhs):
+    return operator.contains(rhs, lhs)
+
+
+@register_op(Function.DateAdd)
+def date_add(date, num_days):
+    return date + datetime.timedelta(days=num_days)
+
+
+@register_op(Function.DateSubtract)
+def date_subtract(date, num_days):
+    return date - datetime.timedelta(days=num_days)
+
+
+register_op(Function.Not)(operator.not_)
+register_op(Function.Negate)(operator.neg)
+register_op(Function.EQ)(operator.eq)
+register_op(Function.NE)(operator.ne)
+register_op(Function.LT)(operator.lt)
+register_op(Function.LE)(operator.le)
+register_op(Function.GT)(operator.gt)
+register_op(Function.GE)(operator.ge)
+register_op(Function.Add)(operator.add)
+register_op(Function.Subtract)(operator.sub)

--- a/databuilder/population_validation.py
+++ b/databuilder/population_validation.py
@@ -8,6 +8,7 @@ from databuilder.query_model import (
     Categorise,
     Function,
     SelectColumn,
+    Series,
     ValidationError,
     Value,
     get_series_type,
@@ -19,6 +20,10 @@ def validate_population_definition(population):
     """
     Test that a given Series is suitable for use as a population definition
     """
+    if not isinstance(population, Series):
+        raise ValidationError(
+            "population definition must be a `query_model.Series` instance"
+        )
     if not has_one_row_per_patient(population) or get_series_type(population) != bool:
         raise ValidationError(
             "population definition must be a one-row-per-patient series of boolean type"

--- a/databuilder/query_engines/query_model_convert_to_old.py
+++ b/databuilder/query_engines/query_model_convert_to_old.py
@@ -31,7 +31,6 @@ CONNECTOR_MAP = {
 }
 
 FUNCTION_CLASS_MAP = {
-    new.Function.DateDifference: old.DateDifference,
     new.Function.RoundToFirstOfMonth: old.RoundToFirstOfMonth,
     new.Function.RoundToFirstOfYear: old.RoundToFirstOfYear,
     new.Function.DateAdd: old.DateAddition,
@@ -201,6 +200,11 @@ def convert_function(node):
 
 for type_ in FUNCTION_CLASS_MAP.keys():
     convert_node.register(type_)(convert_function)
+
+
+@convert_node.register
+def convert_date_difference_in_years(node: new.Function.DateDifferenceInYears):
+    return old.DateDifference(convert_value(node.lhs), convert_value(node.rhs), "years")
 
 
 def convert_connector(node):

--- a/databuilder/query_engines/sqlite.py
+++ b/databuilder/query_engines/sqlite.py
@@ -54,7 +54,13 @@ class SQLiteQueryEngine(BaseQueryEngine):
             frame = domain.get_node()
             return self.get_select_query_for_frame(frame)
         else:
-            return self.get_select_query_for_patient_domain()
+            # TODO: This branch is only present to support aggregations over data which
+            # is already patient-level. Our query model currently allows this (simply
+            # because (simply because it's tricky to forbid it statically using the
+            # machinery we have) and previously the spec tests made (inadvertent) use of
+            # it. We need to either forbid this in the query model, or decide that we do
+            # want to support it and write some tests for it.
+            return self.get_select_query_for_patient_domain()  # pragma: no cover
 
     def get_select_query_for_patient_domain(self):
         """

--- a/databuilder/query_engines/sqlite.py
+++ b/databuilder/query_engines/sqlite.py
@@ -123,21 +123,11 @@ class SQLiteQueryEngine(BaseQueryEngine):
 
     @get_sql.register(Function.And)
     def get_sql_and(self, node):
-        # SQLAlchemy doesn't provide reverse bitwise operations, so `True & Column()` raises a `TypeError`.
-        # See https://github.com/sqlalchemy/sqlalchemy/issues/5846.
-        try:
-            return operators.and_(self.get_sql(node.lhs), self.get_sql(node.rhs))
-        except TypeError:
-            return operators.and_(self.get_sql(node.rhs), self.get_sql(node.lhs))
+        return sqlalchemy.and_(self.get_sql(node.lhs), self.get_sql(node.rhs))
 
     @get_sql.register(Function.Or)
     def get_sql_or(self, node):
-        # SQLAlchemy doesn't provide reverse bitwise operations, so `False | Column()` raises a `TypeError`.
-        # See https://github.com/sqlalchemy/sqlalchemy/issues/5846.
-        try:
-            return operators.or_(self.get_sql(node.lhs), self.get_sql(node.rhs))
-        except TypeError:
-            return operators.or_(self.get_sql(node.rhs), self.get_sql(node.lhs))
+        return sqlalchemy.or_(self.get_sql(node.lhs), self.get_sql(node.rhs))
 
     @get_sql.register(Function.LT)
     def get_sql_lt(self, node):

--- a/databuilder/query_language.py
+++ b/databuilder/query_language.py
@@ -1,16 +1,13 @@
 import dataclasses
 
-from . import query_model as qm
+from databuilder import query_model as qm
+from databuilder.population_validation import validate_population_definition
 
 
 class Dataset:
     def set_population(self, population):
-        # TODO raise proper error here
-        assert isinstance(population, BoolSeries)
+        validate_population_definition(population.qm_node)
         object.__setattr__(self, "population", population)
-
-    def use_unrestricted_population(self):  # pragma: no cover
-        self.set_population(BoolSeries(qm.Value(True)))
 
     def __setattr__(self, name, value):
         # TODO raise proper errors here

--- a/databuilder/query_model.py
+++ b/databuilder/query_model.py
@@ -12,6 +12,7 @@ from .typing_utils import get_typespec, get_typevars, type_matches
 # The below classes and functions are the public API surface of the query model
 __all__ = [
     "Node",
+    "Series",
     "Value",
     "SelectTable",
     "SelectPatientTable",

--- a/databuilder/query_model.py
+++ b/databuilder/query_model.py
@@ -296,10 +296,9 @@ class Function:
         lhs: Series[date]
         rhs: Series[int]
 
-    class DateDifference(Series[int]):
-        start: Series[date]
-        end: Series[date]
-        units: Series[str]
+    class DateDifferenceInYears(Series[int]):
+        lhs: Series[date]
+        rhs: Series[date]
 
     class YearFromDate(Series[int]):
         source: Series[date]

--- a/tests/generative/variable_strategies.py
+++ b/tests/generative/variable_strategies.py
@@ -281,7 +281,7 @@ def is_trivial(node):  # pragma: no cover
         Function.Subtract,
         Function.DateAdd,
         Function.DateSubtract,
-        Function.DateDifference,
+        Function.DateDifferenceInYears,
         Function.In,
     ]:
         # All binary functions are completely determined if all of their inputs are literals

--- a/tests/legacy/query_model_convert_to_new.py
+++ b/tests/legacy/query_model_convert_to_new.py
@@ -31,7 +31,7 @@ OPERATOR_MAP = {
 
 
 FUNCTION_CLASS_MAP = {
-    old.DateDifference: new.Function.DateDifference,
+    old.DateDifference: new.Function.DateDifferenceInYears,
     old.RoundToFirstOfMonth: new.Function.RoundToFirstOfMonth,
     old.RoundToFirstOfYear: new.Function.RoundToFirstOfYear,
     old.DateAddition: new.Function.DateAdd,
@@ -152,7 +152,10 @@ def convert_value_from_category(node: old.ValueFromCategory):
 @convert_node.register
 def convert_value_from_function(node: old.ValueFromFunction):
     Function = FUNCTION_CLASS_MAP[type(node)]
-    return Function(*[convert_value(arg) for arg in node.arguments])
+    if Function is new.Function.DateDifferenceInYears:
+        assert node.arguments[2] == "years"
+        return Function(*[convert_value(arg) for arg in node.arguments[:2]])
+    return Function(*[convert_value(arg) for arg in node.arguments])  # pragma: no cover
 
 
 @convert_node.register

--- a/tests/lib/in_memory/engine.py
+++ b/tests/lib/in_memory/engine.py
@@ -223,7 +223,7 @@ class InMemoryQueryEngine(BaseQueryEngine):
     def visit_DateSubtract(self, node):
         assert False
 
-    def visit_DateDifference(self, node):
+    def visit_DateDifferenceInYears(self, node):
         assert False
 
     def visit_YearFromDate(self, node):

--- a/tests/spec/combine_series/test_patient_series_and_patient_series.py
+++ b/tests/spec/combine_series/test_patient_series_and_patient_series.py
@@ -15,7 +15,7 @@ table_data = {
 def test_patient_series_and_patient_series(spec_test):
     spec_test(
         table_data,
-        (p.i1 + p.i2).sum_for_patient(),
+        p.i1 + p.i2,
         {
             1: (101 + 102),
             2: (201 + 202),

--- a/tests/spec/combine_series/test_patient_series_and_value.py
+++ b/tests/spec/combine_series/test_patient_series_and_value.py
@@ -15,7 +15,7 @@ table_data = {
 def test_patient_series_and_value(spec_test):
     spec_test(
         table_data,
-        (p.i1 + 1).sum_for_patient(),
+        p.i1 + 1,
         {
             1: (101 + 1),
             2: (201 + 1),
@@ -26,7 +26,7 @@ def test_patient_series_and_value(spec_test):
 def test_value_and_patient_series(spec_test):
     spec_test(
         table_data,
-        (1 + p.i1).sum_for_patient(),
+        1 + p.i1,
         {
             1: (1 + 101),
             2: (1 + 201),

--- a/tests/spec/conftest.py
+++ b/tests/spec/conftest.py
@@ -48,7 +48,7 @@ def spec_test(request, engine):
             # because the patients wouldn't be included in the universe). We also then need to include a variable which
             # references those patients via a patient table in order to include them in the universe.
             populate_missing_patients(input_data)
-            dataset.use_unrestricted_population()
+            dataset.set_population(~tables.p.patient_id.is_null())
             dataset._hidden = tables.p.b1
         dataset.v = series
 

--- a/tests/unit/test_population_validation.py
+++ b/tests/unit/test_population_validation.py
@@ -22,6 +22,12 @@ from databuilder.query_model import (
 )
 
 
+def test_rejects_non_series():
+    aint_no_series = "I am not a Series"
+    with pytest.raises(ValidationError, match="must be a `query_model.Series`"):
+        validate_population_definition(aint_no_series)
+
+
 def test_rejects_invalid_dimension():
     event_series = SelectColumn(
         SelectTable("events", schema=TableSchema(value=bool)), "value"

--- a/tests/unit/test_population_validation.py
+++ b/tests/unit/test_population_validation.py
@@ -1,0 +1,268 @@
+import dataclasses
+import datetime
+
+import pytest
+
+from databuilder import query_model
+from databuilder.population_validation import (
+    ValidationError,
+    evaluate,
+    validate_population_definition,
+)
+from databuilder.query_model import (
+    AggregateByPatient,
+    Categorise,
+    Function,
+    SelectColumn,
+    SelectPatientTable,
+    SelectTable,
+    Series,
+    TableSchema,
+    Value,
+)
+
+
+def test_rejects_invalid_dimension():
+    event_series = SelectColumn(
+        SelectTable("events", schema=TableSchema(value=bool)), "value"
+    )
+    with pytest.raises(ValidationError, match="one-row-per-patient series"):
+        validate_population_definition(event_series)
+
+
+def test_rejects_invalid_type():
+    int_series = SelectColumn(
+        SelectPatientTable("patients", schema=TableSchema(value=int)), "value"
+    )
+    with pytest.raises(ValidationError, match="boolean type"):
+        validate_population_definition(int_series)
+
+
+def test_accepts_basic_reasonable_population():
+    has_registration = AggregateByPatient.Exists(SelectTable("registrations"))
+    assert validate_population_definition(has_registration)
+
+
+def test_rejects_basic_unreasonable_population():
+    not_died = Function.Not(AggregateByPatient.Exists(SelectTable("ons_deaths")))
+    with pytest.raises(ValidationError, match="must not evaluate as True for NULL"):
+        validate_population_definition(not_died)
+
+
+# TEST EVALUATE FUNCTION
+#
+
+patients = SelectPatientTable("patients", schema=TableSchema(value=int))
+events = SelectTable("events", schema=TableSchema(value=int))
+patients_value = SelectColumn(patients, "value")
+events_value = SelectColumn(events, "value")
+
+cases = [
+    (
+        True,
+        # events.count_for_patient() + 3 >= 3
+        Function.GE(
+            Function.Add(AggregateByPatient.Count(events), Value(3)),
+            Value(3),
+        ),
+    ),
+    (
+        False,
+        # events.count_for_patient() + 3 >= 4
+        Function.GE(
+            Function.Add(AggregateByPatient.Count(events), Value(3)),
+            Value(4),
+        ),
+    ),
+    (
+        True,
+        # patients.v.is_null()
+        Function.IsNull(patients_value),
+    ),
+    (
+        False,
+        # ~patients.v.is_null()
+        Function.Not(Function.IsNull(patients_value)),
+    ),
+    (
+        True,
+        # events.v.max_for_patient().is_null()
+        Function.IsNull(AggregateByPatient.Max(events_value)),
+    ),
+    (
+        None,
+        # events.v.max_for_patient() > 100
+        Function.GT(
+            AggregateByPatient.Max(events_value),
+            Value(100),
+        ),
+    ),
+    (
+        True,
+        # patients.v == 1 | (10 < 20)
+        Function.Or(
+            Function.EQ(patients_value, Value(1)),
+            Function.LT(Value(2), Value(3)),
+        ),
+    ),
+    (
+        None,
+        # patients.v == 100 | (patients.v <= 20)
+        Function.Or(
+            Function.EQ(patients_value, Value(100)),
+            Function.LE(patients_value, Value(3)),
+        ),
+    ),
+    (
+        False,
+        # ~patients.v.is_null | events.exists_for_patient()
+        Function.Or(
+            Function.Not(Function.IsNull(patients_value)),
+            AggregateByPatient.Exists(events),
+        ),
+    ),
+    (
+        True,
+        # (1 == 1) & (2 == 2)
+        Function.And(
+            Function.EQ(Value(1), Value(1)),
+            Function.EQ(Value(2), Value(2)),
+        ),
+    ),
+    (
+        False,
+        # ~(patients.v == 100 & events.exists_for_patient())
+        Function.And(
+            Function.EQ(patients_value, Value(100)),
+            AggregateByPatient.Exists(events),
+        ),
+    ),
+    (
+        None,
+        # patients.v == 1 & events.v.sum_for_patient() == 2
+        Function.And(
+            Function.EQ(patients_value, Value(1)),
+            Function.EQ(AggregateByPatient.Sum(events_value), Value(2)),
+        ),
+    ),
+    (
+        True,
+        Function.In(Value(10), Value({30, 20, 10})),
+    ),
+    (
+        None,
+        Function.In(
+            patients_value,
+            AggregateByPatient.CombineAsSet(events_value),
+        ),
+    ),
+    (
+        "bar",
+        Categorise(
+            {
+                Value("foo"): Function.EQ(patients_value, Value(1)),
+                Value("bar"): Function.EQ(Value(1), Value(1)),
+            },
+            default=None,
+        ),
+    ),
+    (
+        "baz",
+        Categorise(
+            {
+                Value("foo"): Function.EQ(patients_value, Value(1)),
+                Value("bar"): Function.EQ(patients_value, Value(2)),
+            },
+            default=Value("baz"),
+        ),
+    ),
+    (
+        None,
+        Categorise(
+            {
+                Value("foo"): Function.EQ(patients_value, Value(1)),
+                Value("bar"): Function.EQ(patients_value, Value(2)),
+            },
+            default=None,
+        ),
+    ),
+    (
+        datetime.date(2021, 1, 1),
+        Function.RoundToFirstOfYear(Value(datetime.date(2021, 8, 16))),
+    ),
+    (
+        datetime.date(2021, 8, 1),
+        Function.RoundToFirstOfMonth(Value(datetime.date(2021, 8, 16))),
+    ),
+    (
+        datetime.date(2021, 6, 13),
+        Function.DateAdd(Value(datetime.date(2021, 5, 4)), Value(40)),
+    ),
+    (
+        datetime.date(2021, 3, 25),
+        Function.DateSubtract(Value(datetime.date(2021, 5, 4)), Value(40)),
+    ),
+    (
+        2022,
+        Function.YearFromDate(Value(datetime.date(2022, 4, 29))),
+    ),
+    (
+        3,
+        Function.DateDifferenceInYears(
+            Value(datetime.date(2020, 2, 29)), Value(datetime.date(2023, 3, 1))
+        ),
+    ),
+    (
+        2,
+        Function.DateDifferenceInYears(
+            Value(datetime.date(2020, 2, 29)), Value(datetime.date(2023, 2, 27))
+        ),
+    ),
+]
+
+
+@pytest.mark.parametrize("expected,query", cases)
+def test_evaluate(expected, query):
+    result = evaluate(query)
+    assert result == expected, f"Expected {expected}, got {result} in:\n{query}"
+
+
+# TEST EVALUTE DEFINITION IS EXHAUSTIVE
+#
+# Test that the `evaluate()` single dispatch function is exhaustively defined so we
+# can't forget to update it if we add a new query model operation.
+#
+
+
+def get_all_operations():
+    "Return every operation defined in the query model"
+    return [cls for cls in iterate_query_model_namespace() if is_operation(cls)]
+
+
+def is_operation(cls):
+    "Return whether an arbitrary value is a query model operation class"
+    # We need to check this first or the `issubclass` check can fail
+    if not isinstance(cls, type):
+        return False
+    # We need to check it's a proper subclass as the Node base class isn't itself a
+    # dataclass so the `fields()` call will fail
+    if not issubclass(cls, query_model.Node) or cls is query_model.Node:
+        return False
+    # If it takes arguments it's an operation, otherwise it's an abstract type
+    return len(dataclasses.fields(cls)) > 0
+
+
+def iterate_query_model_namespace():
+    "Yield every public thing in the query_model module"
+    yield from [getattr(query_model, name) for name in query_model.__all__]
+    yield from vars(query_model.Function).values()
+    yield from vars(query_model.AggregateByPatient).values()
+
+
+@pytest.mark.parametrize(
+    "operation", [op for op in get_all_operations() if issubclass(op, Series)]
+)
+def test_evaluate_function_defined_for(operation):
+    default = evaluate.dispatch(object)
+    function = evaluate.dispatch(operation)
+    assert function != default, f"No `evaluate()` implementation for {operation}"

--- a/tests/unit/test_query_language.py
+++ b/tests/unit/test_query_language.py
@@ -51,7 +51,7 @@ def test_dataset():
 
 def test_dataset_preserves_variable_order():
     dataset = Dataset()
-    dataset.use_unrestricted_population()
+    dataset.set_population(~patients.patient_id.is_null())
     dataset.foo = patients.date_of_birth.year
     dataset.baz = patients.date_of_birth.year + 100
     dataset.bar = patients.date_of_birth.year - 100

--- a/tests/unit/test_query_language.py
+++ b/tests/unit/test_query_language.py
@@ -1,7 +1,5 @@
 from datetime import date
 
-import pytest
-
 from databuilder.query_language import (
     Dataset,
     DateSeries,
@@ -94,7 +92,6 @@ class TestIntSeries:
             Function.LE(qm_int_series, Value(2000)),
         )
 
-    @pytest.mark.xfail(reason="LE comparison with IntSeries not supported")
     def test_le_intseries(self):
         assert_produces(
             IntSeries(qm_int_series) <= IntSeries(qm_int_series),

--- a/tests/unit/test_validate_dummy_data.py
+++ b/tests/unit/test_validate_dummy_data.py
@@ -40,7 +40,7 @@ def test_validate_file_types_match(a, b, matches):
 @pytest.mark.parametrize("gzipped,extension", [(False, "csv"), (True, "csv.gz")])
 def test_validate_dummy_data_file_csv(tmp_path, value, is_valid, gzipped, extension):
     dataset = Dataset()
-    dataset.use_unrestricted_population()
+    dataset.set_population(~patients.patient_id.is_null())
     dataset.year = patients.date_of_birth.year
 
     dummy_data = f"patient_id,year\n123,1980\n456,{value}"


### PR DESCRIPTION
This adds code to ensure that the population definition is valid; in particular, this it doesn't evaluate as True when given NULL inputs. I have neither a neat technical phrase for this, nor a user-friendly explanation — but hopefully both of those will come later.