### PR TITLE
Begin backend refactor

### DIFF
--- a/databuilder/backends/base.py
+++ b/databuilder/backends/base.py
@@ -16,10 +16,6 @@ class BaseBackend:
     patient_join_column = None
     tables = None
 
-    def __init__(self, database_url, temporary_database=None):
-        self.database_url = database_url
-        self.temporary_database = temporary_database
-
     def __init_subclass__(cls, **kwargs):
         assert cls.backend_id is not None
         assert cls.query_engine_class is not None

--- a/databuilder/main.py
+++ b/databuilder/main.py
@@ -24,8 +24,11 @@ def generate_dataset(
     log.info(f"Generating dataset for {str(definition_file)}")
 
     dataset = load_definition(definition_file)
-    backend = BACKENDS[backend_id](db_url, temporary_database=temporary_database)
-    results = extract(dataset, backend)
+    backend = BACKENDS[backend_id]()
+    query_engine = backend.query_engine_class(
+        db_url, backend, temporary_database=temporary_database
+    )
+    results = extract(dataset, query_engine, backend)
 
     dataset_file.parent.mkdir(parents=True, exist_ok=True)
     write_dataset(results, dataset_file)
@@ -46,8 +49,9 @@ def validate_dataset(definition_file, output_file, backend_id):
     log.info(f"Validating dataset for {str(definition_file)}")
 
     dataset = load_definition(definition_file)
-    backend = BACKENDS[backend_id](database_url=None)
-    results = validate(dataset, backend)
+    backend = BACKENDS[backend_id]()
+    query_engine = backend.query_engine_class(None, backend)
+    results = validate(dataset, query_engine)
     log.info("Validation succeeded")
 
     output_file.parent.mkdir(parents=True, exist_ok=True)
@@ -65,8 +69,8 @@ def generate_measures(
 def test_connection(backend, url):
     from sqlalchemy import select
 
-    backend = BACKENDS[backend](url, temporary_database=None)
-    query_engine = backend.query_engine_class(backend)
+    backend = BACKENDS[backend]()
+    query_engine = backend.query_engine_class(url, backend)
     with query_engine.engine.connect() as connection:
         connection.execute(select(1))
     print("SUCCESS")
@@ -101,27 +105,26 @@ def add_to_sys_path(directory):
         sys.path = original
 
 
-def extract(dataset_definition, backend):
+def extract(dataset_definition, query_engine, backend):
     """
     Extracts the dataset from the backend specified
     Args:
         dataset_definition: The definition of the Dataset
+        query_engine: The Query Engine with which the Dataset is being extracted
         backend: The Backend that the Dataset is being extracted from
     Returns:
         Yields the dataset as rows
     """
     backend.validate_contracts()
     dataset = ql.compile(dataset_definition)
-    query_engine = backend.query_engine_class(backend)
     with query_engine.execute_query(dataset) as results:
         for row in results:
             yield dict(row)
 
 
-def validate(dataset_class, backend):
+def validate(dataset_class, query_engine):
     try:
         dataset = ql.compile(dataset_class)
-        query_engine = backend.query_engine_class(backend)
         setup_queries, results_query, cleanup_queries = query_engine.get_queries(
             dataset
         )

--- a/databuilder/main.py
+++ b/databuilder/main.py
@@ -28,7 +28,8 @@ def generate_dataset(
     query_engine = backend.query_engine_class(
         db_url, backend, temporary_database=temporary_database
     )
-    results = extract(dataset, query_engine, backend)
+    backend.validate_contracts()
+    results = extract(dataset, query_engine)
 
     dataset_file.parent.mkdir(parents=True, exist_ok=True)
     write_dataset(results, dataset_file)
@@ -105,17 +106,15 @@ def add_to_sys_path(directory):
         sys.path = original
 
 
-def extract(dataset_definition, query_engine, backend):
+def extract(dataset_definition, query_engine):
     """
     Extracts the dataset from the backend specified
     Args:
         dataset_definition: The definition of the Dataset
         query_engine: The Query Engine with which the Dataset is being extracted
-        backend: The Backend that the Dataset is being extracted from
     Returns:
         Yields the dataset as rows
     """
-    backend.validate_contracts()
     dataset = ql.compile(dataset_definition)
     with query_engine.execute_query(dataset) as results:
         for row in results:

--- a/databuilder/main.py
+++ b/databuilder/main.py
@@ -66,7 +66,7 @@ def test_connection(backend, url):
     from sqlalchemy import select
 
     backend = BACKENDS[backend](url, temporary_database=None)
-    query_engine = backend.query_engine_class({}, backend)
+    query_engine = backend.query_engine_class(backend)
     with query_engine.engine.connect() as connection:
         connection.execute(select(1))
     print("SUCCESS")
@@ -112,8 +112,8 @@ def extract(dataset_definition, backend):
     """
     backend.validate_contracts()
     dataset = ql.compile(dataset_definition)
-    query_engine = backend.query_engine_class(dataset, backend)
-    with query_engine.execute_query() as results:
+    query_engine = backend.query_engine_class(backend)
+    with query_engine.execute_query(dataset) as results:
         for row in results:
             yield dict(row)
 
@@ -121,8 +121,10 @@ def extract(dataset_definition, backend):
 def validate(dataset_class, backend):
     try:
         dataset = ql.compile(dataset_class)
-        query_engine = backend.query_engine_class(dataset, backend)
-        setup_queries, results_query, cleanup_queries = query_engine.get_queries()
+        query_engine = backend.query_engine_class(backend)
+        setup_queries, results_query, cleanup_queries = query_engine.get_queries(
+            dataset
+        )
         return setup_queries + [results_query] + cleanup_queries
     except Exception:  # pragma: no cover (puzzle: dataset definition that compiles to QM but not SQL)
         log.error("Validation failed")

--- a/databuilder/query_engines/base.py
+++ b/databuilder/query_engines/base.py
@@ -5,18 +5,17 @@ class BaseQueryEngine:
     language (SQL, pandas dataframes etc).
     """
 
-    def __init__(self, column_definitions, backend):
+    def __init__(self, backend):
+        """
+        `backend` is a Backend instance
+        """
+        self.backend = backend
+
+    def execute_query(self, column_definitions):
         """
         `column_definitions` is a dictionary mapping output column names to
         query model graphs which specify the queries used to populate them
 
-        `backend` is a Backend instance
-        """
-        self.column_definitions = column_definitions
-        self.backend = backend
-
-    def execute_query(self):
-        """
         Override this method to do the things necessary to generate query code and execute
         it against a particular backend
         """

--- a/databuilder/query_engines/base.py
+++ b/databuilder/query_engines/base.py
@@ -5,11 +5,16 @@ class BaseQueryEngine:
     language (SQL, pandas dataframes etc).
     """
 
-    def __init__(self, backend):
+    def __init__(self, dsn, backend, temporary_database=None):
         """
+        `dsn` is  Data Source Name — a string (usually a URL) which provides connection
+            details to a data source (usually a RDBMS)
         `backend` is a Backend instance
         """
+        self.dsn = dsn
         self.backend = backend
+        # TODO: Not sure this belongs here but let's worry about that later
+        self.temporary_database = temporary_database
 
     def execute_query(self, column_definitions):
         """

--- a/databuilder/query_engines/base_sql.py
+++ b/databuilder/query_engines/base_sql.py
@@ -588,7 +588,7 @@ class BaseSQLQueryEngine(BaseQueryEngine):
     #
     @cached_property
     def engine(self):
-        engine_url = sqlalchemy.engine.make_url(self.backend.database_url)
+        engine_url = sqlalchemy.engine.make_url(self.dsn)
         # Hardcode the specific SQLAlchemy dialect we want to use: this is the
         # dialect the query engine will have been written for and tested with and we
         # don't want to allow global config changes to alter this

--- a/databuilder/query_engines/base_sql.py
+++ b/databuilder/query_engines/base_sql.py
@@ -136,7 +136,7 @@ class BaseSQLQueryEngine(BaseQueryEngine):
         # See docstring on `get_sql_element` for details on this
         self.sql_element_cache: dict[QueryNode, ClauseElement] = {}
 
-    def get_queries(self):
+    def get_queries(self, column_definitions):
         """
         Build the list of SQL queries to execute
 
@@ -144,8 +144,6 @@ class BaseSQLQueryEngine(BaseQueryEngine):
 
             list_of_setup_queries, query_to_fetch_results, list_of_cleanup_queries
         """
-        column_definitions = self.column_definitions
-
         # Check that we are being passed the new-style query model and convert it to
         # the old, which we use internally for now.
         assert isinstance(list(column_definitions.values())[0], query_model.Node)
@@ -199,8 +197,10 @@ class BaseSQLQueryEngine(BaseQueryEngine):
         return setup_queries, results_query, cleanup_queries
 
     @contextlib.contextmanager
-    def execute_query(self):
-        setup_queries, results_query, cleanup_queries = self.get_queries()
+    def execute_query(self, column_definitions):
+        setup_queries, results_query, cleanup_queries = self.get_queries(
+            column_definitions
+        )
         with self.engine.connect() as cursor:
             for query in setup_queries:
                 cursor.execute(query)

--- a/databuilder/query_engines/mssql.py
+++ b/databuilder/query_engines/mssql.py
@@ -47,7 +47,7 @@ class MssqlQueryEngine(BaseSQLQueryEngine):
         return False
 
     @contextlib.contextmanager
-    def execute_query(self):
+    def execute_query(self, column_definitions):
         """Execute a query against an MSSQL backend"""
         if self.backend.temporary_database:
             # If we've got access to a temporary database then we use this
@@ -55,7 +55,9 @@ class MssqlQueryEngine(BaseSQLQueryEngine):
             # in batches. This gives us the illusion of having a robust
             # connection to the database, whereas in practice in frequently
             # errors out when attempting to download large sets of results.
-            setup_queries, results_query, cleanup_queries = self.get_queries()
+            setup_queries, results_query, cleanup_queries = self.get_queries(
+                column_definitions
+            )
             # We're not expecting to have any cleanup to do here because we should be
             # using session-scoped temporary tables
             assert not cleanup_queries
@@ -75,7 +77,7 @@ class MssqlQueryEngine(BaseSQLQueryEngine):
         else:
             # Otherwise we just execute the queries and download the results in
             # the normal manner
-            with super().execute_query() as results:
+            with super().execute_query(column_definitions) as results:
                 yield results
 
     def _convert_date_diff_to_days(

--- a/databuilder/query_engines/mssql.py
+++ b/databuilder/query_engines/mssql.py
@@ -49,7 +49,7 @@ class MssqlQueryEngine(BaseSQLQueryEngine):
     @contextlib.contextmanager
     def execute_query(self, column_definitions):
         """Execute a query against an MSSQL backend"""
-        if self.backend.temporary_database:
+        if self.temporary_database:
             # If we've got access to a temporary database then we use this
             # function to manage storing our results in there and downloading
             # in batches. This gives us the illusion of having a robust
@@ -65,7 +65,7 @@ class MssqlQueryEngine(BaseSQLQueryEngine):
                 engine=self.engine,
                 queries=setup_queries + [results_query],
                 # The double dot syntax allows us to reference tables in another database
-                temp_table_prefix=f"{self.backend.temporary_database}..TempExtract",
+                temp_table_prefix=f"{self.temporary_database}..TempExtract",
                 # This value was copied from the previous cohortextractor. I
                 # suspect it has no real scientific basis.
                 batch_size=32000,

--- a/databuilder/query_engines/spark.py
+++ b/databuilder/query_engines/spark.py
@@ -60,7 +60,7 @@ class SparkQueryEngine(BaseSQLQueryEngine):
         return True
 
     def get_temp_database(self):
-        return self.backend.temporary_database
+        return self.temporary_database
 
     def _convert_date_diff_to_days(
         self, start, end

--- a/databuilder/query_engines/sqlite.py
+++ b/databuilder/query_engines/sqlite.py
@@ -303,7 +303,7 @@ class SQLiteQueryEngine(BaseQueryEngine):
 
     @cached_property
     def engine(self):
-        engine_url = sqlalchemy.engine.make_url(self.backend.database_url)
+        engine_url = sqlalchemy.engine.make_url(self.dsn)
         # Hardcode the specific SQLAlchemy dialect we want to use: this is the
         # dialect the query engine will have been written for and tested with and we
         # don't want to allow global config changes to alter this

--- a/databuilder/query_engines/sqlite.py
+++ b/databuilder/query_engines/sqlite.py
@@ -296,8 +296,8 @@ class SQLiteQueryEngine(BaseQueryEngine):
         return query
 
     @contextlib.contextmanager
-    def execute_query(self):
-        results_query = self.get_query(self.column_definitions)
+    def execute_query(self, variable_definitions):
+        results_query = self.get_query(variable_definitions)
         with self.engine.connect() as cursor:
             yield cursor.execute(results_query)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -59,20 +59,20 @@ class QueryEngineFixture:
     def setup(self, *items, metadata=None):
         return self.database.setup(*items, metadata=metadata)
 
-    def extract(self, dataset, **backend_kwargs):
-        results = list(
-            main.extract(
-                dataset, self.backend(self.database.host_url(), **backend_kwargs)
-            )
+    def extract(self, dataset, **engine_kwargs):
+        backend = self.backend()
+        query_engine = self.query_engine_class(
+            self.database.host_url(), backend, **engine_kwargs
         )
+        results = list(main.extract(dataset, query_engine, backend))
         # We don't explicitly order the results and not all databases naturally return
         # in the same order
         results.sort(key=lambda i: i["patient_id"])
         return results
 
     def extract_qm(self, variables):
-        backend = self.backend(self.database.host_url())
-        query_engine = self.query_engine_class(backend)
+        backend = self.backend()
+        query_engine = self.query_engine_class(self.database.host_url(), backend)
         with query_engine.execute_query(variables) as results:
             result = list(dict(row) for row in results)
             result.sort(key=lambda i: i["patient_id"])  # ensure stable ordering

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,19 +60,17 @@ class QueryEngineFixture:
         return self.database.setup(*items, metadata=metadata)
 
     def extract(self, dataset, **engine_kwargs):
-        backend = self.backend()
         query_engine = self.query_engine_class(
-            self.database.host_url(), backend, **engine_kwargs
+            self.database.host_url(), self.backend(), **engine_kwargs
         )
-        results = list(main.extract(dataset, query_engine, backend))
+        results = list(main.extract(dataset, query_engine))
         # We don't explicitly order the results and not all databases naturally return
         # in the same order
         results.sort(key=lambda i: i["patient_id"])
         return results
 
     def extract_qm(self, variables):
-        backend = self.backend()
-        query_engine = self.query_engine_class(self.database.host_url(), backend)
+        query_engine = self.query_engine_class(self.database.host_url(), self.backend())
         with query_engine.execute_query(variables) as results:
             result = list(dict(row) for row in results)
             result.sort(key=lambda i: i["patient_id"])  # ensure stable ordering

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -72,8 +72,8 @@ class QueryEngineFixture:
 
     def extract_qm(self, variables):
         backend = self.backend(self.database.host_url())
-        query_engine = self.query_engine_class(variables, backend)
-        with query_engine.execute_query() as results:
+        query_engine = self.query_engine_class(backend)
+        with query_engine.execute_query(variables) as results:
             result = list(dict(row) for row in results)
             result.sort(key=lambda i: i["patient_id"])  # ensure stable ordering
             return result

--- a/tests/generative/test_query_model.py
+++ b/tests/generative/test_query_model.py
@@ -77,8 +77,8 @@ def run_with(database_class, engine_class, instances, variables):
     database = database_class()
     database.setup(instances, metadata=sqla_metadata)
 
-    engine = engine_class(variables, Backend(database.host_url()))
-    with engine.execute_query() as results:
+    engine = engine_class(Backend(database.host_url()))
+    with engine.execute_query(variables) as results:
         result = list(dict(row) for row in results)
         result.sort(key=lambda i: i["patient_id"])  # ensure stable ordering
         return result

--- a/tests/generative/test_query_model.py
+++ b/tests/generative/test_query_model.py
@@ -77,7 +77,7 @@ def run_with(database_class, engine_class, instances, variables):
     database = database_class()
     database.setup(instances, metadata=sqla_metadata)
 
-    engine = engine_class(Backend(database.host_url()))
+    engine = engine_class(database.host_url(), Backend())
     with engine.execute_query(variables) as results:
         result = list(dict(row) for row in results)
         result.sort(key=lambda i: i["patient_id"])  # ensure stable ordering

--- a/tests/legacy/conftest.py
+++ b/tests/legacy/conftest.py
@@ -11,9 +11,9 @@ from .query_model_convert_to_new import convert as convert_to_new
 # old-style cohort definitions. This allows us to retain these old test cases as a harness while we
 # refactor the Query Engine.
 class LegacyQueryEngineFixture(QueryEngineFixture):
-    def build_engine(self, cohort, **backend_kwargs):
+    def build_engine(self, **backend_kwargs):
         backend = self.backend(self.database.host_url(), **backend_kwargs)
-        return backend.query_engine_class(self._convert(cohort), backend)
+        return backend.query_engine_class(backend)
 
     def extract(self, cohort, **backend_kwargs):
         with self._execute(cohort, **backend_kwargs) as results:
@@ -22,7 +22,8 @@ class LegacyQueryEngineFixture(QueryEngineFixture):
             return result
 
     def _execute(self, cohort, **backend_kwargs):
-        return self.build_engine(cohort, **backend_kwargs).execute_query()
+        converted = self._convert(cohort)
+        return self.build_engine(**backend_kwargs).execute_query(converted)
 
     @staticmethod
     def _convert(cohort):

--- a/tests/legacy/test_query_engine_legacy.py
+++ b/tests/legacy/test_query_engine_legacy.py
@@ -22,10 +22,7 @@ class OldCohortWithPopulation:
 
 
 def test_query_engine_caches_sql_engine(engine):
-    class EmptyCohort:
-        pass
-
-    query_engine = engine.build_engine(EmptyCohort)
+    query_engine = engine.build_engine()
     # Check that the property caches the results and gives us the same object each time
     sql_engine_1 = query_engine.engine
     sql_engine_2 = query_engine.engine

--- a/tests/lib/in_memory/engine.py
+++ b/tests/lib/in_memory/engine.py
@@ -19,7 +19,7 @@ class InMemoryQueryEngine(BaseQueryEngine):
     """
 
     @contextlib.contextmanager
-    def execute_query(self):
+    def execute_query(self, variable_definitions):
         name_to_col = {
             "patient_id": Column(
                 {patient: [patient] for patient in self.all_patients},
@@ -27,7 +27,7 @@ class InMemoryQueryEngine(BaseQueryEngine):
             )
         }
 
-        for name, node in self.column_definitions.items():
+        for name, node in variable_definitions.items():
             col = self.visit(node)
             assert not col.any_patient_has_multiple_values()
             name_to_col[name] = col

--- a/tests/lib/in_memory/engine.py
+++ b/tests/lib/in_memory/engine.py
@@ -47,7 +47,7 @@ class InMemoryQueryEngine(BaseQueryEngine):
         # a database to connect to.  Since our database is just an object in our
         # process, we instantiate this engine with an instance of the database.  See
         # InMemoryDatabase.host_url.
-        return self.backend.database_url
+        return self.dsn
 
     @property
     def tables(self):

--- a/tests/unit/query_engines/test_sqlite.py
+++ b/tests/unit/query_engines/test_sqlite.py
@@ -16,7 +16,7 @@ class DummyBackend:
 def test_or_with_literal():
     # SQLAlchemy doesn't provide reverse bitwise operations, so `False | Column()` raises a `TypeError`.
     # See https://github.com/sqlalchemy/sqlalchemy/issues/5846.
-    engine = SQLiteQueryEngine(None, DummyBackend())
+    engine = SQLiteQueryEngine(DummyBackend())
     engine.get_sql(Function.Or(Value(True), SelectColumn(SelectPatientTable("t"), "c")))
     engine.get_sql(Function.Or(SelectColumn(SelectPatientTable("t"), "c"), Value(True)))
 
@@ -24,7 +24,7 @@ def test_or_with_literal():
 def test_and_with_literal():
     # SQLAlchemy doesn't provide reverse bitwise operations, so `True & Column()` raises a `TypeError`.
     # See https://github.com/sqlalchemy/sqlalchemy/issues/5846.
-    engine = SQLiteQueryEngine(None, DummyBackend())
+    engine = SQLiteQueryEngine(DummyBackend())
     engine.get_sql(
         Function.And(Value(False), SelectColumn(SelectPatientTable("t"), "c"))
     )

--- a/tests/unit/query_engines/test_sqlite.py
+++ b/tests/unit/query_engines/test_sqlite.py
@@ -16,7 +16,7 @@ class DummyBackend:
 def test_or_with_literal():
     # SQLAlchemy doesn't provide reverse bitwise operations, so `False | Column()` raises a `TypeError`.
     # See https://github.com/sqlalchemy/sqlalchemy/issues/5846.
-    engine = SQLiteQueryEngine(DummyBackend())
+    engine = SQLiteQueryEngine(None, DummyBackend())
     engine.get_sql(Function.Or(Value(True), SelectColumn(SelectPatientTable("t"), "c")))
     engine.get_sql(Function.Or(SelectColumn(SelectPatientTable("t"), "c"), Value(True)))
 
@@ -24,7 +24,7 @@ def test_or_with_literal():
 def test_and_with_literal():
     # SQLAlchemy doesn't provide reverse bitwise operations, so `True & Column()` raises a `TypeError`.
     # See https://github.com/sqlalchemy/sqlalchemy/issues/5846.
-    engine = SQLiteQueryEngine(DummyBackend())
+    engine = SQLiteQueryEngine(None, DummyBackend())
     engine.get_sql(
         Function.And(Value(False), SelectColumn(SelectPatientTable("t"), "c"))
     )


### PR DESCRIPTION
This begins the process of unwinding the slightly muddled relationship between Query Engines and Backends. In particular:
 * database connection details are now passed directly to the Query Engine, rather than via the Backend;
 * the dataset definition is no longer passed to the Query Engine constructor, but rather to the `execute_query()` method