### PR TITLE
Add `generate-docs` to `test-all`

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -192,7 +192,7 @@ test-generative *ARGS: devenv
     $BIN/python -m pytest tests/generative {{ ARGS }}
 
 # Run by CI. Run all tests, checking code coverage. Optional args are passed to pytest.
-test-all *ARGS: devenv build-databuilder
+test-all *ARGS: devenv build-databuilder generate-docs
     #!/usr/bin/env bash
     set -euo pipefail
 


### PR DESCRIPTION
We add `generate-docs` to `test-all` so it is run by CI.