### PR TITLE
Support more date operations

### DIFF
--- a/databuilder/population_validation.py
+++ b/databuilder/population_validation.py
@@ -223,13 +223,13 @@ def in_(lhs, rhs):
     return operator.contains(rhs, lhs)
 
 
-@register_op(Function.DateAdd)
-def date_add(date, num_days):
+@register_op(Function.DateAddDays)
+def date_add_days(date, num_days):
     return date + datetime.timedelta(days=num_days)
 
 
-@register_op(Function.DateSubtract)
-def date_subtract(date, num_days):
+@register_op(Function.DateSubtractDays)
+def date_subtract_days(date, num_days):
     return date - datetime.timedelta(days=num_days)
 
 

--- a/databuilder/population_validation.py
+++ b/databuilder/population_validation.py
@@ -199,6 +199,16 @@ def year_from_date(date):
     return date.year
 
 
+@register_op(Function.MonthFromDate)
+def month_from_date(date):
+    return date.month
+
+
+@register_op(Function.DayFromDate)
+def day_from_date(date):
+    return date.day
+
+
 @register_op(Function.DateDifferenceInYears)
 def date_difference_in_years(start, end):
     year_diff = end.year - start.year

--- a/databuilder/query_engines/query_model_convert_to_old.py
+++ b/databuilder/query_engines/query_model_convert_to_old.py
@@ -35,9 +35,9 @@ CONNECTOR_MAP = {
 FUNCTION_CLASS_MAP = {
     new.Function.RoundToFirstOfMonth: old.RoundToFirstOfMonth,
     new.Function.RoundToFirstOfYear: old.RoundToFirstOfYear,
-    new.Function.DateAdd: old.DateAddition,
+    new.Function.DateAddDays: old.DateAddition,
     new.Function.Add: old.DateDeltaAddition,
-    new.Function.DateSubtract: old.DateSubtraction,
+    new.Function.DateSubtractDays: old.DateSubtraction,
     new.Function.Subtract: old.DateDeltaSubtraction,
     new.Function.YearFromDate: old.YearFromDate,
 }

--- a/databuilder/query_language.py
+++ b/databuilder/query_language.py
@@ -205,6 +205,14 @@ class DateFunctions(ComparableFunctions):
     def year(self):
         return _apply(qm.Function.YearFromDate, self)
 
+    @property
+    def month(self):
+        return _apply(qm.Function.MonthFromDate, self)
+
+    @property
+    def day(self):
+        return _apply(qm.Function.DayFromDate, self)
+
 
 class DateAggregations(ComparableAggregations):
     "Empty for now"

--- a/databuilder/query_language.py
+++ b/databuilder/query_language.py
@@ -222,6 +222,18 @@ class DateFunctions(ComparableFunctions):
     def subtract_days(self, other):
         return _apply(qm.Function.DateSubtractDays, self, other)
 
+    def is_before(self, other):
+        return self < other
+
+    def is_on_or_before(self, other):
+        return self <= other
+
+    def is_after(self, other):
+        return self > other
+
+    def is_on_or_after(self, other):
+        return self >= other
+
 
 class DateAggregations(ComparableAggregations):
     "Empty for now"

--- a/databuilder/query_language.py
+++ b/databuilder/query_language.py
@@ -213,6 +213,9 @@ class DateFunctions(ComparableFunctions):
     def day(self):
         return _apply(qm.Function.DayFromDate, self)
 
+    def difference_in_years(self, other):
+        return _apply(qm.Function.DateDifferenceInYears, self, other)
+
 
 class DateAggregations(ComparableAggregations):
     "Empty for now"

--- a/databuilder/query_language.py
+++ b/databuilder/query_language.py
@@ -200,6 +200,13 @@ class FloatPatientSeries(NumericFunctions, PatientSeries):
 #
 
 
+def parse_date_if_str(value):
+    if isinstance(value, str):
+        return datetime.date.fromisoformat(value)
+    else:
+        return value
+
+
 class DateFunctions(ComparableFunctions):
     @property
     def year(self):
@@ -214,6 +221,7 @@ class DateFunctions(ComparableFunctions):
         return _apply(qm.Function.DayFromDate, self)
 
     def difference_in_years(self, other):
+        other = parse_date_if_str(other)
         return _apply(qm.Function.DateDifferenceInYears, self, other)
 
     def add_days(self, other):
@@ -223,15 +231,19 @@ class DateFunctions(ComparableFunctions):
         return _apply(qm.Function.DateSubtractDays, self, other)
 
     def is_before(self, other):
+        other = parse_date_if_str(other)
         return self < other
 
     def is_on_or_before(self, other):
+        other = parse_date_if_str(other)
         return self <= other
 
     def is_after(self, other):
+        other = parse_date_if_str(other)
         return self > other
 
     def is_on_or_after(self, other):
+        other = parse_date_if_str(other)
         return self >= other
 
 

--- a/databuilder/query_language.py
+++ b/databuilder/query_language.py
@@ -216,6 +216,12 @@ class DateFunctions(ComparableFunctions):
     def difference_in_years(self, other):
         return _apply(qm.Function.DateDifferenceInYears, self, other)
 
+    def add_days(self, other):
+        return _apply(qm.Function.DateAddDays, self, other)
+
+    def subtract_days(self, other):
+        return _apply(qm.Function.DateSubtractDays, self, other)
+
 
 class DateAggregations(ComparableAggregations):
     "Empty for now"

--- a/databuilder/query_model.py
+++ b/databuilder/query_model.py
@@ -292,11 +292,11 @@ class Function:
     class RoundToFirstOfYear(Series[date]):
         source: Series[date]
 
-    class DateAdd(Series[date]):
+    class DateAddDays(Series[date]):
         lhs: Series[date]
         rhs: Series[int]
 
-    class DateSubtract(Series[date]):
+    class DateSubtractDays(Series[date]):
         lhs: Series[date]
         rhs: Series[int]
 

--- a/databuilder/query_model.py
+++ b/databuilder/query_model.py
@@ -307,6 +307,12 @@ class Function:
     class YearFromDate(Series[int]):
         source: Series[date]
 
+    class MonthFromDate(Series[int]):
+        source: Series[date]
+
+    class DayFromDate(Series[int]):
+        source: Series[date]
+
     # Containment is a special case: its right-hand side must be something vector-like i.e.
     # something containing multiple values. To build a series whose values are vectors,
     # use the `CombineAsSet` aggregation.

--- a/tests/generative/variable_strategies.py
+++ b/tests/generative/variable_strategies.py
@@ -276,8 +276,8 @@ def is_trivial(node):  # pragma: no cover
         Function.GE,
         Function.Add,
         Function.Subtract,
-        Function.DateAdd,
-        Function.DateSubtract,
+        Function.DateAddDays,
+        Function.DateSubtractDays,
         Function.DateDifferenceInYears,
         Function.In,
     ]:

