### PR TITLE
Make `backend` optional for query engines

### DIFF
--- a/databuilder/backends/base.py
+++ b/databuilder/backends/base.py
@@ -59,8 +59,7 @@ class BaseBackend:
         Raises:
             ValueError: If unknown table passed in
         """
-        table = self.tables[table_name]
-        return table.get_query().alias(table_name)
+        return self.tables[table_name].get_expression(table_name)
 
 
 class SQLTable:
@@ -92,12 +91,12 @@ class MappedTable(SQLTable):
         if "patient_id" not in self.columns:
             self.columns["patient_id"] = Column("integer", source)
 
-    def get_query(self):
+    def get_expression(self, table_name):
         columns = self._make_columns()
         query = sqlalchemy.select(columns).select_from(
             sqlalchemy.table(self.source, schema=self._schema)
         )
-        return query
+        return query.alias(table_name)
 
 
 class QueryTable(SQLTable):
@@ -111,9 +110,10 @@ class QueryTable(SQLTable):
         if "patient_id" not in self.columns:
             self.columns["patient_id"] = Column("integer")
 
-    def get_query(self):
+    def get_expression(self, table_name):
         columns = self._make_columns()
-        return sqlalchemy.text(self.query).columns(*columns)
+        query = sqlalchemy.text(self.query).columns(*columns)
+        return query.alias(table_name)
 
 
 class Column:

--- a/databuilder/backends/base.py
+++ b/databuilder/backends/base.py
@@ -49,16 +49,20 @@ class BaseBackend:
             contract = table.implements
             contract.validate_implementation(cls, name)
 
-    def get_table_expression(self, table_name):
+    def get_table_expression(self, table_name, schema):
         """
         Gets SQL expression for a table
         Args:
             table_name: Name of Table
+            schema: a TableSchema
         Returns:
             A SQLAlchmey TableClause
         Raises:
             ValueError: If unknown table passed in
         """
+        # TODO: We currently ignore the `schema` argument here. But I think we should
+        # move towards having the supplied schema define the column types or, if not
+        # that, then we should validate that the types match.
         return self.tables[table_name].get_expression(table_name)
 
 

--- a/databuilder/backends/base.py
+++ b/databuilder/backends/base.py
@@ -55,7 +55,7 @@ class BaseBackend:
         Args:
             table_name: Name of Table
         Returns:
-            A SQL subquery
+            A SQLAlchmey TableClause
         Raises:
             ValueError: If unknown table passed in
         """
@@ -74,9 +74,7 @@ class SQLTable:
     def _make_column(self, name, column):
         source = column.source or name
         type_ = TYPES_BY_NAME[column.type].value
-        sql_column = sqlalchemy.Column(source, type_)
-        if source != name:
-            sql_column = sql_column.label(name)
+        sql_column = sqlalchemy.Column(source, type_, key=name)
         return sql_column
 
 
@@ -93,10 +91,7 @@ class MappedTable(SQLTable):
 
     def get_expression(self, table_name):
         columns = self._make_columns()
-        query = sqlalchemy.select(columns).select_from(
-            sqlalchemy.table(self.source, schema=self._schema)
-        )
-        return query.alias(table_name)
+        return sqlalchemy.table(self.source, *columns, schema=self._schema)
 
 
 class QueryTable(SQLTable):

--- a/databuilder/backends/base.py
+++ b/databuilder/backends/base.py
@@ -1,6 +1,6 @@
 import sqlalchemy
 
-from ..sqlalchemy_types import TYPES_BY_NAME
+from databuilder.sqlalchemy_types import TYPES_BY_NAME, type_from_python_type
 
 # Mutable global for storing registered backends
 BACKENDS = {}
@@ -120,3 +120,18 @@ class Column:
         self.type = column_type
         self.source = source
         self.system = system
+
+
+class DefaultBackend:
+    def get_table_expression(self, table_name, schema):
+        """
+        Returns a SQLAlchemy Table object matching the supplied name and schema
+        """
+        return sqlalchemy.table(
+            table_name,
+            sqlalchemy.Column("patient_id"),
+            *[
+                sqlalchemy.Column(name, type_=type_from_python_type(type_))
+                for (name, type_) in schema.items()
+            ],
+        )

--- a/databuilder/codes.py
+++ b/databuilder/codes.py
@@ -21,6 +21,10 @@ class BaseCode:
     def __init_subclass__(cls, system_id, **kwargs):
         REGISTRY[system_id] = cls
 
+    @classmethod
+    def _primitive_type(cls):
+        return str
+
     # The presence of this method allows query engines to work with values of this type,
     # despite not being explicitly told about them beforehand
     def _to_primitive_type(self):

