### PR TITLE
Add Spark query engine

### DIFF
--- a/databuilder/query_engines/spark.py
+++ b/databuilder/query_engines/spark.py
@@ -2,7 +2,8 @@ import sqlalchemy
 
 from databuilder import sqlalchemy_types
 from databuilder.query_engines.base_sql import BaseSQLQueryEngine
-from databuilder.query_engines.spark_dialect import SparkDialect
+from databuilder.query_engines.spark_dialect import CreateTemporaryViewAs, SparkDialect
+from databuilder.sqlalchemy_utils import GeneratedTable
 
 
 class SparkQueryEngine(BaseSQLQueryEngine):
@@ -18,3 +19,14 @@ class SparkQueryEngine(BaseSQLQueryEngine):
         new_date = sqlalchemy.func.date_add(date, num_days)
         # Tell SQLAlchemy that the result is a date without doing any CASTing in the SQL
         return sqlalchemy.type_coerce(new_date, sqlalchemy_types.Date())
+
+    def reify_query(self, query):
+        # Define a table object with the same columns as the query
+        table_name = self.next_intermediate_table_name()
+        columns = [
+            sqlalchemy.Column(c.name, c.type, key=c.key) for c in query.selected_columns
+        ]
+        table = GeneratedTable(table_name, sqlalchemy.MetaData(), *columns)
+        # Create a temporary (session-scoped) view from the query
+        table.setup_queries = [CreateTemporaryViewAs(table, query)]
+        return table

--- a/databuilder/query_engines/spark.py
+++ b/databuilder/query_engines/spark.py
@@ -1,0 +1,20 @@
+import sqlalchemy
+
+from databuilder import sqlalchemy_types
+from databuilder.query_engines.base_sql import BaseSQLQueryEngine
+from databuilder.query_engines.spark_dialect import SparkDialect
+
+
+class SparkQueryEngine(BaseSQLQueryEngine):
+    sqlalchemy_dialect = SparkDialect
+
+    def get_date_part(self, date, part):
+        func = sqlalchemy.func
+        get_part = {"YEAR": func.year, "MONTH": func.month, "DAY": func.day}[part]
+        # Tell SQLAlchemy that the result is an int without doing any CASTing in the SQL
+        return sqlalchemy.type_coerce(get_part(date), sqlalchemy_types.Integer())
+
+    def date_add_days(self, date, num_days):
+        new_date = sqlalchemy.func.date_add(date, num_days)
+        # Tell SQLAlchemy that the result is a date without doing any CASTing in the SQL
+        return sqlalchemy.type_coerce(new_date, sqlalchemy_types.Date())

--- a/tests/acceptance/test_age_distribution_study.py
+++ b/tests/acceptance/test_age_distribution_study.py
@@ -3,8 +3,8 @@ from datetime import datetime
 from tests.lib.tpp_schema import patient
 
 
-def test_generate_dataset(study, database):
-    database.setup(
+def test_generate_dataset(study, mssql_database):
+    mssql_database.setup(
         patient(dob=datetime(1910, 5, 5)),
         patient(dob=datetime(2010, 5, 5)),
     )
@@ -12,7 +12,7 @@ def test_generate_dataset(study, database):
     study.setup_from_repo(
         "opensafely/test-age-distribution", "analysis/dataset_definition.py"
     )
-    study.generate(database, "tpp")
+    study.generate(mssql_database, "tpp")
     results = study.results()
 
     assert len(results) == 1

--- a/tests/acceptance/test_embedded_study.py
+++ b/tests/acceptance/test_embedded_study.py
@@ -32,26 +32,26 @@ class DummyDataStudy:
         )
 
 
