### PR TITLE
Remove patient-level aggregation support and refactor

### DIFF
--- a/databuilder/query_engines/sqlite.py
+++ b/databuilder/query_engines/sqlite.py
@@ -68,7 +68,11 @@ class SQLiteQueryEngine(BaseQueryEngine):
             # If there's only one table then use the IDs from that
             return sqlalchemy.select(tables[0].c.patient_id)
         else:
-            assert False, "No tables referenced in population expression"
+            # Gracefully handle the degenerate case where the population expression
+            # doesn't reference any tables at all. Our validation rules ensure that such
+            # an expression will never evaluate True so the population will always be
+            # empty. But we can at least return an empty result, rather than blowing up.
+            return sqlalchemy.select(sqlalchemy.literal(None).label("patient_id"))
 
     @singledispatchmethod
     def get_sql(self, node):

--- a/databuilder/query_engines/sqlite.py
+++ b/databuilder/query_engines/sqlite.py
@@ -38,7 +38,7 @@ class SQLiteQueryEngine(BaseQueryEngine):
             *[expr.label(name) for name, expr in variable_expressions.items()]
         )
         query = query.where(population_expression)
-        query = prepare_query(query)
+        query = apply_patient_joins(query)
         return query
 
     def select_patient_id_for_population(self, population_expression):
@@ -186,7 +186,7 @@ class SQLiteQueryEngine(BaseQueryEngine):
         expression = self.get_sql(source_node)
         query = query.add_columns(aggregation_func(expression).label("value"))
         query = query.group_by(query.selected_columns[0])
-        query = prepare_query(query)
+        query = apply_patient_joins(query)
         aggregated_table = self.reify_query(query)
         return aggregated_table.c.value
 
@@ -245,7 +245,7 @@ class SQLiteQueryEngine(BaseQueryEngine):
             )
         )
 
-        query = prepare_query(query)
+        query = apply_patient_joins(query)
 
         # Make the above into a subquery and pull out the relevant columns. Note, we're
         # deliberately using a subquery rather than `reify_query()` here as we want the
@@ -313,11 +313,6 @@ class SQLiteQueryEngine(BaseQueryEngine):
         # break in future -- we want to know immediately if it does
         assert isinstance(engine.dialect, self.sqlalchemy_dialect)
         return engine
-
-
-def prepare_query(query):
-    query = apply_patient_joins(query)
-    return query
 
 
 def apply_patient_joins(query):

--- a/databuilder/query_engines/sqlite.py
+++ b/databuilder/query_engines/sqlite.py
@@ -104,7 +104,7 @@ class SQLiteQueryEngine(BaseQueryEngine):
 
     @get_sql.register(Value)
     def get_sql_value(self, node):
-        return node.value
+        return sqlalchemy.literal(node.value)
 
     @get_sql.register(Function.EQ)
     def get_sql_eq(self, node):

--- a/databuilder/query_engines/sqlite.py
+++ b/databuilder/query_engines/sqlite.py
@@ -60,10 +60,10 @@ class SQLiteQueryEngine(BaseQueryEngine):
         if len(tables) > 1:
             # Select all patient IDs from all tables referenced in the expression
             id_selects = [sqlalchemy.select(table.c.patient_id) for table in tables]
-            # Create a CTE which is the union of all these IDs. (Note UNION rather than
-            # UNION ALL so we don't get duplicates.)
-            population_cte = sqlalchemy.union(*id_selects).cte()
-            return sqlalchemy.select(population_cte.c.patient_id)
+            # Create a table which contains the union of all these IDs. (Note UNION
+            # rather than UNION ALL so we don't get duplicates.)
+            population_table = self.reify_query(sqlalchemy.union(*id_selects))
+            return sqlalchemy.select(population_table.c.patient_id)
         elif len(tables) == 1:
             # If there's only one table then use the IDs from that
             return sqlalchemy.select(tables[0].c.patient_id)

--- a/databuilder/query_model.py
+++ b/databuilder/query_model.py
@@ -142,6 +142,7 @@ class ManyRowsPerPatientSeries(Series):
     ...
 
 
+# A Frame which has had a Sort operation applied to it
 class SortedFrame(ManyRowsPerPatientFrame):
     ...
 
@@ -193,9 +194,10 @@ class PickOneRowPerPatient(OneRowPerPatientFrame):
     position: Position
 
 