--- a/databuilder/legacy_sqlalchemy_utils.py
+++ b/databuilder/legacy_sqlalchemy_utils.py
@@ -13,7 +13,7 @@ def select_first_row_per_partition(query, partition_column, sort_columns, descen
     table_expr = get_primary_table(query)
 
     # Find all the selected column names
-    column_names = [column.name for column in query.selected_columns]
+    column_names = [column.key for column in query.selected_columns]
 
     # Query to select the columns that we need to sort on
     order_columns = [table_expr.c[column] for column in sort_columns]

--- a/databuilder/query_engines/base.py
+++ b/databuilder/query_engines/base.py
@@ -5,11 +5,11 @@ class BaseQueryEngine:
     language (SQL, pandas dataframes etc).
     """
 
-    def __init__(self, dsn, backend, temporary_database=None):
+    def __init__(self, dsn, backend=None, temporary_database=None):
         """
         `dsn` is  Data Source Name — a string (usually a URL) which provides connection
             details to a data source (usually a RDBMS)
-        `backend` is a Backend instance
+        `backend` is an optional Backend instance
         """
         self.dsn = dsn
         self.backend = backend

--- a/databuilder/query_engines/base_sql.py
+++ b/databuilder/query_engines/base_sql.py
@@ -5,6 +5,7 @@ import sqlalchemy
 import sqlalchemy.engine.interfaces
 from sqlalchemy.sql import operators
 
+from databuilder.backends.base import DefaultBackend
 from databuilder.query_model import (
     AggregateByPatient,
     Case,
@@ -31,6 +32,11 @@ from .base import BaseQueryEngine
 class BaseSQLQueryEngine(BaseQueryEngine):
 
     sqlalchemy_dialect: sqlalchemy.engine.interfaces.Dialect
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if not self.backend:
+            self.backend = DefaultBackend()
 
     def get_query(self, variable_definitions):
         variable_definitions = apply_transforms(variable_definitions)

--- a/databuilder/query_engines/base_sql.py
+++ b/databuilder/query_engines/base_sql.py
@@ -365,7 +365,7 @@ class BaseSQLQueryEngine(BaseQueryEngine):
     @get_table.register(SelectPatientTable)
     @cache
     def get_table_select_table(self, node):
-        return self.backend.get_table_expression(node.name)
+        return self.backend.get_table_expression(node.name, node.schema)
 
     # We ignore Filter and Sort operations completely at this point in the code and just
     # pass the underlying table reference through. It's only later, when building the

--- a/databuilder/query_engines/legacy_base_sql.py
+++ b/databuilder/query_engines/legacy_base_sql.py
@@ -271,7 +271,8 @@ class BaseSQLQueryEngine(BaseQueryEngine):
     @get_sql_element_no_cache.register
     def get_element_from_table(self, node: Table):
         table = self.backend.get_table_expression(node.name)
-        return table.select()
+        labeled_columns = [c.label(c.key) for c in table.columns]
+        return sqlalchemy.select(*labeled_columns)
 
     @get_sql_element_no_cache.register
     def get_element_from_filtered_table(self, node: FilteredTable):
@@ -332,7 +333,7 @@ class BaseSQLQueryEngine(BaseQueryEngine):
         columns = [query.selected_columns[name] for name in column_names]
         query = query.with_only_columns(columns)
 
-        table_columns = [sqlalchemy.Column(c.name, c.type) for c in columns]
+        table_columns = [sqlalchemy.Column(c.key, c.type) for c in columns]
         table_name = self.get_temp_table_name("group_table")
         table = TemporaryTable(table_name, sqlalchemy.MetaData(), *table_columns)
 

--- a/databuilder/query_engines/legacy_base_sql.py
+++ b/databuilder/query_engines/legacy_base_sql.py
@@ -270,7 +270,7 @@ class BaseSQLQueryEngine(BaseQueryEngine):
 
     @get_sql_element_no_cache.register
     def get_element_from_table(self, node: Table):
-        table = self.backend.get_table_expression(node.name)
+        table = self.backend.get_table_expression(node.name, schema=None)
         labeled_columns = [c.label(c.key) for c in table.columns]
         return sqlalchemy.select(*labeled_columns)
 

--- a/databuilder/sqlalchemy_types.py
+++ b/databuilder/sqlalchemy_types.py
@@ -1,3 +1,4 @@
+import datetime
 from enum import Enum
 
 import sqlalchemy.types
@@ -12,6 +13,7 @@ __all__ = [
     "String",
     "Text",
     "TYPES_BY_NAME",
+    "type_from_python_type",
 ]
 
 # SQLAlchemy has different coercion rules for custom types vs built-in types. For
@@ -40,6 +42,28 @@ class Date(sqlalchemy.types.TypeDecorator):
 class DateTime(sqlalchemy.types.TypeDecorator):
     impl = sqlalchemy.types.DateTime
     cache_ok = True
+
+
+TYPE_MAP = {
+    bool: Boolean,
+    datetime.date: Date,
+    datetime.datetime: DateTime,
+    float: Float,
+    int: Integer,
+    str: Text,
+}
+
+
+def type_from_python_type(type_):
+    "Return the SQLAlchemy Type for a given Python type"
+    if hasattr(type_, "_primitive_type"):
+        lookup_type = type_._primitive_type()
+    else:
+        lookup_type = type_
+    try:
+        return TYPE_MAP[lookup_type]
+    except KeyError:
+        raise TypeError(f"Unsupported column type: {type_}")
 
 
 TYPES_BY_NAME = Enum(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,6 @@ from .lib.databases import (
 )
 from .lib.docker import Containers
 from .lib.in_memory import InMemoryDatabase, InMemoryQueryEngine
-from .lib.mock_backend import backend_factory
 from .lib.study import Study
 
 
@@ -55,14 +54,13 @@ class QueryEngineFixture:
         self.name = name
         self.database = database
         self.query_engine_class = query_engine_class
-        self.backend = backend_factory(query_engine_class)
 
     def setup(self, *items, metadata=None):
         return self.database.setup(*items, metadata=metadata)
 
     def extract(self, dataset, **engine_kwargs):
         query_engine = self.query_engine_class(
-            self.database.host_url(), self.backend(), **engine_kwargs
+            self.database.host_url(), backend=None, **engine_kwargs
         )
         results = list(main.extract(dataset, query_engine))
         # We don't explicitly order the results and not all databases naturally return
@@ -71,7 +69,7 @@ class QueryEngineFixture:
         return results
 
     def extract_qm(self, variables):
-        query_engine = self.query_engine_class(self.database.host_url(), self.backend())
+        query_engine = self.query_engine_class(self.database.host_url(), backend=None)
         with query_engine.execute_query(variables) as results:
             result = list(dict(row) for row in results)
             result.sort(key=lambda i: i["patient_id"])  # ensure stable ordering

--- a/tests/generative/data_setup.py
+++ b/tests/generative/data_setup.py
@@ -8,6 +8,7 @@ from databuilder.query_model import (
     SelectPatientTable,
     SelectTable,
 )
+from databuilder.sqlalchemy_types import Integer, type_from_python_type
 
 
 def setup(schema, num_patient_tables, num_event_tables):
@@ -48,12 +49,11 @@ def _build_orm_classes(prefix, count, schema, patient_id_column, ids, registry):
 
 def _build_orm_class(name, schema, patient_id_column, ids, registry):
     columns = [
-        sqlalchemy.Column("Id", sqlalchemy.Integer, primary_key=True, default=ids),
-        sqlalchemy.Column(patient_id_column, sqlalchemy.Integer),
+        sqlalchemy.Column("Id", Integer, primary_key=True, default=ids),
+        sqlalchemy.Column(patient_id_column, Integer),
     ]
     for col_name, type_ in schema.items():
-        sqla_type = {int: sqlalchemy.Integer, bool: sqlalchemy.Boolean}[type_]
-        columns.append(sqlalchemy.Column(col_name, sqla_type))
+        columns.append(sqlalchemy.Column(col_name, type_from_python_type(type_)))
 
     table = sqlalchemy.Table(name, registry.metadata, *columns)
     class_ = type(name, (object,), dict(__tablename__=name, metadata=registry.metadata))

--- a/tests/generative/data_setup.py
+++ b/tests/generative/data_setup.py
@@ -10,17 +10,18 @@ from databuilder.query_model import (
 )
 from databuilder.sqlalchemy_types import Integer, type_from_python_type
 
+from ..lib.util import next_id
+
 
 def setup(schema, num_patient_tables, num_event_tables):
     registry = sqlalchemy.orm.registry()
-    ids = iter(range(1, 2**63)).__next__
     patient_id_column = "PatientId"
 
     patient_table_names, patient_classes = _build_orm_classes(
-        "p", num_patient_tables, schema, patient_id_column, ids, registry
+        "p", num_patient_tables, schema, patient_id_column, registry
     )
     event_table_names, event_classes = _build_orm_classes(
-        "e", num_event_tables, schema, patient_id_column, ids, registry
+        "e", num_event_tables, schema, patient_id_column, registry
     )
 
     table_names = patient_table_names + event_table_names
@@ -38,18 +39,17 @@ def setup(schema, num_patient_tables, num_event_tables):
     )
 
 
-def _build_orm_classes(prefix, count, schema, patient_id_column, ids, registry):
+def _build_orm_classes(prefix, count, schema, patient_id_column, registry):
     names = [f"{prefix}{i}" for i in range(count)]
     classes = [
-        _build_orm_class(name, schema, patient_id_column, ids, registry)
-        for name in names
+        _build_orm_class(name, schema, patient_id_column, registry) for name in names
     ]
     return names, classes
 
 
-def _build_orm_class(name, schema, patient_id_column, ids, registry):
+def _build_orm_class(name, schema, patient_id_column, registry):
     columns = [
-        sqlalchemy.Column("Id", Integer, primary_key=True, default=ids),
+        sqlalchemy.Column("Id", Integer, primary_key=True, default=next_id),
         sqlalchemy.Column(patient_id_column, Integer),
     ]
     for col_name, type_ in schema.items():

--- a/tests/generative/data_setup.py
+++ b/tests/generative/data_setup.py
@@ -10,7 +10,7 @@ from databuilder.query_model import (
 )
 from databuilder.sqlalchemy_types import Integer, type_from_python_type
 
-from ..lib.util import next_id
+from ..lib.util import next_id, null
 
 
 def setup(schema, num_patient_tables, num_event_tables):
@@ -50,10 +50,12 @@ def _build_orm_classes(prefix, count, schema, patient_id_column, registry):
 def _build_orm_class(name, schema, patient_id_column, registry):
     columns = [
         sqlalchemy.Column("Id", Integer, primary_key=True, default=next_id),
-        sqlalchemy.Column(patient_id_column, Integer),
+        sqlalchemy.Column(patient_id_column, Integer, nullable=False),
     ]
     for col_name, type_ in schema.items():
-        columns.append(sqlalchemy.Column(col_name, type_from_python_type(type_)))
+        columns.append(
+            sqlalchemy.Column(col_name, type_from_python_type(type_), default=null)
+        )
 
     table = sqlalchemy.Table(name, registry.metadata, *columns)
     class_ = type(name, (object,), dict(__tablename__=name, metadata=registry.metadata))

--- a/tests/generative/test_query_model.py
+++ b/tests/generative/test_query_model.py
@@ -17,7 +17,6 @@ schema = TableSchema(i1=int, i2=int, b1=bool, b2=bool)
     patient_id_column,
     patient_classes,
     event_classes,
-    Backend,
     all_patients_query,
     sqla_metadata,
 ) = data_setup.setup(schema, num_patient_tables=2, num_event_tables=2)
@@ -77,7 +76,7 @@ def run_with(database_class, engine_class, instances, variables):
     database = database_class()
     database.setup(instances, metadata=sqla_metadata)
 
-    engine = engine_class(database.host_url(), Backend())
+    engine = engine_class(database.host_url())
     with engine.execute_query(variables) as results:
         result = list(dict(row) for row in results)
         result.sort(key=lambda i: i["patient_id"])  # ensure stable ordering

--- a/tests/integration/test_query_engines.py
+++ b/tests/integration/test_query_engines.py
@@ -28,12 +28,12 @@ from ..lib.mock_backend import EventLevelTable
 #
 def test_sort_without_using_chained_operations(engine):
     engine.setup(
-        EventLevelTable(PatientId=1, i1=101, i2=3),
-        EventLevelTable(PatientId=1, i1=102, i2=2),
-        EventLevelTable(PatientId=1, i1=102, i2=1),
-        EventLevelTable(PatientId=2, i1=203, i2=1),
-        EventLevelTable(PatientId=2, i1=202, i2=2),
-        EventLevelTable(PatientId=2, i1=202, i2=3),
+        EventLevelTable(patient_id=1, i1=101, i2=3),
+        EventLevelTable(patient_id=1, i1=102, i2=2),
+        EventLevelTable(patient_id=1, i1=102, i2=1),
+        EventLevelTable(patient_id=2, i1=203, i2=1),
+        EventLevelTable(patient_id=2, i1=202, i2=2),
+        EventLevelTable(patient_id=2, i1=202, i2=3),
     )
 
     table = SelectTable("event_level_table")
@@ -59,9 +59,9 @@ def test_sort_without_using_chained_operations(engine):
 #
 def test_multiple_takes_without_chaining(engine):
     engine.setup(
-        EventLevelTable(PatientId=1, i1=1, b1=True),
-        EventLevelTable(PatientId=1, i1=2, b1=True),
-        EventLevelTable(PatientId=1, i1=3, b1=False),
+        EventLevelTable(patient_id=1, i1=1, b1=True),
+        EventLevelTable(patient_id=1, i1=2, b1=True),
+        EventLevelTable(patient_id=1, i1=3, b1=False),
     )
 
     table = SelectTable("event_level_table")

--- a/tests/integration/test_query_engines.py
+++ b/tests/integration/test_query_engines.py
@@ -7,12 +7,11 @@ from databuilder.query_model import (
     PickOneRowPerPatient,
     Position,
     SelectColumn,
-    SelectTable,
     Sort,
     Value,
 )
 
-from ..lib.mock_backend import EventLevelTable
+from ..spec.tables import EventLevelTable, e
 
 
 # The in-memory query engine does not currently work with multiple sort operations where
@@ -36,7 +35,7 @@ def test_sort_without_using_chained_operations(engine):
         EventLevelTable(patient_id=2, i1=202, i2=3),
     )
 
-    table = SelectTable("event_level_table")
+    table = e.qm_node
     sort1 = Sort(table, SelectColumn(table, "i2"))
     sort2 = Sort(sort1, SelectColumn(sort1, "i1"))
     pick = PickOneRowPerPatient(sort2, Position.FIRST)
@@ -64,7 +63,7 @@ def test_multiple_takes_without_chaining(engine):
         EventLevelTable(patient_id=1, i1=3, b1=False),
     )
 
-    table = SelectTable("event_level_table")
+    table = e.qm_node
     filter1 = Filter(table, Function.GE(SelectColumn(table, "i1"), Value(2)))
     filter2 = Filter(filter1, SelectColumn(filter1, "b1"))
     values = SelectColumn(filter2, "i1")

--- a/tests/legacy/conftest.py
+++ b/tests/legacy/conftest.py
@@ -4,7 +4,7 @@ from databuilder.query_engines.legacy_mssql import MssqlQueryEngine
 from databuilder.query_engines.legacy_spark import SparkQueryEngine
 
 from ..conftest import QueryEngineFixture
-from ..lib.mock_backend import backend_factory
+from ..lib.mock_backend import MockBackend
 from .query_model_convert_to_new import convert as convert_to_new
 
 
@@ -12,14 +12,9 @@ from .query_model_convert_to_new import convert as convert_to_new
 # old-style cohort definitions. This allows us to retain these old test cases as a harness while we
 # refactor the Query Engine.
 class LegacyQueryEngineFixture(QueryEngineFixture):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.backend = backend_factory(self.query_engine_class)
-
     def build_engine(self, **engine_kwargs):
-        backend = self.backend()
-        return backend.query_engine_class(
-            self.database.host_url(), backend, **engine_kwargs
+        return self.query_engine_class(
+            self.database.host_url(), MockBackend(), **engine_kwargs
         )
 
     def extract(self, cohort, **engine_kwargs):

--- a/tests/legacy/conftest.py
+++ b/tests/legacy/conftest.py
@@ -4,6 +4,7 @@ from databuilder.query_engines.legacy_mssql import MssqlQueryEngine
 from databuilder.query_engines.legacy_spark import SparkQueryEngine
 
 from ..conftest import QueryEngineFixture
+from ..lib.mock_backend import backend_factory
 from .query_model_convert_to_new import convert as convert_to_new
 
 
@@ -11,6 +12,10 @@ from .query_model_convert_to_new import convert as convert_to_new
 # old-style cohort definitions. This allows us to retain these old test cases as a harness while we
 # refactor the Query Engine.
 class LegacyQueryEngineFixture(QueryEngineFixture):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.backend = backend_factory(self.query_engine_class)
+
     def build_engine(self, **engine_kwargs):
         backend = self.backend()
         return backend.query_engine_class(

--- a/tests/lib/mock_backend.py
+++ b/tests/lib/mock_backend.py
@@ -69,6 +69,9 @@ def backend_factory(query_engine_cls):
             implements=contracts.PatientLevelTable,
             source="patient_level_table",
             columns=dict(
+                # Temporarily add an explicit patient_id column while this table is part
+                # of a backend with a different default patient_id column
+                patient_id=Column("integer", source="patient_id"),
                 i1=Column("integer", source="i1"),
                 i2=Column("integer", source="i2"),
                 b1=Column("boolean", source="b1"),
@@ -82,6 +85,9 @@ def backend_factory(query_engine_cls):
             implements=contracts.EventLevelTable,
             source="event_level_table",
             columns=dict(
+                # Temporarily add an explicit patient_id column while this table is part
+                # of a backend with a different default patient_id column
+                patient_id=Column("integer", source="patient_id"),
                 i1=Column("integer", source="i1"),
                 i2=Column("integer", source="i2"),
                 b1=Column("boolean", source="b1"),
@@ -187,7 +193,7 @@ def patient(
 class PatientLevelTable(Base):
     __tablename__ = "patient_level_table"
     Id = sqlalchemy.Column(sqlalchemy.Integer, primary_key=True, default=next_id)
-    PatientId = sqlalchemy.Column(sqlalchemy.Integer, default=null)
+    patient_id = sqlalchemy.Column(sqlalchemy.Integer, default=null)
     i1 = sqlalchemy.Column(sqlalchemy.Integer, default=null)
     i2 = sqlalchemy.Column(sqlalchemy.Integer, default=null)
     b1 = sqlalchemy.Column(sqlalchemy.Boolean, default=null)
@@ -200,7 +206,7 @@ class PatientLevelTable(Base):
 class EventLevelTable(Base):
     __tablename__ = "event_level_table"
     Id = sqlalchemy.Column(sqlalchemy.Integer, primary_key=True, default=next_id)
-    PatientId = sqlalchemy.Column(sqlalchemy.Integer, default=null)
+    patient_id = sqlalchemy.Column(sqlalchemy.Integer, default=null)
     i1 = sqlalchemy.Column(sqlalchemy.Integer, default=null)
     i2 = sqlalchemy.Column(sqlalchemy.Integer, default=null)
     b1 = sqlalchemy.Column(sqlalchemy.Boolean, default=null)

--- a/tests/lib/mock_backend.py
+++ b/tests/lib/mock_backend.py
@@ -7,71 +7,57 @@ from . import contracts
 from .util import next_id, null
 
 
-def backend_factory(query_engine_cls):
-    """
-    Return a instance of MockBackend associated with the supplied Query Engine
+class MockBackend(BaseBackend):
+    backend_id = "mock_backend"
+    query_engine_class = MssqlQueryEngine
+    patient_join_column = "PatientId"
 
-    Note: argument name can't be `query_engine_class` because Python's scoping rules
-    won't let us reference it in the class body.
-    """
-
-    class MockBackend(BaseBackend):
-        backend_id = f"mock_{query_engine_cls.__name__}"
-        query_engine_class = query_engine_cls
-        patient_join_column = "PatientId"
-
-        patients = MappedTable(
-            implements=contracts.Patients,
-            source="patients",
-            columns=dict(
-                height=Column("integer", source="Height"),
-                date_of_birth=Column("date", source="DateOfBirth"),
-                sex=Column("varchar", source="Sex"),
-                some_bool=Column("boolean", source="SomeBool"),
-                some_int=Column("integer", source="SomeInt"),
-            ),
-        )
-        practice_registrations = MappedTable(
-            implements=contracts.Registrations,
-            source="practice_registrations",
-            columns=dict(
-                stp=Column("varchar", source="StpId"),
-                date_start=Column("date", source="StartDate"),
-                date_end=Column("date", source="EndDate"),
-            ),
-        )
-        clinical_events = MappedTable(
-            implements=contracts.Events,
-            source="events",
-            columns=dict(
-                code=Column("varchar", source="EventCode"),
-                system=Column("varchar", source="System"),
-                date=Column("date", source="Date"),
-                value=Column("integer", source="ResultValue"),
-            ),
-        )
-        positive_tests = QueryTable(
-            implements=contracts.Tests,
-            columns=dict(
-                patient_id=Column("integer"),
-                result=Column("boolean"),
-                test_date=Column("date"),
-            ),
-            query="""
-                SELECT
-                  PatientID as patient_id,
-                  PositiveResult as result,
-                  TestDate as test_date
-                FROM
-                  all_tests
-            """,
-        )
-
-    return MockBackend
-
-
-# Create a default MockBackend instance for code which is still expecting this
-MockBackend = backend_factory(MssqlQueryEngine)
+    patients = MappedTable(
+        implements=contracts.Patients,
+        source="patients",
+        columns=dict(
+            height=Column("integer", source="Height"),
+            date_of_birth=Column("date", source="DateOfBirth"),
+            sex=Column("varchar", source="Sex"),
+            some_bool=Column("boolean", source="SomeBool"),
+            some_int=Column("integer", source="SomeInt"),
+        ),
+    )
+    practice_registrations = MappedTable(
+        implements=contracts.Registrations,
+        source="practice_registrations",
+        columns=dict(
+            stp=Column("varchar", source="StpId"),
+            date_start=Column("date", source="StartDate"),
+            date_end=Column("date", source="EndDate"),
+        ),
+    )
+    clinical_events = MappedTable(
+        implements=contracts.Events,
+        source="events",
+        columns=dict(
+            code=Column("varchar", source="EventCode"),
+            system=Column("varchar", source="System"),
+            date=Column("date", source="Date"),
+            value=Column("integer", source="ResultValue"),
+        ),
+    )
+    positive_tests = QueryTable(
+        implements=contracts.Tests,
+        columns=dict(
+            patient_id=Column("integer"),
+            result=Column("boolean"),
+            test_date=Column("date"),
+        ),
+        query="""
+            SELECT
+              PatientID as patient_id,
+              PositiveResult as result,
+              TestDate as test_date
+            FROM
+              all_tests
+        """,
+    )
 
 
 Base = sqlalchemy.orm.declarative_base()

--- a/tests/lib/mock_backend.py
+++ b/tests/lib/mock_backend.py
@@ -66,38 +66,6 @@ def backend_factory(query_engine_cls):
                   all_tests
             """,
         )
