### PR TITLE
Fix some sorting issues

### DIFF
--- a/databuilder/query_engines/sqlite.py
+++ b/databuilder/query_engines/sqlite.py
@@ -9,7 +9,6 @@ from databuilder.query_model import (
     AggregateByPatient,
     Filter,
     Function,
-    PickOneRowPerPatient,
     Position,
     SelectColumn,
     SelectPatientTable,
@@ -18,6 +17,10 @@ from databuilder.query_model import (
     Value,
     get_domain,
     has_many_rows_per_patient,
+)
+from databuilder.query_model_transforms import (
+    PickOneRowPerPatientWithColumns,
+    apply_transforms,
 )
 
 from .base import BaseQueryEngine
@@ -28,6 +31,7 @@ class SQLiteQueryEngine(BaseQueryEngine):
     sqlalchemy_dialect = SQLiteDialect_pysqlite
 
     def get_query(self, variable_definitions):
+        variable_definitions = apply_transforms(variable_definitions)
         variable_expressions = {
             name: self.get_sql(definition)
             for name, definition in variable_definitions.items()
@@ -223,22 +227,18 @@ class SQLiteQueryEngine(BaseQueryEngine):
                 # Otherwise convert to the appropriate values
                 return sqlalchemy.case((has_row, single_row_value), else_=empty_value)
 
-    @get_sql.register(PickOneRowPerPatient)
+    @get_sql.register(PickOneRowPerPatientWithColumns)
     def get_sql_pick_one_row_per_patient(self, node):
-        query = self.get_select_query_for_node_domain(node.source)
-
-        # TODO: Really we only want to select the columns from the base table which
-        # we're actually going to use. In the old world we did some pre-processing of
-        # the graph to make this information available at the point we need it and we
-        # should probably reinstate that. But for now we just select all columns from
-        # the base table.
-        query = select_all_columns_from_base_table(query)
-
-        # Add an extra "row number" column to the query which gives the position of each
-        # row within its patient_id partition as implied by the order clauses
+        selected_columns = [self.get_sql(c) for c in node.selected_columns]
         order_clauses = [self.get_sql(c) for c in get_sort_conditions(node.source)]
+
         if node.position == Position.LAST:
             order_clauses = [c.desc() for c in order_clauses]
+
+        query = self.get_select_query_for_node_domain(node.source)
+        query = query.add_columns(*selected_columns)
+        # Add an extra "row number" column to the query which gives the position of each
+        # row within its patient_id partition as implied by the order clauses
         query = query.add_columns(
             sqlalchemy.func.row_number().over(
                 partition_by=query.selected_columns[0], order_by=order_clauses
@@ -327,15 +327,6 @@ def apply_patient_joins(query):
     for table in implicit_joins:
         query = query.join(table, table.c[join_column] == join_key, isouter=True)
     return query
-
-
-# TODO: This is hopefully a temporary workaround. See the comment at this function's one
-# call site for more detail.
-def select_all_columns_from_base_table(query):
-    base_table = query.get_final_froms()[0]
-    already_selected = {c.name for c in query.selected_columns}
-    other_columns = [c for c in base_table.c.values() if c.name not in already_selected]
-    return query.add_columns(*other_columns)
 
 
 def get_table_and_filter_conditions(frame):

--- a/databuilder/query_model.py
+++ b/databuilder/query_model.py
@@ -192,7 +192,7 @@ class Filter(ManyRowsPerPatientFrame):
 
 class Sort(SortedFrame):
     source: ManyRowsPerPatientFrame
-    sort_by: Series[Any]
+    sort_by: Series[Comparable]
 
 
 class PickOneRowPerPatient(OneRowPerPatientFrame):

--- a/databuilder/query_model_transforms.py
+++ b/databuilder/query_model_transforms.py
@@ -1,0 +1,97 @@
+"""
+Apply modifications to the query graph which make it easier to work with or allow us to
+generate more efficient SQL.
+
+This involes adding new kinds of nodes to the query model. However we deliberately
+define these nodes outside of the core query_model module because we're trying to
+maintain separation of three types of concern:
+
+    1. capturing the semantics of the query (which is the query model's job);
+    2. worrying about expressiveness and ease of use (which is ehrQL's job);
+    3. worrying about efficient execution (which is the query engines' job).
+
+The transformations applied here are all about efficient execution, and therefore we
+want to keep them separate from the core query model classes.
+"""
+import copy
+from typing import Any
+
+from databuilder.query_model import PickOneRowPerPatient, SelectColumn, get_input_nodes
+
+
+class PickOneRowPerPatientWithColumns(PickOneRowPerPatient):
+    selected_columns: frozenset[Any]
+
+
+def apply_transforms(variables):
+    # For algorithmic ease we're going to be mutating the query objects, so we make a
+    # copy first to avoid side-effects
+    variables = copy.deepcopy(variables)
+    reverse_index = get_reverse_index(variables.values())
+    add_selected_columns_to_pick_row(reverse_index)
+    return variables
+
+
+def get_reverse_index(nodes):
+    """
+    Return a dict mapping every node in the query to the (possibly empty) set of nodes
+    which reference it
+
+    This allows walking "backwards" along the graph which makes certain kinds of
+    transformation easier.
+    """
+    index = {}
+    for node in nodes:
+        populate_reverse_index(index, node)
+    return index
+
+
+def populate_reverse_index(index, node):
+    index.setdefault(node, set())
+    for subnode in get_input_nodes(node):
+        index.setdefault(subnode, set()).add(node)
+        populate_reverse_index(index, subnode)
+
+
+def add_selected_columns_to_pick_row(reverse_index):
+    """
+    Replace instances of `PickOneRowPerPatient` with `PickOneRowPerPatientWithColumns`
+    which track the columns that are going to be selected and allow us to generate the
+    appropriate query
+    """
+    for node, references in reverse_index.items():
+        if not isinstance(node, PickOneRowPerPatient):
+            continue
+        # Get the name of any columns selected from this node
+        column_names = {c.name for c in references if isinstance(c, SelectColumn)}
+        # Build a new set of SelectColumn operations which reference this node's source
+        # instead
+        selected_columns = frozenset(
+            SelectColumn(node.source, name) for name in column_names
+        )
+        # Create a new node which has the original attributes, plus the tuple of selected
+        # columns
+        new_node = PickOneRowPerPatientWithColumns(
+            source=node.source,
+            position=node.position,
+            selected_columns=selected_columns,
+        )
+        # Update any references to the old node to point to the new one
+        for ref_node in references:
+            update_references(ref_node, node, new_node)
+
+
+def update_references(target, old_ref, new_ref):
+    """
+    Replace references to `old_ref` with `new_ref` on `target`
+    """
+    # We're only expecting nodes with a source attribute here
+    assert target.source == old_ref
+    force_setattr(target, "source", new_ref)
+    # We're only expecting nodes which reference a single input
+    assert get_input_nodes(target) == [new_ref]
+
+
+# We can't modify attributes on frozen dataclass instances in the normal way, so we have
+# to use this
+force_setattr = object.__setattr__

--- a/tests/integration/test_query_engines.py
+++ b/tests/integration/test_query_engines.py
@@ -80,7 +80,9 @@ def test_multiple_takes_without_chaining(engine):
     }
 
 
-def test_handles_degenerate_poppulaton(engine):
+def test_handles_degenerate_population(engine):
+    # Specifying a population of "False" is obviously silly, but it's more work to
+    # identify and reject just this kind of silliness than it is to handle it gracefully
     engine.setup(metadata=sqlalchemy.MetaData())
     variables = dict(
         population=Value(False),

--- a/tests/lib/in_memory/database.py
+++ b/tests/lib/in_memory/database.py
@@ -295,7 +295,10 @@ class Column:
             # values are given the same position or else the resulting sort_index will
             # overspecify the order and we lose the stability of the sort operation
             value_to_position = {
-                value: position for (position, value) in enumerate(sorted(set(vv)))
+                value: position
+                for (position, value) in enumerate(
+                    sorted(set(vv), key=nulls_first_order)
+                )
             }
             return [value_to_position[v] for v in vv]
 
@@ -336,3 +339,8 @@ def handle_null(fn):
 
 def parse_value(value):
     return int(value) if value else None
+
+
+def nulls_first_order(key):
+    # Usable as a key function to `sorted()` which sorts NULLs first
+    return (0 if key is None else 1, key)

--- a/tests/spec/sort_and_pick/test_sort_by_column_with_nulls_and_pick.py
+++ b/tests/spec/sort_and_pick/test_sort_by_column_with_nulls_and_pick.py
@@ -1,0 +1,38 @@
+from ..tables import e
+
+title = "Picking the first or last row for each patient where a column contains NULLs"
+
+table_data = {
+    e: """
+          |  i1
+        --+-----
+        1 |
+        1 | 102
+        1 | 103
+        2 | 203
+        2 | 202
+        2 |
+        """,
+}
+
+
+def test_sort_by_column_with_nulls_and_pick_first(spec_test):
+    spec_test(
+        table_data,
+        e.sort_by(e.i1).first_for_patient().i1,
+        {
+            1: None,
+            2: None,
+        },
+    )
+
+
+def test_sort_by_column_with_nulls_and_pick_last(spec_test):
+    spec_test(
+        table_data,
+        e.sort_by(e.i1).last_for_patient().i1,
+        {
+            1: 103,
+            2: 203,
+        },
+    )

--- a/tests/spec/toc.py
+++ b/tests/spec/toc.py
@@ -8,6 +8,7 @@ contents = {
     "sort_and_pick": [
         "test_sort_by_column_and_pick",
         "test_sort_by_multiple_columns_and_pick",
+        "test_sort_by_column_with_nulls_and_pick",
     ],
     "aggregate_frame": [
         "test_exists_for_patient",

--- a/tests/unit/test_query_model.py
+++ b/tests/unit/test_query_model.py
@@ -27,7 +27,7 @@ from databuilder.query_model import (
     has_one_row_per_patient,
 )
 
-EVENTS_SCHEMA = TableSchema(date=datetime.date, code=str)
+EVENTS_SCHEMA = TableSchema(date=datetime.date, code=str, flag=bool)
 
 
 # TEST BASIC QUERY MODEL PROPERTIES
@@ -311,6 +311,13 @@ def test_cannot_pick_row_from_unsorted_table():
     events = SelectTable("events")
     with pytest.raises(TypeValidationError):
         PickOneRowPerPatient(events, Position.FIRST)  # type: ignore
+
+
+def test_cannot_sort_by_non_comparable_type():
+    events = SelectTable("events", EVENTS_SCHEMA)
+    bool_column = SelectColumn(events, "flag")
+    with pytest.raises(TypeValidationError):
+        Sort(events, bool_column)
 
 
 def test_cannot_pass_argument_without_wrapping_in_value():

--- a/tests/unit/test_query_model_transforms.py
+++ b/tests/unit/test_query_model_transforms.py
@@ -1,0 +1,46 @@
+from databuilder.query_model import (
+    PickOneRowPerPatient,
+    Position,
+    SelectColumn,
+    SelectTable,
+    Sort,
+)
+from databuilder.query_model_transforms import (
+    PickOneRowPerPatientWithColumns,
+    apply_transforms,
+)
+
+
+def test_pick_one_row_per_patient_transform():
+    events = SelectTable("events")
+    date = SelectColumn(events, "date")
+    by_date = Sort(events, date)
+    first_event = PickOneRowPerPatient(by_date, Position.FIRST)
+    variables = dict(
+        first_code=SelectColumn(first_event, "code"),
+        first_value=SelectColumn(first_event, "value"),
+    )
+
+    first_event_with_columns = PickOneRowPerPatientWithColumns(
+        source=by_date,
+        position=Position.FIRST,
+        selected_columns=frozenset(
+            {
+                SelectColumn(
+                    source=by_date,
+                    name="value",
+                ),
+                SelectColumn(
+                    source=by_date,
+                    name="code",
+                ),
+            }
+        ),
+    )
+    expected = {
+        "first_code": SelectColumn(first_event_with_columns, "code"),
+        "first_value": SelectColumn(first_event_with_columns, "value"),
+    }
+
+    transformed = apply_transforms(variables)
+    assert transformed == expected


### PR DESCRIPTION
This fixes two issues:
 * prevents sorting by things which aren't orderable (like booleans);
 * defines a sort order for NULLs and fixes the in-memory engine to handle them.

It also refactors the SQLite implementation to only select the columns that are actually going to be used in the query. This was done not so much for the performance gains (though we would certainly need to do this before going live anyway) but because it means we no longer rely on the backend to tell us the available columns. And this paves the way for a simpler API, and the ability to run without requiring a backend at all.

Sadly, it doesn't entirely put our sorting issues to bed (see [this comment](https://github.com/opensafely-core/databuilder/issues/461#issuecomment-1129076022)); though I did some now wasted work in the belief that it would.