-# An aggregation is any operation which returns a one-row-per-patient series, regardless
-# of the dimension of its inputs. Below are all available aggregations (using a class
-# as a namespace).
+# Aggregations are operations which take frames and/or series and return a new series.
+# Unlike functions (see below), aggregations always return a one-row-per-patient series,
+# regardless of the dimension of their inputs. Below are all available aggregations
+# (using a class as a namespace).
 class AggregateByPatient:
     class Exists(OneRowPerPatientSeries[bool]):
         source: Frame
@@ -221,9 +223,9 @@ class AggregateByPatient:
         source: Series[T]
 
 
-# A function is any operation which takes series and values and returns a series. The
-# dimension of the series it returns will be the highest dimension of its inputs i.e. if
-# any of its inputs has many-rows-per-patient then its output will too.  Below are all
+# Functions are operations which take one or more series and return a new series. The
+# dimension of the returned series will be the highest dimension of its inputs i.e. if
+# any of its inputs has many-rows-per-patient then its output will too. Below are all
 # available functions (using a class as a namespace).
 class Function:
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -56,8 +56,8 @@ class QueryEngineFixture:
         self.query_engine_class = query_engine_class
         self.backend = backend_factory(query_engine_class)
 
-    def setup(self, *items):
-        return self.database.setup(*items)
+    def setup(self, *items, metadata=None):
+        return self.database.setup(*items, metadata=metadata)
 
     def extract(self, dataset, **backend_kwargs):
         results = list(

--- a/tests/integration/test_query_engines.py
+++ b/tests/integration/test_query_engines.py
@@ -1,3 +1,5 @@
+import sqlalchemy
+
 from databuilder.query_model import (
     AggregateByPatient,
     Filter,
@@ -76,3 +78,12 @@ def test_multiple_takes_without_chaining(engine):
     assert results == {
         1: 2,
     }
+
+
+def test_handles_degenerate_poppulaton(engine):
+    engine.setup(metadata=sqlalchemy.MetaData())
+    variables = dict(
+        population=Value(False),
+        v=Value(1),
+    )
+    assert engine.extract_qm(variables) == []

--- a/tests/unit/test_query_model.py
+++ b/tests/unit/test_query_model.py
@@ -27,7 +27,7 @@ from databuilder.query_model import (
     has_one_row_per_patient,
 )
 
-EVENTS_SCHEMA = TableSchema(patient_id=int, date=datetime.date, code=str)
+EVENTS_SCHEMA = TableSchema(date=datetime.date, code=str)
 
 
 # TEST BASIC QUERY MODEL PROPERTIES

--- a/tests/unit/test_query_model.py
+++ b/tests/unit/test_query_model.py
@@ -267,6 +267,21 @@ def test_sorting_frame_using_value_derived_from_child_frame_is_not_ok():
         Sort(events, SelectColumn(foo_events, "date"))
 
 
+def test_can_aggregate_a_many_rows_per_patient_series():
+    events = SelectTable("events", EVENTS_SCHEMA)
+    dates = SelectColumn(events, "date")
+    assert AggregateByPatient.Max(dates)
+
+
+def test_cannot_aggregate_a_one_row_per_patient_series():
+    events = SelectTable("events", EVENTS_SCHEMA)
+    dates = SelectColumn(events, "date")
+    first_event = PickOneRowPerPatient(Sort(events, dates), Position.FIRST)
+    first_date = SelectColumn(first_event, "date")
+    with pytest.raises(DomainMismatchError):
+        AggregateByPatient.Max(first_date)
+
+
 def test_domain_get_node():
     events = SelectTable("events", EVENTS_SCHEMA)
     # This filter operation creates a new domain


### PR DESCRIPTION
The changes in #480 removed the ability to aggregate patient-level series from ehrQL, but these were still legal constructs in the query model. This PR adds extra validation rules to the query model to disallow these, and then removes a lot of quite gnarly code from SQLiteQueryEngine which turns out only to be needed for this purpose.

As mentioned in the [relevant commit](https://github.com/opensafely-core/databuilder/pull/486/commits/b068a120f4a0cd70f46de9fab88fb8d5cba8b13e), there's scope for improving the way this is implemented in the query model but I don't think it needs tackling now.