### PR TITLE
Refactor ehrQL implementation

### DIFF
--- a/databuilder/contracts/base.py
+++ b/databuilder/contracts/base.py
@@ -83,12 +83,14 @@ class TableContract:
                 )
 
     @classmethod
-    def validate_table(cls, table_cls):
-        """Validate that a table is defined with the correct attributes.
+    def validate_schema(cls, schema):
+        """
+        Validate that a schema is defined with the correct columns
+
         This uses asserts rather than raising other exceptions, since any invalid tables
-        must be identified and fixed by the development team.
-        Note that we could use similar logic to generate a table from a contract.
-        However, doing so would mean that we wouldn't be able to typecheck dataset definitions.
+        must be identified and fixed by the development team. Note that we could use
+        similar logic to generate a table from a contract. However, doing so would mean
+        that we wouldn't be able to typecheck dataset definitions.
         """
         # We ignore the patient_id column as that shouldn't form part of the public API
         columns = {
@@ -96,10 +98,8 @@ class TableContract:
             for (name, col) in cls.columns.items()
             if not isinstance(col.type, types.PseudoPatientId)
         }
-        contract_column_names = set(columns)
-        table_column_names = set(table_cls.name_to_series_cls)
-        assert contract_column_names == table_column_names
+        assert columns.keys() == schema.keys()
         for col_name, column in columns.items():
             assert (
-                column.type.series == table_cls.name_to_series_cls[col_name]
+                column.type.python_type == schema[col_name]
             ), f"{col_name} doesn't match {column}"

--- a/databuilder/contracts/types.py
+++ b/databuilder/contracts/types.py
@@ -1,6 +1,6 @@
+import datetime
 from typing import Protocol
 
-from ..query_language import DateSeries, StrSeries
 from ..sqlalchemy_types import TYPES_BY_NAME
 
 
@@ -12,10 +12,13 @@ class BaseType(Protocol):
     # Subclasses must specify the backend Column types that they allow, as
     # tuples of one or more keys from databuilder.sqlalchemy_types.TYPES_BY_NAME
     allowed_backend_types: tuple[TYPES_BY_NAME, ...]
+    # The type used to represent this column in ehrQL
+    python_type: type
 
 
 class Boolean(BaseType):
     allowed_backend_types = (TYPES_BY_NAME.boolean,)
+    python_type = bool
 
 
 class Choice(BaseType):
@@ -24,7 +27,7 @@ class Choice(BaseType):
     """
 
     allowed_backend_types = (TYPES_BY_NAME.integer, TYPES_BY_NAME.varchar)
-    series = StrSeries
+    python_type = str
 
     def __init__(self, *choices):
         self.choices = choices
@@ -38,15 +41,17 @@ class Date(BaseType):
     """A type representing a date"""
 
     allowed_backend_types = (TYPES_BY_NAME.date, TYPES_BY_NAME.datetime)
-    series = DateSeries
+    python_type = datetime.date
 
 
 class Float(BaseType):
     allowed_backend_types = (TYPES_BY_NAME.float,)
+    python_type = float
 
 
 class Integer(BaseType):
     allowed_backend_types = (TYPES_BY_NAME.integer,)
+    python_type = int
 
 
 class PseudoPatientId(BaseType):
@@ -59,3 +64,4 @@ class PseudoPatientId(BaseType):
 
 class String(BaseType):
     allowed_backend_types = (TYPES_BY_NAME.varchar,)
+    python_type = str

--- a/databuilder/tables.py
+++ b/databuilder/tables.py
@@ -1,13 +1,15 @@
-from databuilder.query_language import DateSeries, StrSeries, build_patient_table
+import datetime
+
+from databuilder.query_language import build_patient_table
 
 from .contracts import universal
 
 patients = build_patient_table(
     "patients",
     {
-        "date_of_birth": DateSeries,
-        "date_of_death": DateSeries,
-        "sex": StrSeries,
+        "date_of_birth": datetime.date,
+        "date_of_death": datetime.date,
+        "sex": str,
     },
     contract=universal.Patients,
 )

--- a/tests/spec/tables.py
+++ b/tests/spec/tables.py
@@ -1,17 +1,12 @@
-from databuilder.query_language import (
-    BoolSeries,
-    IntSeries,
-    build_event_table,
-    build_patient_table,
-)
+from databuilder.query_language import build_event_table, build_patient_table
 
 p = build_patient_table(
     "patient_level_table",
     {
-        "i1": IntSeries,
-        "i2": IntSeries,
-        "b1": BoolSeries,
-        "b2": BoolSeries,
+        "i1": int,
+        "i2": int,
+        "b1": bool,
+        "b2": bool,
     },
 )
 
@@ -19,9 +14,9 @@ p = build_patient_table(
 e = build_event_table(
     "event_level_table",
     {
-        "i1": IntSeries,
-        "i2": IntSeries,
-        "b1": BoolSeries,
-        "b2": BoolSeries,
+        "i1": int,
+        "i2": int,
+        "b1": bool,
+        "b2": bool,
     },
 )


### PR DESCRIPTION
The current implementation doesn't distinguish between event series and
patient series. But it needs to, because aggregation operations should
be available on event series but not on patient series.

Distinguishing the two requires a different approach from that currently
taken because whether a  method on a `PatientSeries` should return a
`PatientSeries` or an `EventSeries` depends on the dimension of its
arguments and can't be set statically. So instead we ask the query model
what the dimension of the result is, and use that to determine the
appropriate return type.

Given that we have to do this, then it makes to sense to also use the
query model's type inference code to determine the type of the result
and select the appropriate Series class.

This requires that we pass the query model the TableSchema for any
tables we reference. This replaces the role of the `name_to_series_cls`
mapping.

Depends on #481