--- a/tests/legacy/query_model_convert_to_new.py
+++ b/tests/legacy/query_model_convert_to_new.py
@@ -35,9 +35,9 @@ FUNCTION_CLASS_MAP = {
     old.DateDifference: new.Function.DateDifferenceInYears,
     old.RoundToFirstOfMonth: new.Function.RoundToFirstOfMonth,
     old.RoundToFirstOfYear: new.Function.RoundToFirstOfYear,
-    old.DateAddition: new.Function.DateAdd,
+    old.DateAddition: new.Function.DateAddDays,
     old.DateDeltaAddition: new.Function.Add,
-    old.DateSubtraction: new.Function.DateSubtract,
+    old.DateSubtraction: new.Function.DateSubtractDays,
     old.DateDeltaSubtraction: new.Function.Subtract,
 }
 

--- a/tests/lib/in_memory/engine.py
+++ b/tests/lib/in_memory/engine.py
@@ -216,10 +216,10 @@ class InMemoryQueryEngine(BaseQueryEngine):
     def visit_RoundToFirstOfYear(self, node):
         assert False
 
-    def visit_DateAdd(self, node):
+    def visit_DateAddDays(self, node):
         assert False
 
-    def visit_DateSubtract(self, node):
+    def visit_DateSubtractDays(self, node):
         assert False
 
     def visit_DateDifferenceInYears(self, node):