-        patient_level_table = MappedTable(
-            implements=contracts.PatientLevelTable,
-            source="patient_level_table",
-            columns=dict(
-                # Temporarily add an explicit patient_id column while this table is part
-                # of a backend with a different default patient_id column
-                patient_id=Column("integer", source="patient_id"),
-                i1=Column("integer", source="i1"),
-                i2=Column("integer", source="i2"),
-                b1=Column("boolean", source="b1"),
-                b2=Column("boolean", source="b2"),
-                c1=Column("varchar", source="c1"),
-                d1=Column("date", source="d1"),
-                d2=Column("date", source="d2"),
-            ),
-        )
-        event_level_table = MappedTable(
-            implements=contracts.EventLevelTable,
-            source="event_level_table",
-            columns=dict(
-                # Temporarily add an explicit patient_id column while this table is part
-                # of a backend with a different default patient_id column
-                patient_id=Column("integer", source="patient_id"),
-                i1=Column("integer", source="i1"),
-                i2=Column("integer", source="i2"),
-                b1=Column("boolean", source="b1"),
-                b2=Column("boolean", source="b2"),
-                c1=Column("varchar", source="c1"),
-                d1=Column("date", source="d1"),
-                d2=Column("date", source="d2"),
-            ),
-        )
 
     return MockBackend
 
