### PR TITLE
Rudimentary codelist support

### DIFF
--- a/databuilder/codes.py
+++ b/databuilder/codes.py
@@ -1,0 +1,38 @@
+"""
+We make each coding system a distinct type. The query model's type checking will then
+enforce that queries use the appropriate coding system for a given column.
+"""
+import dataclasses
+
+
+@dataclasses.dataclass(frozen=True)
+class BaseCode:
+    value: str
+
+
+class BNFCode(BaseCode):
+    "Pseudo BNF"
+
+
+class CTV3Code(BaseCode):
+    "CTV3 (Read V3)"
+
+
+class DMDCode(BaseCode):
+    "Dictionary of Medicines and Devices"
+
+
+class ICD10Code(BaseCode):
+    "ICD-10"
+
+
+class OPCS4Code(BaseCode):
+    "OPCS-4"
+
+
+class Read2Code(BaseCode):
+    "Read V2"
+
+
+class SNOMEDCTCode(BaseCode):
+    "SNOMED CT"

--- a/databuilder/codes.py
+++ b/databuilder/codes.py
@@ -9,6 +9,11 @@ import dataclasses
 class BaseCode:
     value: str
 
+    # The presence of this method allows query engines to work with values of this type,
+    # despite not being explicitly told about them beforehand
+    def _to_primitive_type(self):
+        return self.value
+
 
 class BNFCode(BaseCode):
     "Pseudo BNF"