--- a/tests/lib/in_memory/engine.py
+++ b/tests/lib/in_memory/engine.py
@@ -226,7 +226,13 @@ class InMemoryQueryEngine(BaseQueryEngine):
         assert False
 
     def visit_YearFromDate(self, node):
-        assert False
+        return self.visit_unary_op_with_null(node, operator.attrgetter("year"))
+
+    def visit_MonthFromDate(self, node):
+        return self.visit_unary_op_with_null(node, operator.attrgetter("month"))
+
+    def visit_DayFromDate(self, node):
+        return self.visit_unary_op_with_null(node, operator.attrgetter("day"))
 
     def visit_In(self, node):
         def op(lhs, rhs):

--- a/tests/lib/in_memory/engine.py
+++ b/tests/lib/in_memory/engine.py
@@ -223,7 +223,14 @@ class InMemoryQueryEngine(BaseQueryEngine):
         assert False
 
     def visit_DateDifferenceInYears(self, node):
-        assert False
+        def year_diff(start, end):
+            year_diff = end.year - start.year
+            if (end.month, end.day) < (start.month, start.day):
+                return year_diff - 1
+            else:
+                return year_diff
+
+        return self.visit_binary_op_with_null(node, year_diff)
 
     def visit_YearFromDate(self, node):
         return self.visit_unary_op_with_null(node, operator.attrgetter("year"))

--- a/tests/lib/in_memory/engine.py
+++ b/tests/lib/in_memory/engine.py
@@ -1,4 +1,5 @@
 import contextlib
+import datetime
 import operator
 
 from databuilder import query_model as qm
@@ -217,10 +218,16 @@ class InMemoryQueryEngine(BaseQueryEngine):
         assert False
 
     def visit_DateAddDays(self, node):
-        assert False
+        def date_add_days(date, num_days):
+            return date + datetime.timedelta(days=num_days)
+
+        return self.visit_binary_op_with_null(node, date_add_days)
 
     def visit_DateSubtractDays(self, node):
-        assert False
+        def date_subtract_days(date, num_days):
+            return date - datetime.timedelta(days=num_days)
+
+        return self.visit_binary_op_with_null(node, date_subtract_days)
 
     def visit_DateDifferenceInYears(self, node):
         def year_diff(start, end):

--- a/tests/lib/mock_backend.py
+++ b/tests/lib/mock_backend.py
@@ -74,6 +74,7 @@ def backend_factory(query_engine_cls):
                 b1=Column("boolean", source="b1"),
                 b2=Column("boolean", source="b2"),
                 c1=Column("varchar", source="c1"),
+                d1=Column("date", source="d1"),
             ),
         )
         event_level_table = MappedTable(
@@ -85,6 +86,7 @@ def backend_factory(query_engine_cls):
                 b1=Column("boolean", source="b1"),
                 b2=Column("boolean", source="b2"),
                 c1=Column("varchar", source="c1"),
+                d1=Column("date", source="d1"),
             ),
         )
 
@@ -189,6 +191,7 @@ class PatientLevelTable(Base):
     b1 = sqlalchemy.Column(sqlalchemy.Boolean, default=null)
     b2 = sqlalchemy.Column(sqlalchemy.Boolean, default=null)
     c1 = sqlalchemy.Column(sqlalchemy.Text, default=null)
+    d1 = sqlalchemy.Column(sqlalchemy.Date, default=null)
 
 
 class EventLevelTable(Base):
@@ -200,3 +203,4 @@ class EventLevelTable(Base):
     b1 = sqlalchemy.Column(sqlalchemy.Boolean, default=null)
     b2 = sqlalchemy.Column(sqlalchemy.Boolean, default=null)
     c1 = sqlalchemy.Column(sqlalchemy.Text, default=null)