@@ -176,29 +144,3 @@ def patient(
         ),
         *entities,
     ]
-
-
-class PatientLevelTable(Base):
-    __tablename__ = "patient_level_table"
-    Id = sqlalchemy.Column(sqlalchemy.Integer, primary_key=True, default=next_id)
-    patient_id = sqlalchemy.Column(sqlalchemy.Integer, default=null)
-    i1 = sqlalchemy.Column(sqlalchemy.Integer, default=null)
-    i2 = sqlalchemy.Column(sqlalchemy.Integer, default=null)
-    b1 = sqlalchemy.Column(sqlalchemy.Boolean, default=null)
-    b2 = sqlalchemy.Column(sqlalchemy.Boolean, default=null)
-    c1 = sqlalchemy.Column(sqlalchemy.Text, default=null)
-    d1 = sqlalchemy.Column(sqlalchemy.Date, default=null)
-    d2 = sqlalchemy.Column(sqlalchemy.Date, default=null)
-
-
-class EventLevelTable(Base):
-    __tablename__ = "event_level_table"
-    Id = sqlalchemy.Column(sqlalchemy.Integer, primary_key=True, default=next_id)
-    patient_id = sqlalchemy.Column(sqlalchemy.Integer, default=null)
-    i1 = sqlalchemy.Column(sqlalchemy.Integer, default=null)
-    i2 = sqlalchemy.Column(sqlalchemy.Integer, default=null)
-    b1 = sqlalchemy.Column(sqlalchemy.Boolean, default=null)
-    b2 = sqlalchemy.Column(sqlalchemy.Boolean, default=null)
-    c1 = sqlalchemy.Column(sqlalchemy.Text, default=null)
-    d1 = sqlalchemy.Column(sqlalchemy.Date, default=null)
-    d2 = sqlalchemy.Column(sqlalchemy.Date, default=null)