-def test_generate_dataset(study, database):
-    database.setup(
+def test_generate_dataset(study, mssql_database):
+    mssql_database.setup(
         patient(dob=datetime(1943, 5, 5)),
         patient(dob=datetime(1999, 5, 5)),
     )
 
     study.setup_from_string(trivial_dataset_definition)
-    study.generate(database, "tpp")
+    study.generate(mssql_database, "tpp")
     results = study.results()
 
     assert len(results) == 2
     assert {r["year"] for r in results} == {"1943", "1999"}
 
 
-def test_validate_dataset_happy_path(study, database):
+def test_validate_dataset_happy_path(study, mssql_database):
     study.setup_from_string(trivial_dataset_definition)
     study.validate()
 
 
-def test_validate_dataset_error_path(study, database):
+def test_validate_dataset_error_path(study, mssql_database):
     study.setup_from_string(invalid_dataset_definition)
     with pytest.raises(NameError):
         study.validate()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ from databuilder.query_engines.sqlite import SQLiteQueryEngine
 
 from .lib.databases import (
     InMemorySQLiteDatabase,
-    make_database,
+    make_mssql_database,
     make_spark_database,
     wait_for_database,
 )
@@ -30,8 +30,8 @@ def containers():
 
 
 @pytest.fixture(scope="session")
-def database(containers):
-    database = make_database(containers)
+def mssql_database(containers):
+    database = make_mssql_database(containers)
     wait_for_database(database)
     yield database
 
@@ -87,7 +87,7 @@ def in_memory_sqlite_database():
 
 
 @pytest.fixture(params=["in_memory", "sqlite", "mssql"])
-def engine(request, in_memory_sqlite_database, database):
+def engine(request, in_memory_sqlite_database, mssql_database):
     name = request.param
     if name == "in_memory":
         # There are some tests we currently expect to fail against the in-memory engine
@@ -98,7 +98,7 @@ def engine(request, in_memory_sqlite_database, database):
     elif name == "sqlite":
         return QueryEngineFixture(name, in_memory_sqlite_database, SQLiteQueryEngine)
     elif name == "mssql":
-        return QueryEngineFixture(name, database, MSSQLQueryEngine)
+        return QueryEngineFixture(name, mssql_database, MSSQLQueryEngine)
     else:
         assert False
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ import pytest
 from databuilder import main
 from databuilder.definition.base import dataset_registry
 from databuilder.query_engines.mssql import MSSQLQueryEngine
+from databuilder.query_engines.spark import SparkQueryEngine
 from databuilder.query_engines.sqlite import SQLiteQueryEngine
 
 from .lib.databases import (
@@ -86,8 +87,8 @@ def in_memory_sqlite_database():
     return InMemorySQLiteDatabase()
 
 
-@pytest.fixture(params=["in_memory", "sqlite", "mssql"])
-def engine(request, in_memory_sqlite_database, mssql_database):
+@pytest.fixture(params=["in_memory", "sqlite", "mssql", "spark"])
+def engine(request, in_memory_sqlite_database, mssql_database, spark_database):
     name = request.param
     if name == "in_memory":
         # There are some tests we currently expect to fail against the in-memory engine
@@ -99,6 +100,8 @@ def engine(request, in_memory_sqlite_database, mssql_database):
         return QueryEngineFixture(name, in_memory_sqlite_database, SQLiteQueryEngine)
     elif name == "mssql":
         return QueryEngineFixture(name, mssql_database, MSSQLQueryEngine)
+    elif name == "spark":
+        return QueryEngineFixture(name, spark_database, SparkQueryEngine)
     else:
         assert False
 

--- a/tests/docker/test_cli.py
+++ b/tests/docker/test_cli.py
@@ -4,11 +4,11 @@ from tests.lib import fixtures
 from tests.lib.tpp_schema import patient
 
 
-def test_generate_dataset_in_container(study, database):
-    database.setup(patient(dob=datetime(1943, 5, 5)))
+def test_generate_dataset_in_container(study, mssql_database):
+    mssql_database.setup(patient(dob=datetime(1943, 5, 5)))
 
     study.setup_from_string(fixtures.trivial_dataset_definition)
-    study.generate_in_docker(database, "tpp")
+    study.generate_in_docker(mssql_database, "tpp")
     results = study.results()
 
     assert len(results) == 1

--- a/tests/docker/test_drivers.py
+++ b/tests/docker/test_drivers.py
@@ -9,9 +9,9 @@ import pytest
 # to add a check the test to skip on the in-memory and SQLite engines because the test
 # won't apply to them.
 @pytest.fixture(params=["mssql", "spark"])
-def engine(request, database, spark_database):
+def engine(request, mssql_database, spark_database):
     if request.param == "mssql":
-        return SimpleNamespace(name=request.param, database=database)
+        return SimpleNamespace(name=request.param, database=mssql_database)
     elif request.param == "spark":
         return SimpleNamespace(name=request.param, database=spark_database)
     else:

--- a/tests/docker/test_drivers.py
+++ b/tests/docker/test_drivers.py
@@ -1,24 +1,11 @@
-from types import SimpleNamespace
-
 import pytest
 
 
-# TODO: Until we move the mssql and spark engines back from "legacy" status the default
-# engine fixture doesn't give us the coverage we need so we replace it here. Once these
-# are included in the default engine fixture we can delete this one. But we'll also need
-# to add a check the test to skip on the in-memory and SQLite engines because the test
-# won't apply to them.
-@pytest.fixture(params=["mssql", "spark"])
-def engine(request, mssql_database, spark_database):
-    if request.param == "mssql":
-        return SimpleNamespace(name=request.param, database=mssql_database)
-    elif request.param == "spark":
-        return SimpleNamespace(name=request.param, database=spark_database)
-    else:
-        assert False
-
-
 def test_driver_in_container(run_in_container, engine):
+    # This test doesn't make sense for these in-memory databases
+    if engine.name in {"in_memory", "sqlite"}:
+        pytest.skip()
+
     backends = {
         "mssql": "tpp",
         "spark": "databricks",

--- a/tests/integration/backends/test_tpp.py
+++ b/tests/integration/backends/test_tpp.py
@@ -29,8 +29,8 @@ def run_query(database, query):
         "strips just trailing xs",
     ],
 )
-def test_hospitalization_table_code_conversion(database, raw, codes):
-    database.setup(
+def test_hospitalization_table_code_conversion(mssql_database, raw, codes):
+    mssql_database.setup(
         patient(
             related=[apcs(codes=raw)],
         )
@@ -39,7 +39,7 @@ def test_hospitalization_table_code_conversion(database, raw, codes):
     table = TPPBackend.hospitalizations.get_expression("hospitalizations")
     query = sqlalchemy.select(table.c.code)
 
-    results = list(run_query(database, query))
+    results = list(run_query(mssql_database, query))
 
     # Because of the way that we split the raw codes, the order in which they are returned is not the same as the order
     # they appear in the table.
@@ -47,8 +47,8 @@ def test_hospitalization_table_code_conversion(database, raw, codes):
     assert {r[0] for r in results} == set(codes)
 
 
-def test_patients_contract_table(database):
-    database.setup(
+def test_patients_contract_table(mssql_database):
+    mssql_database.setup(
         patient(1, "M", "1990-01-01", date_of_death="2021-01-04"),
         patient(2, "F", "1990-01-01", date_of_death="2020-02-04"),
         patient(3, "I", "1990-01-01", date_of_death="9999-12-31"),
@@ -61,7 +61,7 @@ def test_patients_contract_table(database):
         table.c.patient_id, table.c.date_of_birth, table.c.date_of_death, table.c.sex
     )
 
-    results = list(run_query(database, query))
+    results = list(run_query(mssql_database, query))
     assert results == [
         (1, date(1990, 1, 1), date(2021, 1, 1), "male"),
         (2, date(1990, 1, 1), date(2020, 2, 1), "female"),

--- a/tests/integration/query_engines/test_mssql_lib.py
+++ b/tests/integration/query_engines/test_mssql_lib.py
@@ -9,11 +9,11 @@ from databuilder.query_engines.mssql_lib import (
 )
 
 
-def test_fetch_results_in_batches_happy_path(database):
+def test_fetch_results_in_batches_happy_path(mssql_database):
     table = sqlalchemy.table("test_table")
     test_data = _make_test_data(rows=12)
 
-    engine = database.engine()
+    engine = mssql_database.engine()
     with engine.connect() as conn:
         _populate_table(conn, table, test_data)
 
@@ -28,11 +28,11 @@ def test_fetch_results_in_batches_happy_path(database):
         assert _as_dicts(results) == test_data
 
 
-def test_fetch_results_in_batches_with_retry(database):
+def test_fetch_results_in_batches_with_retry(mssql_database):
     table = sqlalchemy.table("test_table")
     test_data = _make_test_data(rows=12)
 
-    engine = database.engine()
+    engine = mssql_database.engine()
     with engine.connect() as conn:
         _populate_table(conn, table, test_data)
 
@@ -52,11 +52,11 @@ def test_fetch_results_in_batches_with_retry(database):
             assert execute.call_count == 5
 
 
-def test_fetch_results_in_batches_with_reconnect_and_retry(database):
+def test_fetch_results_in_batches_with_reconnect_and_retry(mssql_database):
     table = sqlalchemy.table("test_table")
     test_data = _make_test_data(rows=12)
 
-    engine = database.engine()
+    engine = mssql_database.engine()
     with engine.connect() as conn:
         _populate_table(conn, table, test_data)
 
@@ -78,11 +78,11 @@ def test_fetch_results_in_batches_with_reconnect_and_retry(database):
             assert execute.call_count == 5
 
 
-def test_fetch_results_in_batches_caches_results(database, temp_tables):
+def test_fetch_results_in_batches_caches_results(mssql_database, temp_tables):
     table = sqlalchemy.table("test_table")
     test_data = _make_test_data(rows=12)
 
-    engine = database.engine()
+    engine = mssql_database.engine()
     with engine.connect() as conn:
         _populate_table(conn, table, test_data)
 
@@ -173,9 +173,9 @@ def _as_dicts(results):
 
 
 @pytest.fixture
-def temp_tables(database):
+def temp_tables(mssql_database):
     temp_tables = TempTables(
-        engine=database.engine(), database="temp_tables", prefix="temp_"
+        engine=mssql_database.engine(), database="temp_tables", prefix="temp_"
     )
     temp_tables.drop_all()
     try:

--- a/tests/integration/test___main__.py
+++ b/tests/integration/test___main__.py
@@ -1,9 +1,9 @@
 from databuilder.__main__ import main
 
 
-def test_test_connection(monkeypatch, database, capsys):
+def test_test_connection(monkeypatch, mssql_database, capsys):
     monkeypatch.setenv("BACKEND", "tpp")
-    monkeypatch.setenv("DATABASE_URL", database.host_url())
+    monkeypatch.setenv("DATABASE_URL", mssql_database.host_url())
     argv = ["test-connection"]
     main(argv)
     out, _ = capsys.readouterr()

--- a/tests/legacy/conftest.py
+++ b/tests/legacy/conftest.py
@@ -39,10 +39,10 @@ class LegacyQueryEngineFixture(QueryEngineFixture):
 @pytest.fixture(
     scope="session", params=["mssql", pytest.param("spark", marks=pytest.mark.spark)]
 )
-def engine(request, database, spark_database):
+def engine(request, mssql_database, spark_database):
     name = request.param
     if name == "mssql":
-        return LegacyQueryEngineFixture(name, database, MssqlQueryEngine)
+        return LegacyQueryEngineFixture(name, mssql_database, MssqlQueryEngine)
     elif name == "spark":
         return LegacyQueryEngineFixture(name, spark_database, SparkQueryEngine)
     else:

--- a/tests/lib/databases.py
+++ b/tests/lib/databases.py
@@ -130,7 +130,7 @@ def wait_for_database(database, timeout=10):
             time.sleep(1)
 
 
-def make_database(containers):
+def make_mssql_database(containers):
     password = "Your_password123!"
 
     container_name = "databuilder-mssql"

--- a/tests/unit/query_engines/test_spark_dialect.py
+++ b/tests/unit/query_engines/test_spark_dialect.py
@@ -1,0 +1,32 @@
+import sqlalchemy
+from sqlalchemy.sql.visitors import iterate
+
+from databuilder.query_engines.spark_dialect import CreateTemporaryViewAs
+
+
+def test_create_temporary_view_as():
+    table = sqlalchemy.table("foo", sqlalchemy.Column("bar"))
+    query = sqlalchemy.select(table.c.bar).where(table.c.bar > 1)
+    target_table = sqlalchemy.table("test")
+    create_view = CreateTemporaryViewAs(target_table, query)
+    assert str(create_view).strip() == (
+        "CREATE TEMPORARY VIEW test AS SELECT foo.bar \n"
+        "FROM foo \n"
+        "WHERE foo.bar > :bar_1"
+    )
+
+
+def test_create_temporary_view_as_can_be_iterated():
+    # If we don't define the `get_children()` method on `CreateTemporaryViewAs` we won't
+    # get an error when attempting to iterate the resulting element structure: it will
+    # just act as a leaf node. But as we rely heavily on query introspection we need to
+    # ensure we can iterate over query structures.
+    table = sqlalchemy.table("foo", sqlalchemy.Column("bar"))
+    query = sqlalchemy.select(table.c.bar).where(table.c.bar > 1)
+    target_table = sqlalchemy.table("test")
+    create_view = CreateTemporaryViewAs(target_table, query)
+
+    # Check that element supports iteration by confirming that we can get back to both
+    # the target table and the original table by iterating it
+    assert any([e is table for e in iterate(create_view)]), "no `table`"
+    assert any([e is target_table for e in iterate(create_view)]), "no `target_table`"


### PR DESCRIPTION
This was done less because we desperately need a Spark query engine right now (although it's been made clear we definitely do need to support this soon) and more because it will let us safely delete large swathes of legacy code, which will in turn let us simplify things for the code walk-through next week.

The Spark tests are still [excruciatingly slow](https://github.com/opensafely-core/databuilder/issues/248) but there's not much we can do about that right now.