### PR TITLE
Make Series instances unhashable

### DIFF
--- a/databuilder/query_language.py
+++ b/databuilder/query_language.py
@@ -43,6 +43,11 @@ def compile(dataset):  # noqa A003
 class Series:
     qm_node: qm.Node
 
+    def __hash__(self):
+        # The issue here is not mutability but the fact that we overload `__eq__` for
+        # syntatic sugar, which makes these types spectacularly ill-behaved as dict keys
+        raise TypeError(f"unhashable type: {self.__class__.__name__!r}")
+
     # These are the basic operations that apply to any series regardless of type or
     # dimension
     def __eq__(self, other):

--- a/tests/unit/test_query_language.py
+++ b/tests/unit/test_query_language.py
@@ -133,3 +133,11 @@ def test_passing_a_single_value_to_is_in_raises_error():
     int_series = IntEventSeries(qm_int_series)
     with pytest.raises(TypeValidationError):
         int_series.is_in(1)
+
+
+def test_series_are_not_hashable():
+    # The issue here is not mutability but the fact that we overload `__eq__` for
+    # syntatic sugar, which makes these types spectacularly ill-behaved as dict keys
+    int_series = IntEventSeries(qm_int_series)
+    with pytest.raises(TypeError):
+        {int_series: True}


### PR DESCRIPTION
The issue here is not mutability but the fact that we overload `__eq__`
for syntatic sugar, which makes these types spectacularly ill-behaved as
dict keys. They'll appear to work OK up until the point where you get a
hash collision, at which point distinct objects will behave as equal and
you will go mad.