--- a/tests/lib/mock_backend.py
+++ b/tests/lib/mock_backend.py
@@ -4,6 +4,7 @@ from databuilder.backends.base import BaseBackend, Column, MappedTable, QueryTab
 from databuilder.query_engines.legacy_mssql import MssqlQueryEngine
 
 from . import contracts
+from .util import next_id, null
 
 
 def backend_factory(query_engine_cls):
@@ -103,19 +104,6 @@ def backend_factory(query_engine_cls):
 
 # Create a default MockBackend instance for code which is still expecting this
 MockBackend = backend_factory(MssqlQueryEngine)
-
-# Generate an integer sequence to use as default IDs. Normally you'd rely on the DBMS to
-# provide these, but we need to support DBMSs like Spark which don't have this feature.
-next_id = iter(range(1, 2**63)).__next__
-
-
-# We need each NULL-able column to have an explicit default of NULL. Without this,
-# SQLAlchemy will just omit empty columns from the INSERT. That's fine for most DBMSs
-# but Spark needs every column in the table to be specified, even if it just has a NULL
-# value. Note: we have to use a callable returning `None` here because if we use `None`
-# directly SQLAlchemy interprets this is "there is no default".
-def null():
-    return None
 
 
 Base = sqlalchemy.orm.declarative_base()

