### PR TITLE
Add minimum/maximum series aggregations

### DIFF
--- a/databuilder/query_engines/base_sql.py
+++ b/databuilder/query_engines/base_sql.py
@@ -285,6 +285,14 @@ class BaseSQLQueryEngine(BaseQueryEngine):
     def get_sql_sum(self, node):
         return self.aggregate_series_by_patient(node.source, sqlalchemy.func.sum)
 
+    @get_sql.register(AggregateByPatient.Min)
+    def get_sql_min(self, node):
+        return self.aggregate_series_by_patient(node.source, sqlalchemy.func.min)
+
+    @get_sql.register(AggregateByPatient.Max)
+    def get_sql_max(self, node):
+        return self.aggregate_series_by_patient(node.source, sqlalchemy.func.max)
+
     @get_sql.register(AggregateByPatient.Exists)
     def get_sql_exists(self, node):
         return self.aggregate_frame_by_patient(

--- a/databuilder/query_language.py
+++ b/databuilder/query_language.py
@@ -143,7 +143,11 @@ class ComparableFunctions:
 
 
 class ComparableAggregations:
-    "Empty for now"
+    def minimum_for_patient(self):
+        return _apply(qm.AggregateByPatient.Min, self)
+
+    def maximum_for_patient(self):
+        return _apply(qm.AggregateByPatient.Max, self)
 
 
 class StrEventSeries(ComparableFunctions, ComparableAggregations, EventSeries):

--- a/databuilder/query_model.py
+++ b/databuilder/query_model.py
@@ -206,11 +206,11 @@ class AggregateByPatient:
     class Count(OneRowPerPatientSeries[int]):
         source: Frame
 
-    class Min(AggregatedSeries[T]):
-        source: Series[T]
+    class Min(AggregatedSeries[Comparable]):
+        source: Series[Comparable]
 
-    class Max(AggregatedSeries[T]):
-        source: Series[T]
+    class Max(AggregatedSeries[Comparable]):
+        source: Series[Comparable]
 
     class Sum(AggregatedSeries[Numeric]):
         source: Series[Numeric]

--- a/tests/generative/variable_strategies.py
+++ b/tests/generative/variable_strategies.py
@@ -96,10 +96,8 @@ def variable(patient_tables, event_tables, schema, int_values, bool_values):
             value,
             exists,
             count_,
-            # TODO: not supported by in-memory engine
-            # min_,
-            # TODO: not supported by in-memory engine
-            # max_,
+            min_,
+            max_,
             sum_,
         )
     )
@@ -165,10 +163,8 @@ def variable(patient_tables, event_tables, schema, int_values, bool_values):
 
     exists = qm_builds(AggregateByPatient.Exists, many_rows_per_patient_frame)
     count_ = qm_builds(AggregateByPatient.Count, many_rows_per_patient_frame)
-    # TODO: not supported by in-memory engine
-    # min_ = qm_builds(AggregateByPatient.Min, series)
-    # TODO: not supported by in-memory engine
-    # max_ = qm_builds(AggregateByPatient.Max, series)
+    min_ = qm_builds(AggregateByPatient.Min, series)
+    max_ = qm_builds(AggregateByPatient.Max, series)
     sum_ = qm_builds(AggregateByPatient.Sum, many_rows_per_patient_series)
 
     eq = qm_builds(Function.EQ, series, series)

--- a/tests/lib/in_memory/database.py
+++ b/tests/lib/in_memory/database.py
@@ -232,9 +232,11 @@ class Column:
 
     def aggregate_values(self, fn, default):
         def fn_with_null(values):
-            if any(value is None for value in values):
-                return None
-            return fn(values)
+            filtered = [v for v in values if v is not None]
+            if not filtered:
+                return default
+            else:
+                return fn(filtered)
 
         return self.make_new_column(lambda p, vv: [fn_with_null(vv)], default)
 

--- a/tests/lib/in_memory/engine.py
+++ b/tests/lib/in_memory/engine.py
@@ -111,14 +111,16 @@ class InMemoryQueryEngine(BaseQueryEngine):
         return self.visit(node.source).count()
 
     def visit_Min(self, node):