+    d1 = sqlalchemy.Column(sqlalchemy.Date, default=null)

--- a/tests/lib/mock_backend.py
+++ b/tests/lib/mock_backend.py
@@ -75,6 +75,7 @@ def backend_factory(query_engine_cls):
                 b2=Column("boolean", source="b2"),
                 c1=Column("varchar", source="c1"),
                 d1=Column("date", source="d1"),
+                d2=Column("date", source="d2"),
             ),
         )
         event_level_table = MappedTable(
@@ -87,6 +88,7 @@ def backend_factory(query_engine_cls):
                 b2=Column("boolean", source="b2"),
                 c1=Column("varchar", source="c1"),
                 d1=Column("date", source="d1"),
+                d2=Column("date", source="d2"),
             ),
         )
 
@@ -192,6 +194,7 @@ class PatientLevelTable(Base):
     b2 = sqlalchemy.Column(sqlalchemy.Boolean, default=null)
     c1 = sqlalchemy.Column(sqlalchemy.Text, default=null)
     d1 = sqlalchemy.Column(sqlalchemy.Date, default=null)
+    d2 = sqlalchemy.Column(sqlalchemy.Date, default=null)
 
 
 class EventLevelTable(Base):
@@ -204,3 +207,4 @@ class EventLevelTable(Base):
     b2 = sqlalchemy.Column(sqlalchemy.Boolean, default=null)
     c1 = sqlalchemy.Column(sqlalchemy.Text, default=null)
     d1 = sqlalchemy.Column(sqlalchemy.Date, default=null)
+    d2 = sqlalchemy.Column(sqlalchemy.Date, default=null)

--- a/tests/spec/conftest.py
+++ b/tests/spec/conftest.py
@@ -1,3 +1,5 @@
+import datetime
+
 import pytest
 
 from databuilder.query_language import Dataset
@@ -77,6 +79,8 @@ def parse_value(col_name, value):
         parse = lambda v: {"T": True, "F": False}[v]  # noqa E731
     elif col_name[0] == "c":
         parse = str
+    elif col_name[0] == "d":
+        parse = datetime.date.fromisoformat
     else:
         assert False
 

--- a/tests/spec/date_series_ops/__init__.py
+++ b/tests/spec/date_series_ops/__init__.py
@@ -1,0 +1,1 @@
+title = "Operations on all series containing dates"

--- a/tests/spec/date_series_ops/test_date_comparison_types.py
+++ b/tests/spec/date_series_ops/test_date_comparison_types.py
@@ -1,0 +1,55 @@
+import datetime
+
+from ..tables import p
+
+title = "Types usable in comparisons involving dates"
+
+table_data = {
+    p: """
+          |     d1     |     d2
+        --+------------+------------
+        1 | 1990-01-01 | 1980-01-01
+        2 | 2000-01-01 | 1980-01-01
+        3 | 2010-01-01 | 2020-01-01
+        4 |            | 2020-01-01
+        """,
+}
+
+
+def test_accepts_python_date_object(spec_test):
+    spec_test(
+        table_data,
+        p.d1.is_before(datetime.date(2000, 1, 20)),
+        {
+            1: True,
+            2: True,
+            3: False,
+            4: None,
+        },
+    )
+
+
+def test_accepts_iso_formated_date_string(spec_test):
+    spec_test(
+        table_data,
+        p.d1.is_before("2000-01-20"),
+        {
+            1: True,
+            2: True,
+            3: False,
+            4: None,
+        },
+    )
+
+
+def test_accepts_another_date_series(spec_test):
+    spec_test(
+        table_data,
+        p.d1.is_before(p.d2),
+        {
+            1: False,
+            2: False,
+            3: True,
+            4: None,
+        },
+    )