--- a/tests/lib/util.py
+++ b/tests/lib/util.py
@@ -20,3 +20,21 @@ def iter_flatten(iterable, iter_classes=(list, tuple)):
             yield from iter_flatten(item, iter_classes)
         else:
             yield item
+
+
+# SQLAlchemy ORM Utils
+#
+
+
+# Generate an integer sequence to use as default IDs. Normally you'd rely on the DBMS to
+# provide these, but we need to support DBMSs like Spark which don't have this feature.
+next_id = iter(range(1, 2**63)).__next__
+
+
+# We need each NULL-able column to have an explicit default of NULL. Without this,
+# SQLAlchemy will just omit empty columns from the INSERT. That's fine for most DBMSs
+# but Spark needs every column in the table to be specified, even if it just has a NULL
+# value. Note: we have to use a callable returning `None` here because if we use `None`
+# directly SQLAlchemy interprets this is "there is no default".
+def null():
+    return None

--- a/tests/spec/conftest.py
+++ b/tests/spec/conftest.py
@@ -49,7 +49,7 @@ def parse_table(s):
 
     header, _, *lines = s.strip().splitlines()
     col_names = [token.strip() for token in header.split("|")]
-    col_names[0] = "PatientId"
+    col_names[0] = "patient_id"
     rows = [parse_row(col_names, line) for line in lines]
     return rows
 
