### PR TITLE
Support categorised codelists

### DIFF
--- a/databuilder/population_validation.py
+++ b/databuilder/population_validation.py
@@ -5,7 +5,7 @@ from functools import singledispatch
 
 from databuilder.query_model import (
     AggregateByPatient,
-    Categorise,
+    Case,
     Function,
     SelectColumn,
     Series,
@@ -155,9 +155,9 @@ def evaluate_or(node):
         return None
 
 
-@evaluate.register(Categorise)
-def evaluate_categorise(node):
-    for value, condition in node.categories.items():
+@evaluate.register(Case)
+def evaluate_case(node):
+    for value, condition in node.cases.items():
         if evaluate(condition) is True:
             return evaluate(value)
     if node.default is not None:

--- a/databuilder/population_validation.py
+++ b/databuilder/population_validation.py
@@ -157,7 +157,7 @@ def evaluate_or(node):
 
 @evaluate.register(Case)
 def evaluate_case(node):
-    for value, condition in node.cases.items():
+    for condition, value in node.cases.items():
         if evaluate(condition) is True:
             return evaluate(value)
     if node.default is not None:

--- a/databuilder/query_engines/query_model_convert_to_old.py
+++ b/databuilder/query_engines/query_model_convert_to_old.py
@@ -181,10 +181,9 @@ for type_ in AGGREGATE_MAP.keys():
 
 
 @convert_node.register
-def convert_categorise(node: new.Categorise):
+def convert_case(node: new.Case):
     definitions = {
-        convert_value(key): convert_node(value)
-        for key, value in node.categories.items()
+        convert_value(key): convert_node(value) for key, value in node.cases.items()
     }
     if node.default is not None:
         default = convert_value(node.default)

--- a/databuilder/query_engines/query_model_convert_to_old.py
+++ b/databuilder/query_engines/query_model_convert_to_old.py
@@ -183,7 +183,8 @@ for type_ in AGGREGATE_MAP.keys():
 @convert_node.register
 def convert_case(node: new.Case):
     definitions = {
-        convert_value(key): convert_node(value) for key, value in node.cases.items()
+        convert_value(value): convert_node(condition)
+        for condition, value in node.cases.items()
     }
     if node.default is not None:
         default = convert_value(node.default)

--- a/databuilder/query_engines/sqlite.py
+++ b/databuilder/query_engines/sqlite.py
@@ -7,6 +7,7 @@ from sqlalchemy.sql import operators
 
 from databuilder.query_model import (
     AggregateByPatient,
+    Case,
     Filter,
     Function,
     Position,
@@ -158,6 +159,18 @@ class SQLiteQueryEngine(BaseQueryEngine):
     def get_sql_select_column(self, node):
         source = self.get_sql(node.source)
         return source.c[node.name]
+
+    @get_sql.register(Case)
+    def get_sql_case(self, node):
+        cases = [
+            (self.get_sql(condition), self.get_sql(value))
+            for (condition, value) in node.cases.items()
+        ]
+        if node.default is not None:
+            default = self.get_sql(node.default)
+        else:
+            default = None
+        return sqlalchemy.case(*cases, else_=default)
 
     # We have to apply caching here otherwise we generate distinct objects representing
     # the same table and this confuses SQLAlchemy into generating queries with ambiguous

--- a/databuilder/query_language.py
+++ b/databuilder/query_language.py
@@ -273,7 +273,7 @@ def _convert(arg):
         return arg.qm_node
     # If it's a Codelist extract the set of codes and put it in a Value wrapper
     elif isinstance(arg, Codelist):
-        return qm.Value(arg.codes)
+        return qm.Value(frozenset(arg.codes))
     # Otherwise it's a static value and needs to be put in a query model Value wrapper
     else:
         return qm.Value(arg)

--- a/databuilder/query_language.py
+++ b/databuilder/query_language.py
@@ -2,7 +2,7 @@ import dataclasses
 import datetime
 
 from databuilder import query_model as qm
-from databuilder.codes import BaseCode
+from databuilder.codes import BaseCode, Codelist
 from databuilder.population_validation import validate_population_definition
 from databuilder.query_model import get_series_type, has_one_row_per_patient
 
@@ -271,6 +271,9 @@ def _convert(arg):
     # If it's an ehrQL series then get the wrapped query model node
     elif isinstance(arg, Series):
         return arg.qm_node
+    # If it's a Codelist extract the set of codes and put it in a Value wrapper
+    elif isinstance(arg, Codelist):
+        return qm.Value(arg.codes)
     # Otherwise it's a static value and needs to be put in a query model Value wrapper
     else:
         return qm.Value(arg)

--- a/databuilder/query_language.py
+++ b/databuilder/query_language.py
@@ -216,13 +216,17 @@ class DatePatientSeries(DateFunctions, PatientSeries):
 # CODE SERIES
 #
 
-# For now we treat Codes as totally opaque objects and so Code series get no functions
-# or aggregations beyond those common to all series
-class CodeEventSeries(EventSeries):
+
+class CodeFunctions:
+    def to_category(self, categorisation):
+        return self.map_values(categorisation)
+
+
+class CodeEventSeries(CodeFunctions, EventSeries):
     _type = BaseCode
 
 
-class CodePatientSeries(PatientSeries):
+class CodePatientSeries(CodeFunctions, PatientSeries):
     _type = BaseCode
 
 

--- a/databuilder/query_language.py
+++ b/databuilder/query_language.py
@@ -241,15 +241,19 @@ def _apply(qm_cls, *args):
     series or static values, returns an ehrQL series
     """
     # Convert all arguments into query model nodes
-    qm_args = [
-        # If it's an ehrQL series then get the wrapped query model node, otherwise it's
-        # a static value and needs to be put in query model Value wrapper
-        arg.qm_node if isinstance(arg, Series) else qm.Value(arg)
-        for arg in args
-    ]
+    qm_args = map(_convert, args)
     qm_node = qm_cls(*qm_args)
     # Wrap the resulting node back up in an ehrQL series
     return _wrap(qm_node)
+
+
+def _convert(arg):
+    # If it's an ehrQL series then get the wrapped query model node
+    if isinstance(arg, Series):
+        return arg.qm_node
+    # Otherwise it's a static value and needs to be put in a query model Value wrapper
+    else:
+        return qm.Value(arg)
 
 
 # FRAME TYPES

--- a/databuilder/query_model.py
+++ b/databuilder/query_model.py
@@ -317,7 +317,7 @@ class Function:
 
 class Case(Series[T]):
     cases: Mapping[Series[bool], Series[T]]
-    default: Optional[Series[T]]
+    default: Optional[Series[T]] = None
 
     def __hash__(self):
         # `cases` is a dict and so not hashable by default, but we treat it as

--- a/databuilder/query_model.py
+++ b/databuilder/query_model.py
@@ -23,7 +23,7 @@ __all__ = [
     "Position",
     "AggregateByPatient",
     "Function",
-    "Categorise",
+    "Case",
     "TableSchema",
     "ValidationError",
     "DomainMismatchError",
@@ -315,14 +315,14 @@ class Function:
         rhs: Series[Set[T]]
 
 
-class Categorise(Series[T]):
-    categories: Mapping[Series[T], Series[bool]]
+class Case(Series[T]):
+    cases: Mapping[Series[T], Series[bool]]
     default: Optional[Series[T]]
 
     def __hash__(self):
-        # `categories` is a dict and so not hashable by default, but we treat it as
+        # `cases` is a dict and so not hashable by default, but we treat it as
         # immutable once created so we're fine to make it hashable
-        return hash((tuple(self.categories.items()), self.default))
+        return hash((tuple(self.cases.items()), self.default))
 
 
 # TODO: We don't currently support Join in the DSL or the Query Engine but this is the
@@ -524,11 +524,11 @@ def get_input_nodes(node):
     ]
 
 
-# The above bit of dynamic cheekiness doesn't work for Categorise whose inputs are
+# The above bit of dynamic cheekiness doesn't work for Case whose inputs are
 # nested inside a dict object
-@get_input_nodes.register(Categorise)
-def get_input_nodes_for_categorise(node):
-    inputs = [*node.categories.keys(), *node.categories.values()]
+@get_input_nodes.register(Case)
+def get_input_nodes_for_case(node):
+    inputs = [*node.cases.keys(), *node.cases.values()]
     if node.default is not None:
         inputs.append(node.default)
     return inputs

--- a/databuilder/query_model.py
+++ b/databuilder/query_model.py
@@ -316,7 +316,7 @@ class Function:
 
 
 class Case(Series[T]):
-    cases: Mapping[Series[T], Series[bool]]
+    cases: Mapping[Series[bool], Series[T]]
     default: Optional[Series[T]]
 
     def __hash__(self):

--- a/tests/legacy/query_model_convert_to_new.py
+++ b/tests/legacy/query_model_convert_to_new.py
@@ -140,8 +140,8 @@ def convert_value_from_aggregate(node: old.ValueFromAggregate):
 @convert_node.register
 def convert_value_from_category(node: old.ValueFromCategory):
     cases = {
-        convert_value(key): convert_node(value)
-        for key, value in node.definitions.items()
+        convert_node(condition): convert_value(value)
+        for value, condition in node.definitions.items()
     }
     if node.default is not None:
         default = convert_value(node.default)

--- a/tests/legacy/query_model_convert_to_new.py
+++ b/tests/legacy/query_model_convert_to_new.py
@@ -139,7 +139,7 @@ def convert_value_from_aggregate(node: old.ValueFromAggregate):
 
 @convert_node.register
 def convert_value_from_category(node: old.ValueFromCategory):
-    definitions = {
+    cases = {
         convert_value(key): convert_node(value)
         for key, value in node.definitions.items()
     }
@@ -147,7 +147,7 @@ def convert_value_from_category(node: old.ValueFromCategory):
         default = convert_value(node.default)
     else:
         default = None
-    return new.Categorise(definitions, default)
+    return new.Case(cases, default)
 
 
 @convert_node.register

--- a/tests/lib/in_memory/engine.py
+++ b/tests/lib/in_memory/engine.py
@@ -234,5 +234,5 @@ class InMemoryQueryEngine(BaseQueryEngine):
 
         return self.visit_binary_op_with_null(node, op)
 
-    def visit_Categorise(self, node):
+    def visit_Case(self, node):
         assert False

--- a/tests/lib/in_memory/engine.py
+++ b/tests/lib/in_memory/engine.py
@@ -4,7 +4,7 @@ import operator
 from databuilder import query_model as qm
 from databuilder.query_engines.base import BaseQueryEngine
 
-from .database import Column, Table
+from .database import Column, Table, apply_function
 
 T = True
 F = False
@@ -235,4 +235,30 @@ class InMemoryQueryEngine(BaseQueryEngine):
         return self.visit_binary_op_with_null(node, op)
 
     def visit_Case(self, node):
-        assert False
+        cases = [
+            (self.visit(condition), self.visit(value))
+            for condition, value in node.cases.items()
+        ]
+        if node.default is None:
+            default = Column.from_values([], [])
+        else:
+            default = self.visit(node.default)
+        # Flatten arguments into a single list for easier handling
+        arguments = [default, *[i for pair in cases for i in pair]]
+        return apply_function(case_flattened, *arguments)
+
+
+def case_flattened(default, *cases):
+    """
+    Implements CASE WHEN x THEN y ELSE x END logic but takes its arguments in a
+    flattened form:
+
+        default, condition_1, value_1, condition_2, value_2, ... condition_N, value_N
+
+    This means it can be passed directly to `apply_function_to_columns` without needing
+    to do any special argument handling.
+    """
+    for condition, value in zip(cases[::2], cases[1::2]):
+        if condition:
+            return value
+    return default

--- a/tests/spec/code_series_ops/test_containment.py
+++ b/tests/spec/code_series_ops/test_containment.py
@@ -1,4 +1,4 @@
-from databuilder.codes import SNOMEDCTCode
+from databuilder.codes import SNOMEDCTCode, codelist_from_csv_lines
 
 from ..tables import p
 
@@ -20,6 +20,30 @@ def test_is_in(spec_test):
     spec_test(
         table_data,
         p.c1.is_in([SNOMEDCTCode("abc"), SNOMEDCTCode("ghi")]),
+        {
+            1: True,
+            2: False,
+            3: True,
+            4: None,
+        },
+    )
+
+
+def test_is_in_codelist_csv(spec_test):
+
+    codelist = codelist_from_csv_lines(
+        [
+            "code",
+            "abc",
+            "ghi",
+        ],
+        column="code",
+        system="snomedct",
+    )
+
+    spec_test(
+        table_data,
+        p.c1.is_in(codelist),
         {
             1: True,
             2: False,

--- a/tests/spec/code_series_ops/test_map_codes_to_categories.py
+++ b/tests/spec/code_series_ops/test_map_codes_to_categories.py
@@ -30,7 +30,7 @@ def test_map_codes_to_categories(spec_test):
 
     spec_test(
         table_data,
-        p.c1.map_values(codelist.my_categorisation),
+        p.c1.to_category(codelist.my_categorisation),
         {
             1: "cat1",
             2: None,

--- a/tests/spec/code_series_ops/test_map_codes_to_categories.py
+++ b/tests/spec/code_series_ops/test_map_codes_to_categories.py
@@ -1,0 +1,40 @@
+from databuilder.codes import codelist_from_csv_lines
+
+from ..tables import p
+
+title = "Test mapping codes to categories using a categorised codelist"
+
+table_data = {
+    p: """
+          |  c1
+        --+-----
+        1 | abc
+        2 | def
+        3 | ghi
+        4 |
+        """,
+}
+
+
+def test_map_codes_to_categories(spec_test):
+
+    codelist = codelist_from_csv_lines(
+        [
+            "code,my_categorisation",
+            "abc,cat1",
+            "ghi,cat2",
+        ],
+        column="code",
+        system="snomedct",
+    )
+
+    spec_test(
+        table_data,
+        p.c1.map_values(codelist.my_categorisation),
+        {
+            1: "cat1",
+            2: None,
+            3: "cat2",
+            4: None,
+        },
+    )

--- a/tests/spec/series_ops/test_map_values.py
+++ b/tests/spec/series_ops/test_map_values.py
@@ -1,0 +1,27 @@
+from ..tables import p
+
+title = "Map from one set of values to another"
+
+table_data = {
+    p: """
+          |  i1
+        --+-----
+        1 | 101
+        2 | 201
+        3 | 301
+        4 |
+        """,
+}
+
+
+def test_map_values(spec_test):
+    spec_test(
+        table_data,
+        p.i1.map_values({101: "a", 201: "b", 301: "a"}),
+        {
+            1: "a",
+            2: "b",
+            3: "a",
+            4: None,
+        },
+    )

--- a/tests/spec/toc.py
+++ b/tests/spec/toc.py
@@ -24,6 +24,7 @@ contents = {
     "series_ops": [
         "test_equality",
         "test_containment",
+        "test_map_values",
     ],
     "bool_series_ops": [
         "test_logical_ops",

--- a/tests/spec/toc.py
+++ b/tests/spec/toc.py
@@ -35,5 +35,6 @@ contents = {
     ],
     "code_series_ops": [
         "test_containment",
+        "test_map_codes_to_categories",
     ],
 }

--- a/tests/unit/test_codes.py
+++ b/tests/unit/test_codes.py
@@ -1,3 +1,5 @@
+import textwrap
+
 import pytest
 
 from databuilder.codes import CodelistError, CTV3Code, codelist_from_csv
@@ -5,7 +7,14 @@ from databuilder.codes import CodelistError, CTV3Code, codelist_from_csv
 
 def test_codelist_from_csv(tmp_path):
     csv_file = tmp_path / "codes.csv"
-    csv_file.write_text("CodeID,foo\nabc,123\ndef,456\n ghi ,789\n,")
+    csv_text = """
+        CodeID,foo
+        abc,123
+        def,456
+        ghi ,789
+        ,
+        """
+    csv_file.write_text(textwrap.dedent(csv_text.strip()))
     codelist = codelist_from_csv(csv_file, "CodeID", "ctv3")
     assert codelist.codes == {CTV3Code("abc"), CTV3Code("def"), CTV3Code("ghi")}
 
@@ -27,3 +36,28 @@ def test_codelist_from_csv_unknown_system(tmp_path):
     csv_file.touch()
     with pytest.raises(CodelistError, match="not_a_real_system"):
         codelist_from_csv(csv_file, "CodeID", "not_a_real_system")
+
+
+def test_codelist_from_csv_with_categories(tmp_path):
+    csv_file = tmp_path / "codes.csv"
+    csv_text = """
+        CodeID,cat1,__str__
+        abc,123,foo
+        def,456,bar,
+        ghi ,789
+        ,
+        """
+    csv_file.write_text(textwrap.dedent(csv_text.strip()))
+    codelist = codelist_from_csv(csv_file, "CodeID", "ctv3")
+    # Sensibly named category is accessible as an attribute
+    assert codelist.cat1 == {
+        CTV3Code("abc"): "123",
+        CTV3Code("def"): "456",
+        CTV3Code("ghi"): "789",
+    }
+    # Poorly named category is still accessible via the dictionary
+    assert codelist.category_maps["__str__"] == {
+        CTV3Code("abc"): "foo",
+        CTV3Code("def"): "bar",
+        CTV3Code("ghi"): "",
+    }

--- a/tests/unit/test_codes.py
+++ b/tests/unit/test_codes.py
@@ -6,8 +6,8 @@ from databuilder.codes import CodelistError, CTV3Code, codelist_from_csv
 def test_codelist_from_csv(tmp_path):
     csv_file = tmp_path / "codes.csv"
     csv_file.write_text("CodeID,foo\nabc,123\ndef,456\n ghi ,789\n,")
-    codes = codelist_from_csv(csv_file, "CodeID", "ctv3")
-    assert codes == {CTV3Code("abc"), CTV3Code("def"), CTV3Code("ghi")}
+    codelist = codelist_from_csv(csv_file, "CodeID", "ctv3")
+    assert codelist.codes == {CTV3Code("abc"), CTV3Code("def"), CTV3Code("ghi")}
 
 
 def test_codelist_from_csv_missing_column(tmp_path):
@@ -22,6 +22,8 @@ def test_codelist_from_csv_missing_file(tmp_path):
         codelist_from_csv(tmp_path / "no_file_here.csv", "CodeID", "ctv3")
 
 
-def test_codelist_from_csv_unknown_system():
+def test_codelist_from_csv_unknown_system(tmp_path):
+    csv_file = tmp_path / "codes.csv"
+    csv_file.touch()
     with pytest.raises(CodelistError, match="not_a_real_system"):
-        codelist_from_csv("somefile.csv", "CodeID", "not_a_real_system")
+        codelist_from_csv(csv_file, "CodeID", "not_a_real_system")

--- a/tests/unit/test_population_validation.py
+++ b/tests/unit/test_population_validation.py
@@ -166,8 +166,8 @@ cases = [
         "bar",
         Case(
             {
-                Value("foo"): Function.EQ(patients_value, Value(1)),
-                Value("bar"): Function.EQ(Value(1), Value(1)),
+                Function.EQ(patients_value, Value(1)): Value("foo"),
+                Function.EQ(Value(1), Value(1)): Value("bar"),
             },
             default=None,
         ),
@@ -176,8 +176,8 @@ cases = [
         "baz",
         Case(
             {
-                Value("foo"): Function.EQ(patients_value, Value(1)),
-                Value("bar"): Function.EQ(patients_value, Value(2)),
+                Function.EQ(patients_value, Value(1)): Value("foo"),
+                Function.EQ(patients_value, Value(2)): Value("bar"),
             },
             default=Value("baz"),
         ),
@@ -186,8 +186,8 @@ cases = [
         None,
         Case(
             {
-                Value("foo"): Function.EQ(patients_value, Value(1)),
-                Value("bar"): Function.EQ(patients_value, Value(2)),
+                Function.EQ(patients_value, Value(1)): Value("foo"),
+                Function.EQ(patients_value, Value(2)): Value("bar"),
             },
             default=None,
         ),

--- a/tests/unit/test_population_validation.py
+++ b/tests/unit/test_population_validation.py
@@ -11,7 +11,7 @@ from databuilder.population_validation import (
 )
 from databuilder.query_model import (
     AggregateByPatient,
-    Categorise,
+    Case,
     Function,
     SelectColumn,
     SelectPatientTable,
@@ -164,7 +164,7 @@ cases = [
     ),
     (
         "bar",
-        Categorise(
+        Case(
             {
                 Value("foo"): Function.EQ(patients_value, Value(1)),
                 Value("bar"): Function.EQ(Value(1), Value(1)),
@@ -174,7 +174,7 @@ cases = [
     ),
     (
         "baz",
-        Categorise(
+        Case(
             {
                 Value("foo"): Function.EQ(patients_value, Value(1)),
                 Value("bar"): Function.EQ(patients_value, Value(2)),
@@ -184,7 +184,7 @@ cases = [
     ),
     (
         None,
-        Categorise(
+        Case(
             {
                 Value("foo"): Function.EQ(patients_value, Value(1)),
                 Value("bar"): Function.EQ(patients_value, Value(2)),

--- a/tests/unit/test_query_model.py
+++ b/tests/unit/test_query_model.py
@@ -49,9 +49,9 @@ def queries():
     q.first_vaccination = PickOneRowPerPatient(Sort(vaccinations, date), Position.FIRST)
     q.vaccination_status = Case(
         {
-            Value("partial"): Function.EQ(q.vaccination_count, Value(1)),
-            Value("full"): Function.EQ(q.vaccination_count, Value(2)),
-            Value("boosted"): Function.GE(q.vaccination_count, Value(3)),
+            Function.EQ(q.vaccination_count, Value(1)): Value("partial"),
+            Function.EQ(q.vaccination_count, Value(2)): Value("full"),
+            Function.GE(q.vaccination_count, Value(3)): Value("boosted"),
         },
         default=Value("unvaccinated"),
     )

--- a/tests/unit/test_query_model.py
+++ b/tests/unit/test_query_model.py
@@ -7,7 +7,7 @@ import pytest
 
 from databuilder.query_model import (
     AggregateByPatient,
-    Categorise,
+    Case,
     DomainMismatchError,
     Filter,
     Frame,
@@ -47,7 +47,7 @@ def queries():
 
     q.vaccination_count = AggregateByPatient.Count(vaccinations)
     q.first_vaccination = PickOneRowPerPatient(Sort(vaccinations, date), Position.FIRST)
-    q.vaccination_status = Categorise(
+    q.vaccination_status = Case(
         {
             Value("partial"): Function.EQ(q.vaccination_count, Value(1)),
             Value("full"): Function.EQ(q.vaccination_count, Value(2)),


### PR DESCRIPTION
This adds support for mapping codes to categories using a categorised codelist and, as a side effect, for mapping a series of any arbitrary type from one set of values to another.

Behind the scenes this is implemented using a CASE expression. This involved adding support for arbitrary CASE expressions to the query model, the SQLite query engine, and the in-memory query engine. However we don't yet expose this in ehrQL — just the ability to map from one fixed set of values to another.

It may well be that doing this with CASE expressions is horribly inefficient, at least in some circumstances for some databases, so we may need to switch to using a temporary table and a JOIN. However it should be possible to implement this as a separate optimisation, for which I'll write up a ticket to track.

Please note the final, speculative commit and the question raised in the commit message.