--- a/tests/spec/date_series_ops/test_date_comparisons.py
+++ b/tests/spec/date_series_ops/test_date_comparisons.py
@@ -1,0 +1,68 @@
+from datetime import date
+
+from ..tables import p
+
+title = "Comparisons involving dates"
+
+table_data = {
+    p: """
+          |     d1
+        --+------------
+        1 | 1990-01-01
+        2 | 2000-01-01
+        3 | 2010-01-01
+        4 |
+        """,
+}
+
+
+def test_is_before(spec_test):
+    spec_test(
+        table_data,
+        p.d1.is_before(date(2000, 1, 1)),
+        {
+            1: True,
+            2: False,
+            3: False,
+            4: None,
+        },
+    )
+
+
+def test_is_on_or_before(spec_test):
+    spec_test(
+        table_data,
+        p.d1.is_on_or_before(date(2000, 1, 1)),
+        {
+            1: True,
+            2: True,
+            3: False,
+            4: None,
+        },
+    )
+
+
+def test_is_after(spec_test):
+    spec_test(
+        table_data,
+        p.d1.is_after(date(2000, 1, 1)),
+        {
+            1: False,
+            2: False,
+            3: True,
+            4: None,
+        },
+    )
+
+
+def test_is_on_or_after(spec_test):
+    spec_test(
+        table_data,
+        p.d1.is_on_or_after(date(2000, 1, 1)),
+        {
+            1: False,
+            2: True,
+            3: True,
+            4: None,
+        },
+    )

--- a/tests/spec/date_series_ops/test_date_comparisons.py
+++ b/tests/spec/date_series_ops/test_date_comparisons.py
@@ -1,5 +1,3 @@
-from datetime import date
-
 from ..tables import p
 
 title = "Comparisons involving dates"