@@ -73,7 +73,7 @@ def parse_value(col_name, value):
     a null value.
     """
 
-    if col_name == "PatientId" or col_name[0] == "i":
+    if col_name == "patient_id" or col_name[0] == "i":
         parse = int
     elif col_name[0] == "b":
         parse = lambda v: {"T": True, "F": False}[v]  # noqa E731

--- a/tests/spec/conftest.py
+++ b/tests/spec/conftest.py
@@ -4,7 +4,6 @@ import pytest
 
 from databuilder.query_language import Dataset
 
-from ..lib.mock_backend import EventLevelTable, PatientLevelTable
 from . import tables
 
 
@@ -15,8 +14,8 @@ def spec_test(request, engine):
         input_data = []
         for table, s in table_data.items():
             model = {
-                "patient_level_table": PatientLevelTable,
-                "event_level_table": EventLevelTable,
+                "patient_level_table": tables.PatientLevelTable,
+                "event_level_table": tables.EventLevelTable,
             }[table.qm_node.name]
             input_data.extend(model(**row) for row in parse_table(s))
 

--- a/tests/spec/tables.py
+++ b/tests/spec/tables.py
@@ -1,7 +1,11 @@
 import datetime
 
+import sqlalchemy
+
 from databuilder.codes import SNOMEDCTCode
 from databuilder.query_language import build_event_table, build_patient_table
+
+from ..lib.util import next_id, null
 
 p = build_patient_table(
     "patient_level_table",
@@ -29,3 +33,32 @@ e = build_event_table(
         "d2": datetime.date,
     },
 )
+
+
+Base = sqlalchemy.orm.declarative_base()
+
+
+class PatientLevelTable(Base):
+    __tablename__ = "patient_level_table"
+    Id = sqlalchemy.Column(sqlalchemy.Integer, primary_key=True, default=next_id)
+    patient_id = sqlalchemy.Column(sqlalchemy.Integer, default=null)
+    i1 = sqlalchemy.Column(sqlalchemy.Integer, default=null)
+    i2 = sqlalchemy.Column(sqlalchemy.Integer, default=null)
+    b1 = sqlalchemy.Column(sqlalchemy.Boolean, default=null)
+    b2 = sqlalchemy.Column(sqlalchemy.Boolean, default=null)
+    c1 = sqlalchemy.Column(sqlalchemy.Text, default=null)
+    d1 = sqlalchemy.Column(sqlalchemy.Date, default=null)
+    d2 = sqlalchemy.Column(sqlalchemy.Date, default=null)
+
+
+class EventLevelTable(Base):
+    __tablename__ = "event_level_table"
+    Id = sqlalchemy.Column(sqlalchemy.Integer, primary_key=True, default=next_id)
+    patient_id = sqlalchemy.Column(sqlalchemy.Integer, default=null)
+    i1 = sqlalchemy.Column(sqlalchemy.Integer, default=null)
+    i2 = sqlalchemy.Column(sqlalchemy.Integer, default=null)
+    b1 = sqlalchemy.Column(sqlalchemy.Boolean, default=null)
+    b2 = sqlalchemy.Column(sqlalchemy.Boolean, default=null)
+    c1 = sqlalchemy.Column(sqlalchemy.Text, default=null)
+    d1 = sqlalchemy.Column(sqlalchemy.Date, default=null)
+    d2 = sqlalchemy.Column(sqlalchemy.Date, default=null)

--- a/tests/spec/test_conftest.py
+++ b/tests/spec/test_conftest.py
@@ -12,14 +12,14 @@ def test_parse_table():
         """,
         )
         == [
-            {"PatientId": 1, "i1": 101, "i2": 111},
-            {"PatientId": 2, "i1": 201, "i2": None},
+            {"patient_id": 1, "i1": 101, "i2": 111},
+            {"patient_id": 2, "i1": 201, "i2": None},
         ]
     )
 
 
 def test_parse_row():
     assert parse_row(
-        ["PatientId", "i1", "i2"],
+        ["patient_id", "i1", "i2"],
         "1 | 101 | 111",
-    ) == {"PatientId": 1, "i1": 101, "i2": 111}
+    ) == {"patient_id": 1, "i1": 101, "i2": 111}

