### PR TITLE
Support arbitrary case expressions in ehrQL

### DIFF
--- a/tests/integration/test_query_engines.py
+++ b/tests/integration/test_query_engines.py
@@ -1,21 +1,18 @@
-import pytest
 import sqlalchemy
 
 from databuilder.query_model import (
     AggregateByPatient,
-    Case,
     Filter,
     Function,
     PickOneRowPerPatient,
     Position,
     SelectColumn,
-    SelectPatientTable,
     SelectTable,
     Sort,
     Value,
 )
 
-from ..lib.mock_backend import EventLevelTable, PatientLevelTable
+from ..lib.mock_backend import EventLevelTable
 
 
 # The in-memory query engine does not currently work with multiple sort operations where
@@ -92,37 +89,3 @@ def test_handles_degenerate_population(engine):
         v=Value(1),
     )
     assert engine.extract_qm(variables) == []
-
-
-@pytest.mark.parametrize("default", [None, "is_default"])
-def test_case_operation(engine, default):
-    engine.setup(
-        PatientLevelTable(PatientId=1, i1=1),
-        PatientLevelTable(PatientId=2, i1=2),
-        PatientLevelTable(PatientId=3, i1=3),
-        PatientLevelTable(PatientId=4, i1=None),
-    )
-
-    table = SelectPatientTable("patient_level_table")
-    i1 = SelectColumn(table, "i1")
-    case_operation = Case(
-        {
-            Function.LT(i1, Value(2)): Value("less_than_two"),
-            Function.EQ(i1, Value(2)): Value("equals_two"),
-            Function.GT(i1, Value(2)): Value("greater_than_two"),
-        },
-        default=Value(default) if default is not None else None,
-    )
-
-    variables = dict(
-        population=AggregateByPatient.Exists(table),
-        v=case_operation,
-    )
-
-    results = {r["patient_id"]: r["v"] for r in engine.extract_qm(variables)}
-    assert results == {
-        1: "less_than_two",
-        2: "equals_two",
-        3: "greater_than_two",
-        4: default,
-    }

--- a/tests/spec/case_expressions/__init__.py
+++ b/tests/spec/case_expressions/__init__.py
@@ -1,0 +1,1 @@
+title = "Logical case expressions"

--- a/tests/spec/case_expressions/test_case.py
+++ b/tests/spec/case_expressions/test_case.py
@@ -1,0 +1,52 @@
+from databuilder.query_language import case, when
+
+from ..tables import p
+
+title = "Logical case expressions"
+
+table_data = {
+    p: """
+          | i1
+        --+----
+        1 | 6
+        2 | 7
+        3 | 8
+        4 | 9
+        5 |
+        """,
+}
+
+
+def test_case(spec_test):
+    spec_test(
+        table_data,
+        case(
+            when(p.i1 < 8).then(p.i1),
+            when(p.i1 > 8).then(100),
+        ),
+        {
+            1: 6,
+            2: 7,
+            3: None,
+            4: 100,
+            5: None,
+        },
+    )
+
+
+def test_case_with_default(spec_test):
+    spec_test(
+        table_data,
+        case(
+            when(p.i1 < 8).then(p.i1),
+            when(p.i1 > 8).then(100),
+            default=0,
+        ),
+        {
+            1: 6,
+            2: 7,
+            3: 0,
+            4: 100,
+            5: 0,
+        },
+    )

--- a/tests/spec/toc.py
+++ b/tests/spec/toc.py
@@ -37,4 +37,7 @@ contents = {
         "test_containment",
         "test_map_codes_to_categories",
     ],
+    "case_expressions": [
+        "test_case",
+    ],
 }


### PR DESCRIPTION
Happy to bikeshed the syntax a bit more if people would like to.

It strikes me that one advantage of the old syntax, where the values
preceeded the conditions, was that the values then lined up nicely at
the beginning so you could scan them more easily. We could support that
as well/instead of what I've got here easily enough, it's just tricky to
find the right name for the syntactic sugar class because all the
natural ones are Python keywords. Perhaps something like:
```py
case(
  has("abc").when(i1 > 10),
  has("def").when(i1 > 20),
  default="ghi",
)
```

Depends on #497