@@ -19,7 +17,7 @@ table_data = {
 def test_is_before(spec_test):
     spec_test(
         table_data,
-        p.d1.is_before(date(2000, 1, 1)),
+        p.d1.is_before("2000-01-01"),
         {
             1: True,
             2: False,
@@ -32,7 +30,7 @@ def test_is_before(spec_test):
 def test_is_on_or_before(spec_test):
     spec_test(
         table_data,
-        p.d1.is_on_or_before(date(2000, 1, 1)),
+        p.d1.is_on_or_before("2000-01-01"),
         {
             1: True,
             2: True,
@@ -45,7 +43,7 @@ def test_is_on_or_before(spec_test):
 def test_is_after(spec_test):
     spec_test(
         table_data,
-        p.d1.is_after(date(2000, 1, 1)),
+        p.d1.is_after("2000-01-01"),
         {
             1: False,
             2: False,
@@ -58,7 +56,7 @@ def test_is_after(spec_test):
 def test_is_on_or_after(spec_test):
     spec_test(
         table_data,
-        p.d1.is_on_or_after(date(2000, 1, 1)),
+        p.d1.is_on_or_after("2000-01-01"),
         {
             1: False,
             2: True,

--- a/tests/spec/date_series_ops/test_date_series_ops.py
+++ b/tests/spec/date_series_ops/test_date_series_ops.py
@@ -1,3 +1,5 @@
+from datetime import date
+
 from ..tables import p
 
 title = "Operations which apply to all series containing dates"
@@ -45,5 +47,33 @@ def test_get_day(spec_test):
             1: 2,
             2: 4,
             3: None,
+        },
+    )
+
+
+def test_difference_in_years(spec_test):
+    # TODO: We should have some text in the documentation explaining that this is
+    # "number of entire elapsed years", as you'd use to calculate someone's age, rather
+    # than "time difference rounded to nearest year" or anything like that.
+    table_data = {
+        p: """
+              |     d1
+            --+------------
+            1 | 1990-01-30
+            2 | 2000-01-15
+            3 | 2020-01-20
+            4 | 2022-01-10
+            5 |
+            """,
+    }
+    spec_test(
+        table_data,
+        p.d1.difference_in_years(date(2020, 1, 15)),
+        {
+            1: 29,
+            2: 20,
+            3: -1,
+            4: -2,
+            5: None,
         },
     )

--- a/tests/spec/date_series_ops/test_date_series_ops.py
+++ b/tests/spec/date_series_ops/test_date_series_ops.py
@@ -6,11 +6,11 @@ title = "Operations which apply to all series containing dates"
 
 table_data = {
     p: """
-          |     d1
-        --+------------
-        1 | 1990-01-02
-        2 | 2000-03-04
-        3 |
+          |     d1     | i1
+        --+------------+-----
+        1 | 1990-01-02 | 100
+        2 | 2000-03-04 | 200
+        3 |            |
         """,
 }
 
@@ -46,6 +46,30 @@ def test_get_day(spec_test):
         {
             1: 2,
             2: 4,
+            3: None,
+        },
+    )
+
+
+def test_add_days(spec_test):
+    spec_test(
+        table_data,
+        p.d1.add_days(p.i1),
+        {
+            1: date(1990, 4, 12),
+            2: date(2000, 9, 20),
+            3: None,
+        },
+    )
+
+
+def test_subtract_days(spec_test):
+    spec_test(
+        table_data,
+        p.d1.subtract_days(p.i1),
+        {
+            1: date(1989, 9, 24),
+            2: date(1999, 8, 17),
             3: None,
         },
     )

--- a/tests/spec/date_series_ops/test_date_series_ops.py
+++ b/tests/spec/date_series_ops/test_date_series_ops.py
@@ -1,0 +1,49 @@
+from ..tables import p
+
+title = "Operations which apply to all series containing dates"
+
+table_data = {
+    p: """
+          |     d1
+        --+------------
+        1 | 1990-01-02
+        2 | 2000-03-04
+        3 |
+        """,
+}
+
+
+def test_get_year(spec_test):
+    spec_test(
+        table_data,
+        p.d1.year,
+        {
+            1: 1990,
+            2: 2000,
+            3: None,
+        },
+    )
+
+
+def test_get_month(spec_test):
+    spec_test(
+        table_data,
+        p.d1.month,
+        {
+            1: 1,
+            2: 3,
+            3: None,
+        },
+    )
+
+
+def test_get_day(spec_test):
+    spec_test(
+        table_data,
+        p.d1.day,
+        {
+            1: 2,
+            2: 4,
+            3: None,
+        },
+    )

--- a/tests/spec/tables.py
+++ b/tests/spec/tables.py
@@ -1,3 +1,5 @@
+import datetime
+
 from databuilder.codes import SNOMEDCTCode
 from databuilder.query_language import build_event_table, build_patient_table
 
@@ -9,6 +11,7 @@ p = build_patient_table(
         "b1": bool,
         "b2": bool,
         "c1": SNOMEDCTCode,
+        "d1": datetime.date,
     },
 )
 
@@ -21,5 +24,6 @@ e = build_event_table(
         "b1": bool,
         "b2": bool,
         "c1": SNOMEDCTCode,
+        "d1": datetime.date,
     },
 )

--- a/tests/spec/tables.py
+++ b/tests/spec/tables.py
@@ -12,6 +12,7 @@ p = build_patient_table(
         "b2": bool,
         "c1": SNOMEDCTCode,
         "d1": datetime.date,
+        "d2": datetime.date,
     },
 )
 
@@ -25,5 +26,6 @@ e = build_event_table(
         "b2": bool,
         "c1": SNOMEDCTCode,
         "d1": datetime.date,
+        "d2": datetime.date,
     },
 )

--- a/tests/spec/toc.py
+++ b/tests/spec/toc.py
@@ -43,5 +43,6 @@ contents = {
     "date_series_ops": [
         "test_date_series_ops",
         "test_date_comparisons",
+        "test_date_comparison_types",
     ],
 }

--- a/tests/spec/toc.py
+++ b/tests/spec/toc.py
@@ -42,5 +42,6 @@ contents = {
     ],
     "date_series_ops": [
         "test_date_series_ops",
+        "test_date_comparisons",
     ],
 }

--- a/tests/spec/toc.py
+++ b/tests/spec/toc.py
@@ -40,4 +40,7 @@ contents = {
     "case_expressions": [
         "test_case",
     ],
+    "date_series_ops": [
+        "test_date_series_ops",
+    ],
 }

--- a/tests/unit/test_population_validation.py
+++ b/tests/unit/test_population_validation.py
@@ -221,15 +221,27 @@ cases = [
         Function.DayFromDate(Value(datetime.date(2022, 4, 29))),
     ),
     (
-        3,
+        29,
         Function.DateDifferenceInYears(
-            Value(datetime.date(2020, 2, 29)), Value(datetime.date(2023, 3, 1))
+            Value(datetime.date(1990, 1, 30)), Value(datetime.date(2020, 1, 15))
         ),
     ),
     (
-        2,
+        20,
         Function.DateDifferenceInYears(
-            Value(datetime.date(2020, 2, 29)), Value(datetime.date(2023, 2, 27))
+            Value(datetime.date(2000, 1, 15)), Value(datetime.date(2020, 1, 15))
+        ),
+    ),
+    (
+        -1,
+        Function.DateDifferenceInYears(
+            Value(datetime.date(2020, 1, 20)), Value(datetime.date(2020, 1, 15))
+        ),
+    ),
+    (
+        -2,
+        Function.DateDifferenceInYears(
+            Value(datetime.date(2022, 1, 10)), Value(datetime.date(2020, 1, 15))
         ),
     ),
 ]