-        assert False
+        col = self.visit(node.source)
+        return col.aggregate_values(min, default=None)
 
     def visit_Max(self, node):
-        assert False
+        col = self.visit(node.source)
+        return col.aggregate_values(max, default=None)
 
     def visit_Sum(self, node):
         col = self.visit(node.source)
-        return col.aggregate_values(sum, None)
+        return col.aggregate_values(sum, default=None)
 
     def visit_CombineAsSet(self, node):
         assert False

--- a/tests/lib/in_memory/test_database.py
+++ b/tests/lib/in_memory/test_database.py
@@ -201,7 +201,7 @@ def test_column_aggregate_values():
     )
 
 
-def test_column_aggregate_propagates_nulls():
+def test_column_aggregate_ignores_nulls():
     c = Column.parse(
         """
         1 |
@@ -213,7 +213,7 @@ def test_column_aggregate_propagates_nulls():
     assert c.aggregate_values(sum, default=None) == Column.parse(
         """
         1 |
-        2 |
+        2 | 201
         """
     )
 

--- a/tests/spec/aggregate_series/__init__.py
+++ b/tests/spec/aggregate_series/__init__.py
@@ -1,0 +1,1 @@
+title = "Aggregating event series"

--- a/tests/spec/aggregate_series/test_minimum_and_maximum_for_patient.py
+++ b/tests/spec/aggregate_series/test_minimum_and_maximum_for_patient.py
@@ -1,0 +1,40 @@
+from ..tables import e
+
+title = "Minimum and maximum aggregations"
+
+table_data = {
+    e: """
+          |  i1
+        --+-----
+        1 | 101
+        1 | 102
+        1 | 103
+        2 | 201
+        2 |
+        3 |
+        """,
+}
+
+
+def test_minimum_for_patient(spec_test):
+    spec_test(
+        table_data,
+        e.i1.minimum_for_patient(),
+        {
+            1: 101,
+            2: 201,
+            3: None,
+        },
+    )
+
+
+def test_maximum_for_patient(spec_test):
+    spec_test(
+        table_data,
+        e.i1.maximum_for_patient(),
+        {
+            1: 103,
+            2: 201,
+            3: None,
+        },
+    )

--- a/tests/spec/aggregate_series/test_sum_for_patient.py
+++ b/tests/spec/aggregate_series/test_sum_for_patient.py
@@ -1,0 +1,29 @@
+from ..tables import e
+
+title = "Sum aggregation"
+
+table_data = {
+    e: """
+          |  i1
+        --+-----
+        1 | 101
+        1 | 102
+        1 | 103
+        2 | 201
+        2 |
+        2 | 203
+        3 |
+        """,
+}
+
+
+def test_sum_for_patient(spec_test):
+    spec_test(
+        table_data,
+        e.i1.sum_for_patient(),
+        {
+            1: (101 + 102 + 103),
+            2: (201 + 203),
+            3: None,
+        },
+    )

--- a/tests/spec/toc.py
+++ b/tests/spec/toc.py
@@ -14,6 +14,9 @@ contents = {
         "test_exists_for_patient",
         "test_count_for_patient",
     ],
+    "aggregate_series": [
+        "test_minimum_and_maximum_for_patient",
+    ],
     "combine_series": [
         "test_patient_series_and_patient_series",
         "test_patient_series_and_value",

--- a/tests/spec/toc.py
+++ b/tests/spec/toc.py
@@ -16,6 +16,7 @@ contents = {
     ],
     "aggregate_series": [
         "test_minimum_and_maximum_for_patient",
+        "test_sum_for_patient",
     ],
     "combine_series": [
         "test_patient_series_and_patient_series",


### PR DESCRIPTION
I realised I had made use of these when spiking the CIPHA study as they turn out to be quite a natural way of expressing certain sorts of query.

We also take the opportunity to add a spec for `sum_for_patient()` as per #457.