--- a/tests/unit/query_engines/test_sqlite.py
+++ b/tests/unit/query_engines/test_sqlite.py
@@ -5,7 +5,7 @@ from databuilder.query_model import Function, SelectColumn, SelectPatientTable, 
 
 
 class DummyBackend:
-    def get_table_expression(self, _name):
+    def get_table_expression(self, _name, _schema):
         return (
             sqlalchemy.select([sqlalchemy.Column("c")])
             .select_from(sqlalchemy.table("t"))

--- a/tests/unit/test_backends.py
+++ b/tests/unit/test_backends.py
@@ -9,6 +9,4 @@ def test_backend_tables():
         "practice_registrations",
         "clinical_events",
         "positive_tests",
-        "patient_level_table",
-        "event_level_table",
     }

--- a/tests/unit/test_sqlalchemy_types.py
+++ b/tests/unit/test_sqlalchemy_types.py
@@ -1,0 +1,42 @@
+import datetime
+
+import pytest
+
+from databuilder import sqlalchemy_types as types
+from databuilder.codes import CTV3Code
+from databuilder.sqlalchemy_types import type_from_python_type
+
+
+@pytest.mark.parametrize(
+    "type_,expected",
+    [
+        (bool, types.Boolean),
+        (datetime.date, types.Date),
+        (datetime.datetime, types.DateTime),
+        (float, types.Float),
+        (int, types.Integer),
+        (str, types.Text),
+        (CTV3Code, types.Text),
+    ],
+)
+def test_type_from_python_type(type_, expected):
+    assert type_from_python_type(type_) == expected
+
+
+class UnknownType:
+    ...
+
+
+def test_type_from_python_type_raises_error_on_unknown_type():
+    with pytest.raises(TypeError):
+        type_from_python_type(UnknownType)
+
+
+class TypeWithMethod:
+    @classmethod
+    def _primitive_type(cls):
+        return int
+
+
+def test_type_from_python_type_respects_primitive_type_method():
+    assert type_from_python_type(TypeWithMethod) == types.Integer


### PR DESCRIPTION
This involves quite a bit of bureaucratic reshuffling but the end result is that query engines no longer require a backend in order to execute. We now have a `DefaultBackend` which just assumes that the schema included in the query model maps directly on to the schema in the database.

This makes it much easier to disentangle the spec tests from the `MockBackend` and get rid of monstrosities like `backend_factory` altogether.

And in general, it means that you can throw any old bunch of ORM instances into `engine.setup()` and then as long as your dataset definition is built using a matching a schema you can run tests against them.