--- a/tests/unit/test_population_validation.py
+++ b/tests/unit/test_population_validation.py
@@ -213,6 +213,14 @@ cases = [
         Function.YearFromDate(Value(datetime.date(2022, 4, 29))),
     ),
     (
+        4,
+        Function.MonthFromDate(Value(datetime.date(2022, 4, 29))),
+    ),
+    (
+        29,
+        Function.DayFromDate(Value(datetime.date(2022, 4, 29))),
+    ),
+    (
         3,
         Function.DateDifferenceInYears(
             Value(datetime.date(2020, 2, 29)), Value(datetime.date(2023, 3, 1))

--- a/tests/unit/test_population_validation.py
+++ b/tests/unit/test_population_validation.py
@@ -202,11 +202,11 @@ cases = [
     ),
     (
         datetime.date(2021, 6, 13),
-        Function.DateAdd(Value(datetime.date(2021, 5, 4)), Value(40)),
+        Function.DateAddDays(Value(datetime.date(2021, 5, 4)), Value(40)),
     ),
     (
         datetime.date(2021, 3, 25),
-        Function.DateSubtract(Value(datetime.date(2021, 5, 4)), Value(40)),
+        Function.DateSubtractDays(Value(datetime.date(2021, 5, 4)), Value(40)),
     ),
     (
         2022,


### PR DESCRIPTION
This adds support for the remaining date operations which I think we'll need for our first study. As with all these PRs, I'm not particularly wedded to the precise method names or syntax here. But it's all pretty easily changed.

Two things in particular would be worth some future discussion. One is the idea of having some sort of `DateDelta` series which you'd create by subtracting one date from another and then access a `.years` attribute on it to get the difference in years.

I think that would be relatively easy to implement, and might be a nice approach; but I was slightly concerned about adding a series-like thing to ehrQL that wasn't _actually_ a series i.e. you can't pass it directly into anything else, you have to use one its units attributes. I also wasn't sure how nicely the syntax would work with method chaining because you'd have to use parens before you can get the attribute e.g.
```py
age_at_event = (events.take(events.code.is_in(codelist).date - patients.date_of_birth).years
```

That's not to say it's definitely a bad idea. I just wasn't immediately excited enough about it to want to implement it now :)

The other thing to think about is whether to add `+`/`-` operator support. I worried a bit about making the units explicit here. Maybe the operators should only accept `timedelta()` instances (with the time component set to zero)?
