### PR TITLE
Factor out ORM class auto-generation

### DIFF
--- a/tests/generative/data_setup.py
+++ b/tests/generative/data_setup.py
@@ -23,8 +23,6 @@ def setup(schema, num_patient_tables, num_event_tables):
     all_patients_query = _build_query(patient_table_names, event_table_names, schema)
 
     return (
-        # We don't currently support different names for this column
-        "patient_id",
         patient_classes,
         event_classes,
         all_patients_query,

--- a/tests/generative/data_setup.py
+++ b/tests/generative/data_setup.py
@@ -1,4 +1,3 @@
-import sqlalchemy
 import sqlalchemy.orm
 
 from databuilder.query_model import (
@@ -7,59 +6,43 @@ from databuilder.query_model import (
     SelectPatientTable,
     SelectTable,
 )
-from databuilder.sqlalchemy_types import Integer, type_from_python_type
 
-from ..lib.util import next_id, null
+from ..lib.util import orm_class_from_schema
 
 
 def setup(schema, num_patient_tables, num_event_tables):
-    registry = sqlalchemy.orm.registry()
-    patient_id_column = "patient_id"
+    base_class = sqlalchemy.orm.declarative_base()
 
     patient_table_names, patient_classes = _build_orm_classes(
-        "p", num_patient_tables, schema, patient_id_column, registry
+        "p", num_patient_tables, schema, base_class
     )
     event_table_names, event_classes = _build_orm_classes(
-        "e", num_event_tables, schema, patient_id_column, registry
+        "e", num_event_tables, schema, base_class
     )
 
     all_patients_query = _build_query(patient_table_names, event_table_names, schema)
 
     return (
-        patient_id_column,
+        # We don't currently support different names for this column
+        "patient_id",
         patient_classes,
         event_classes,
         all_patients_query,
-        registry.metadata,
+        base_class.metadata,
     )
 
 
-def _build_orm_classes(prefix, count, schema, patient_id_column, registry):
+def _build_orm_classes(prefix, count, schema, base_class):
     names = [f"{prefix}{i}" for i in range(count)]
-    classes = [
-        _build_orm_class(name, schema, patient_id_column, registry) for name in names
-    ]
+    classes = [_build_orm_class(name, schema, base_class) for name in names]
     return names, classes
 
 
-def _build_orm_class(name, schema, patient_id_column, registry):
-    columns = [
-        sqlalchemy.Column("Id", Integer, primary_key=True, default=next_id),
-        sqlalchemy.Column(patient_id_column, Integer, nullable=False),
-    ]
-    for col_name, type_ in schema.items():
-        columns.append(
-            sqlalchemy.Column(col_name, type_from_python_type(type_), default=null)
-        )
-
-    table = sqlalchemy.Table(name, registry.metadata, *columns)
-    class_ = type(name, (object,), dict(__tablename__=name, metadata=registry.metadata))
-    registry.map_imperatively(class_, table)
-
-    # It's helpful to have the classes available as module properties so that we can copy-paste failing test cases
-    # from Hypothesis.
+def _build_orm_class(name, schema, base_class):
+    class_ = orm_class_from_schema(base_class, name, schema)
+    # It's helpful to have the classes available as module properties so that we can
+    # copy-paste failing test cases from Hypothesis.
     globals()[name] = class_
-
     return class_
 
 

--- a/tests/generative/test_query_model.py
+++ b/tests/generative/test_query_model.py
@@ -14,7 +14,6 @@ from .conftest import count_nodes, observe_inputs
 # To simplify data generation, all tables have the same schema.
 schema = TableSchema(i1=int, i2=int, b1=bool, b2=bool)
 (
-    patient_id_column,
     patient_classes,
     event_classes,
     all_patients_query,
@@ -34,7 +33,7 @@ variable_strategy = variable_strategies.variable(
     bool_values,
 )
 data_strategy = data_strategies.data(
-    patient_classes, event_classes, patient_id_column, schema, int_values, bool_values
+    patient_classes, event_classes, schema, int_values, bool_values
 )
 settings = dict(
     max_examples=(int(os.environ.get("EXAMPLES", 100))),

--- a/tests/lib/in_memory/database.py
+++ b/tests/lib/in_memory/database.py
@@ -49,7 +49,7 @@ class InMemoryDatabase:
             self.tables[sqla_table.name] = self.build_table(sqla_table, items)
 
     def build_table(self, sqla_table, items):
-        col_names = [col.name for col in sqla_table.columns if col.name != "Id"]
+        col_names = [col.name for col in sqla_table.columns if col.name != "_pk"]
         row_records = [
             [getattr(item, col_name) for col_name in col_names] for item in items
         ]

--- a/tests/spec/tables.py
+++ b/tests/spec/tables.py
@@ -1,11 +1,11 @@
 import datetime
 
-import sqlalchemy
+import sqlalchemy.orm
 
 from databuilder.codes import SNOMEDCTCode
 from databuilder.query_language import build_event_table, build_patient_table
 
-from ..lib.util import next_id, null
+from ..lib.util import orm_class_from_table
 
 p = build_patient_table(
     "patient_level_table",
@@ -36,29 +36,5 @@ e = build_event_table(
 
 
 Base = sqlalchemy.orm.declarative_base()
-
-
-class PatientLevelTable(Base):
-    __tablename__ = "patient_level_table"
-    Id = sqlalchemy.Column(sqlalchemy.Integer, primary_key=True, default=next_id)
-    patient_id = sqlalchemy.Column(sqlalchemy.Integer, default=null)
-    i1 = sqlalchemy.Column(sqlalchemy.Integer, default=null)
-    i2 = sqlalchemy.Column(sqlalchemy.Integer, default=null)
-    b1 = sqlalchemy.Column(sqlalchemy.Boolean, default=null)
-    b2 = sqlalchemy.Column(sqlalchemy.Boolean, default=null)
-    c1 = sqlalchemy.Column(sqlalchemy.Text, default=null)
-    d1 = sqlalchemy.Column(sqlalchemy.Date, default=null)
-    d2 = sqlalchemy.Column(sqlalchemy.Date, default=null)
-
-
-class EventLevelTable(Base):
-    __tablename__ = "event_level_table"
-    Id = sqlalchemy.Column(sqlalchemy.Integer, primary_key=True, default=next_id)
-    patient_id = sqlalchemy.Column(sqlalchemy.Integer, default=null)
-    i1 = sqlalchemy.Column(sqlalchemy.Integer, default=null)
-    i2 = sqlalchemy.Column(sqlalchemy.Integer, default=null)
-    b1 = sqlalchemy.Column(sqlalchemy.Boolean, default=null)
-    b2 = sqlalchemy.Column(sqlalchemy.Boolean, default=null)
-    c1 = sqlalchemy.Column(sqlalchemy.Text, default=null)
-    d1 = sqlalchemy.Column(sqlalchemy.Date, default=null)
-    d2 = sqlalchemy.Column(sqlalchemy.Date, default=null)
+PatientLevelTable = orm_class_from_table(Base, p)
+EventLevelTable = orm_class_from_table(Base, e)

--- a/tests/spec/test_conftest.py
+++ b/tests/spec/test_conftest.py
@@ -4,6 +4,7 @@ from .conftest import parse_row, parse_table
 def test_parse_table():
     assert (
         parse_table(
+            {"i1": int, "i2": int},
             """
           |  i1 |  i2
         --+-----+-----
@@ -20,6 +21,7 @@ def test_parse_table():
 
 def test_parse_row():
     assert parse_row(
+        {"patient_id": int, "i1": int, "i2": int},
         ["patient_id", "i1", "i2"],
         "1 | 101 | 111",
     ) == {"patient_id": 1, "i1": 101, "i2": 111}


### PR DESCRIPTION
This factors out the code which automatically generates a matching SQLAlchemy ORM class from a table schema into a reusable method and then uses it to reduce duplication in the spec test setup.

This is particularly useful when constructing large tests with realistic schemas as I am currently doing.

We also change the spec test parser to use schema types when parsing tables. This seems to me more robust and flexible than relying on the first character of the column name. And it means we can add new types to the spec tests without needing to specifically teach the parser about them.