--- a/databuilder/codes.py
+++ b/databuilder/codes.py
@@ -2,12 +2,24 @@
 We make each coding system a distinct type. The query model's type checking will then
 enforce that queries use the appropriate coding system for a given column.
 """
+import csv
 import dataclasses
+from pathlib import Path
+
+# Populated by `BaseCode.__init_subclass__` below
+REGISTRY = {}
+
+
+class CodelistError(ValueError):
+    ...
 
 
 @dataclasses.dataclass(frozen=True)
 class BaseCode:
     value: str
+
+    def __init_subclass__(cls, system_id, **kwargs):
+        REGISTRY[system_id] = cls
 
     # The presence of this method allows query engines to work with values of this type,
     # despite not being explicitly told about them beforehand
@@ -15,29 +27,52 @@ class BaseCode:
         return self.value
 
 
-class BNFCode(BaseCode):
+class BNFCode(BaseCode, system_id="bnf"):
     "Pseudo BNF"
 
 
-class CTV3Code(BaseCode):
+class CTV3Code(BaseCode, system_id="ctv3"):
     "CTV3 (Read V3)"
 
 
-class DMDCode(BaseCode):
+class DMDCode(BaseCode, system_id="dmd"):
     "Dictionary of Medicines and Devices"
 
 
-class ICD10Code(BaseCode):
+class ICD10Code(BaseCode, system_id="icd10"):
     "ICD-10"
 
 
-class OPCS4Code(BaseCode):
+class OPCS4Code(BaseCode, system_id="opcs4"):
     "OPCS-4"
 
 
-class Read2Code(BaseCode):
+class Read2Code(BaseCode, system_id="readv2"):
     "Read V2"
 
 
-class SNOMEDCTCode(BaseCode):
+class SNOMEDCTCode(BaseCode, system_id="snomedct"):
     "SNOMED CT"
+
+
+def codelist_from_csv(filename, column, system):
+    try:
+        code_class = REGISTRY[system]
+    except KeyError:
+        raise CodelistError(
+            f"No system matching '{system}', allowed are: "
+            f"{', '.join(REGISTRY.keys())}"
+        )
+    filename = Path(filename)
+    if not filename.exists():
+        raise CodelistError(f"No CSV file at {filename}")
+    codes = []
+    with filename.open("r") as f:
+        for row in csv.DictReader(f):
+            try:
+                value = row[column].strip()
+            except KeyError:
+                raise CodelistError(f"No column '{column}' in {filename}")
+            if value:
+                codes.append(code_class(value))
+    return frozenset(codes)

--- a/databuilder/query_engines/query_model_convert_to_old.py
+++ b/databuilder/query_engines/query_model_convert_to_old.py
@@ -12,6 +12,8 @@ convert the entire old test suite but are covered no longer.
 import dataclasses
 from functools import cache, singledispatch
 
+from databuilder.codes import CTV3Code
+
 from .. import query_model as new
 from . import query_model_old as old
 
@@ -73,7 +75,7 @@ def convert_node(node):
 def convert_value_node(node: new.Value):
     value = node.value
     if isinstance(value, frozenset):
-        if any(isinstance(v, new.Code) for v in value):
+        if any(isinstance(v, CTV3Code) for v in value):
             return convert_codelist(value)
         else:
             return tuple(value)
@@ -248,8 +250,8 @@ def convert_not(node: new.Function.Not):
 
 
 def convert_codelist(codes):
-    system = list(codes)[0].system
-    return old.Codelist(tuple(c.value for c in codes), system=system)
+    assert all(isinstance(c, CTV3Code) for c in codes)
+    return old.Codelist(tuple(c.value for c in codes), system="ctv3")
 
 
 def column_name(column):

--- a/databuilder/query_engines/sqlite.py
+++ b/databuilder/query_engines/sqlite.py
@@ -80,7 +80,17 @@ class SQLiteQueryEngine(BaseQueryEngine):
 
     @get_sql.register(Value)
     def get_sql_value(self, node):
-        return sqlalchemy.literal(node.value)
+        if isinstance(node.value, frozenset):
+            value = tuple(self.convert_value(v) for v in node.value)
+        else:
+            value = self.convert_value(node.value)
+        return sqlalchemy.literal(value)
+
+    def convert_value(self, value):
+        if hasattr(value, "_to_primitive_type"):
+            return value._to_primitive_type()
+        else:
+            return value
 
     @get_sql.register(Function.EQ)
     def get_sql_eq(self, node):

--- a/databuilder/query_engines/sqlite.py
+++ b/databuilder/query_engines/sqlite.py
@@ -94,6 +94,12 @@ class SQLiteQueryEngine(BaseQueryEngine):
     def get_sql_is_null(self, node):
         return operators.is_(self.get_sql(node.source), None)
 
+    @get_sql.register(Function.In)
+    def get_sql_in(self, node):
+        lhs = self.get_sql(node.lhs)
+        rhs = self.get_sql(node.rhs)
+        return lhs.in_(rhs)
+
     @get_sql.register(Function.Not)
     def get_sql_not(self, node):
         return sqlalchemy.not_(self.get_sql(node.source))

--- a/databuilder/query_language.py
+++ b/databuilder/query_language.py
@@ -53,6 +53,9 @@ class Series:
     def is_null(self):
         return _apply(qm.Function.IsNull, self)
 
+    def is_in(self, other):
+        return _apply(qm.Function.In, self, other)
+
 
 class EventSeries(Series):
     def __init_subclass__(cls, **kwargs):

--- a/databuilder/query_language.py
+++ b/databuilder/query_language.py
@@ -54,6 +54,10 @@ class Series:
         return _apply(qm.Function.IsNull, self)
 
     def is_in(self, other):
+        # The query model requires an immutable Set type for containment queries, but
+        # that's a bit user-unfriendly so we accept other types here and convert them
+        if isinstance(other, (tuple, list, set)):
+            other = frozenset(other)
         return _apply(qm.Function.In, self, other)
 
 

--- a/databuilder/query_model.py
+++ b/databuilder/query_model.py
@@ -25,7 +25,6 @@ __all__ = [
     "Function",
     "Categorise",
     "TableSchema",
-    "Code",
     "ValidationError",
     "DomainMismatchError",
     "has_one_row_per_patient",
@@ -49,13 +48,6 @@ __all__ = [
 T = TypeVar("T")
 Numeric = TypeVar("Numeric", int, float)
 Comparable = TypeVar("Comparable", int, float, str, date)
-
-
-@dataclasses.dataclass(frozen=True)
-class Code:
-    "A code is a string tagged with the coding system it's drawn from"
-    value: str
-    system: str
 
 
 class Position(Enum):

--- a/tests/integration/test_query_model_with_codes.py
+++ b/tests/integration/test_query_model_with_codes.py
@@ -1,0 +1,31 @@
+import pytest
+
+from databuilder.codes import CTV3Code, SNOMEDCTCode
+from databuilder.query_model import (
+    Function,
+    SelectColumn,
+    SelectTable,
+    TableSchema,
+    TypeValidationError,
+    Value,
+)
+
+
+def test_comparisons_between_codes_are_ok():
+    events = SelectTable("events", schema=TableSchema({"code": CTV3Code}))
+    code = SelectColumn(events, "code")
+    assert Function.EQ(code, Value(CTV3Code("abc")))
+
+
+def test_attempts_to_mix_coding_systems_are_rejected():
+    events = SelectTable("events", schema=TableSchema({"code": CTV3Code}))
+    code = SelectColumn(events, "code")
+    with pytest.raises(TypeValidationError):
+        Function.EQ(code, Value(SNOMEDCTCode("abc")))
+
+
+def test_attempts_to_mix_codes_and_strings_are_rejected():
+    events = SelectTable("events", schema=TableSchema({"code": CTV3Code}))
+    code = SelectColumn(events, "code")
+    with pytest.raises(TypeValidationError):
+        Function.EQ(code, Value("abc"))

--- a/tests/legacy/query_model_convert_to_new.py
+++ b/tests/legacy/query_model_convert_to_new.py
@@ -10,6 +10,7 @@ import re
 from functools import cache, singledispatch
 
 from databuilder import query_model as new
+from databuilder.codes import CTV3Code
 
 from . import query_model_old as old
 
@@ -180,7 +181,8 @@ def convert_comparator(node: old.Comparator):
 @convert_node.register
 def convert_codelist(node: old.Codelist):
     assert not node.has_categories
-    code_set = frozenset(new.Code(code, system=node.system) for code in node.codes)
+    assert node.system == "ctv3"
+    code_set = frozenset(CTV3Code(code) for code in node.codes)
     return new.Value(code_set)
 
 

--- a/tests/lib/in_memory/engine.py
+++ b/tests/lib/in_memory/engine.py
@@ -65,10 +65,20 @@ class InMemoryQueryEngine(BaseQueryEngine):
         assert False
 
     def visit_Value(self, node):
+        if isinstance(node.value, frozenset):
+            value = frozenset(self.convert_value(v) for v in node.value)
+        else:
+            value = self.convert_value(node.value)
         return Column(
-            {patient: [node.value] for patient in self.all_patients},
+            {patient: [value] for patient in self.all_patients},
             default=None,
         )
+
+    def convert_value(self, value):
+        if hasattr(value, "_to_primitive_type"):
+            return value._to_primitive_type()
+        else:
+            return value
 
     def visit_SelectTable(self, node):
         return self.tables[node.name]

--- a/tests/lib/in_memory/engine.py
+++ b/tests/lib/in_memory/engine.py
@@ -219,7 +219,10 @@ class InMemoryQueryEngine(BaseQueryEngine):
         assert False
 
     def visit_In(self, node):
-        assert False
+        def op(lhs, rhs):
+            return lhs in rhs
+
+        return self.visit_binary_op_with_null(node, op)
 
     def visit_Categorise(self, node):
         assert False

--- a/tests/lib/mock_backend.py
+++ b/tests/lib/mock_backend.py
@@ -73,6 +73,7 @@ def backend_factory(query_engine_cls):
                 i2=Column("integer", source="i2"),
                 b1=Column("boolean", source="b1"),
                 b2=Column("boolean", source="b2"),
+                c1=Column("varchar", source="c1"),
             ),
         )
         event_level_table = MappedTable(
@@ -83,6 +84,7 @@ def backend_factory(query_engine_cls):
                 i2=Column("integer", source="i2"),
                 b1=Column("boolean", source="b1"),
                 b2=Column("boolean", source="b2"),
+                c1=Column("varchar", source="c1"),
             ),
         )
 
@@ -186,6 +188,7 @@ class PatientLevelTable(Base):
     i2 = sqlalchemy.Column(sqlalchemy.Integer, default=null)
     b1 = sqlalchemy.Column(sqlalchemy.Boolean, default=null)
     b2 = sqlalchemy.Column(sqlalchemy.Boolean, default=null)
+    c1 = sqlalchemy.Column(sqlalchemy.Text, default=null)
 
 
 class EventLevelTable(Base):
@@ -196,3 +199,4 @@ class EventLevelTable(Base):
     i2 = sqlalchemy.Column(sqlalchemy.Integer, default=null)
     b1 = sqlalchemy.Column(sqlalchemy.Boolean, default=null)
     b2 = sqlalchemy.Column(sqlalchemy.Boolean, default=null)
+    c1 = sqlalchemy.Column(sqlalchemy.Text, default=null)

--- a/tests/spec/code_series_ops/__init__.py
+++ b/tests/spec/code_series_ops/__init__.py
@@ -1,0 +1,1 @@
+title = "Operations on all series containing codes"

--- a/tests/spec/code_series_ops/test_containment.py
+++ b/tests/spec/code_series_ops/test_containment.py
@@ -1,0 +1,29 @@
+from databuilder.codes import SNOMEDCTCode
+
+from ..tables import p
+
+title = "Testing for containment using codes"
+
+table_data = {
+    p: """
+          |  c1
+        --+-----
+        1 | abc
+        2 | def
+        3 | ghi
+        4 |
+        """,
+}
+
+
+def test_is_in(spec_test):
+    spec_test(
+        table_data,
+        p.c1.is_in([SNOMEDCTCode("abc"), SNOMEDCTCode("ghi")]),
+        {
+            1: True,
+            2: False,
+            3: True,
+            4: None,
+        },
+    )

--- a/tests/spec/conftest.py
+++ b/tests/spec/conftest.py
@@ -75,6 +75,8 @@ def parse_value(col_name, value):
         parse = int
     elif col_name[0] == "b":
         parse = lambda v: {"T": True, "F": False}[v]  # noqa E731
+    elif col_name[0] == "c":
+        parse = str
     else:
         assert False
 

--- a/tests/spec/series_ops/test_containment.py
+++ b/tests/spec/series_ops/test_containment.py
@@ -1,0 +1,27 @@
+from ..tables import p
+
+title = "Testing for containment"
+
+table_data = {
+    p: """
+          |  i1
+        --+-----
+        1 | 101
+        2 | 201
+        3 | 301
+        4 |
+        """,
+}
+
+
+def test_is_in(spec_test):
+    spec_test(
+        table_data,
+        p.i1.is_in(frozenset([101, 301])),
+        {
+            1: True,
+            2: False,
+            3: True,
+            4: None,
+        },
+    )

--- a/tests/spec/series_ops/test_containment.py
+++ b/tests/spec/series_ops/test_containment.py
@@ -17,7 +17,7 @@ table_data = {
 def test_is_in(spec_test):
     spec_test(
         table_data,
-        p.i1.is_in(frozenset([101, 301])),
+        p.i1.is_in([101, 301]),
         {
             1: True,
             2: False,

--- a/tests/spec/tables.py
+++ b/tests/spec/tables.py
@@ -1,3 +1,4 @@
+from databuilder.codes import SNOMEDCTCode
 from databuilder.query_language import build_event_table, build_patient_table
 
 p = build_patient_table(
@@ -7,6 +8,7 @@ p = build_patient_table(
         "i2": int,
         "b1": bool,
         "b2": bool,
+        "c1": SNOMEDCTCode,
     },
 )
 
@@ -18,5 +20,6 @@ e = build_event_table(
         "i2": int,
         "b1": bool,
         "b2": bool,
+        "c1": SNOMEDCTCode,
     },
 )

--- a/tests/spec/toc.py
+++ b/tests/spec/toc.py
@@ -31,4 +31,7 @@ contents = {
         "test_arithmetic_ops",
         "test_comparison_ops",
     ],
+    "code_series_ops": [
+        "test_containment",
+    ],
 }

--- a/tests/spec/toc.py
+++ b/tests/spec/toc.py
@@ -22,6 +22,7 @@ contents = {
     ],
     "series_ops": [
         "test_equality",
+        "test_containment",
     ],
     "bool_series_ops": [
         "test_logical_ops",

--- a/tests/unit/test_codes.py
+++ b/tests/unit/test_codes.py
@@ -1,0 +1,27 @@
+import pytest
+
+from databuilder.codes import CodelistError, CTV3Code, codelist_from_csv
+
+
+def test_codelist_from_csv(tmp_path):
+    csv_file = tmp_path / "codes.csv"
+    csv_file.write_text("CodeID,foo\nabc,123\ndef,456\n ghi ,789\n,")
+    codes = codelist_from_csv(csv_file, "CodeID", "ctv3")
+    assert codes == {CTV3Code("abc"), CTV3Code("def"), CTV3Code("ghi")}
+
+
+def test_codelist_from_csv_missing_column(tmp_path):
+    csv_file = tmp_path / "codes.csv"
+    csv_file.write_text("CodeID,foo\nabc,123\n,def,456\n ghi ,789")
+    with pytest.raises(CodelistError, match="no_col_here"):
+        codelist_from_csv(csv_file, "no_col_here", "ctv3")
+
+
+def test_codelist_from_csv_missing_file(tmp_path):
+    with pytest.raises(CodelistError, match="no_file_here.csv"):
+        codelist_from_csv(tmp_path / "no_file_here.csv", "CodeID", "ctv3")
+
+
+def test_codelist_from_csv_unknown_system():
+    with pytest.raises(CodelistError, match="not_a_real_system"):
+        codelist_from_csv("somefile.csv", "CodeID", "not_a_real_system")

--- a/tests/unit/test_query_language.py
+++ b/tests/unit/test_query_language.py
@@ -1,5 +1,7 @@
 from datetime import date
 
+import pytest
+
 from databuilder.query_language import (
     Dataset,
     DateEventSeries,
@@ -13,6 +15,7 @@ from databuilder.query_model import (
     SelectPatientTable,
     SelectTable,
     TableSchema,
+    TypeValidationError,
     Value,
 )
 
@@ -117,3 +120,16 @@ class TestDateSeries:
         assert_produces(
             DateEventSeries(qm_date_series).year, Function.YearFromDate(qm_date_series)
         )
+
+
+def test_is_in():
+    int_series = IntEventSeries(qm_int_series)
+    assert_produces(
+        int_series.is_in([1, 2]), Function.In(qm_int_series, Value(frozenset([1, 2])))
+    )
+
+
+def test_passing_a_single_value_to_is_in_raises_error():
+    int_series = IntEventSeries(qm_int_series)
+    with pytest.raises(TypeValidationError):
+        int_series.is_in(1)


### PR DESCRIPTION
This adds basic support for querying using codes. We add individual classes for each coding system. This allows us to use the type system to enforce that the right coding system is used.

There's obviously lots more to be done here, but I'd appreciate feedback on the general approach before we go too much further with it.