### PR TITLE
Use caching when generating SQL from query model

### DIFF
--- a/databuilder/functools_utils.py
+++ b/databuilder/functools_utils.py
@@ -1,0 +1,73 @@
+from functools import cache, singledispatchmethod
+
+
+# This is needed to make `singledispatchmethod` play nicely with `cache`, and also to
+# make `cache` behave sensibly with instance methods.
+#
+# First, it's not possible to just decorate `singledispatchmethod` with `cache` like so:
+#
+#   class Foo:
+#       @cache
+#       @singledispatchmethod
+#       def example(self, value):
+#           ...
+#
+#       @example.register(Bar)
+#       def bar_impl(self, value):
+#           ...
+#
+#       @example.register(Baz)
+#       def baz_impl(self, value):
+#           ...
+#
+# Because the cache-decorated method no longer has the `register()` method available.
+#
+# Instead you need to decorate each individual method like so:
+#
+#   class Foo:
+#       @singledispatchmethod
+#       @cache
+#       def example(self, value):
+#           ...
+#
+#       @example.register(Bar)
+#       @cache
+#       def bar_impl(self, value):
+#           ...
+#
+#       @example.register(Baz)
+#       @cache
+#       def baz_impl(self, value):
+#           ...
+#
+# Not only is this repetitive and error prone but it makes it much harder to clear the
+# cache as now you need to call `cache_clear()` on each individual method.
+#
+# Secondly, `@cache` doesn't behave quite as you might want on instance methods. Rather
+# than create independent caches per instance it creates a single shared cache for the
+# class.  As this cache is keyed on `self` as one of its arguments it behaves _sort of
+# like_ an instance cache, if you squint. But its contents never get garbage collected
+# unless you explicity call `cache_clear()`. And if you do call `cache_clear()` it
+# empties the cache for all instances, not just the instance whose method you called it
+# on.
+#
+# The below decorator is desiged to address both these issues and provide a true
+# per-instance cache that works with `singledispatchmethod`.
+class singledispatchmethod_with_cache(singledispatchmethod):
+    """
+    Modifies `singledispatchmethod` to wrap the decorated method with `functools.cache`
+    """
+
+    def __set_name__(self, owner, name):
+        # Record the name of the method
+        self.attribute_name = name
+
+    def __get__(self, obj, cls=None):
+        bound_method = super().__get__(obj, cls)
+        cached_method = cache(bound_method)
+        # Set the cached method as an attribute on the instance so that subsequent
+        # `obj.method` references get the same cached method back. Without this, each
+        # reference would generate a new method with its own isolated cache, rendering
+        # the whole thing pointless.
+        obj.__dict__[self.attribute_name] = cached_method
+        return cached_method

--- a/tests/unit/test_functools_utils.py
+++ b/tests/unit/test_functools_utils.py
@@ -1,0 +1,50 @@
+import pytest
+
+from databuilder.functools_utils import singledispatchmethod_with_cache
+
+
+@pytest.fixture
+def TestClass():
+    COUNTER = 0
+
+    class TestClass:
+        @singledispatchmethod_with_cache
+        def test(self, value):
+            assert False
+
+        @test.register(str)
+        def test_str(self, value):
+            # Use a shared counter to give different results for each call
+            nonlocal COUNTER
+            COUNTER += 1
+            return value, COUNTER
+
+    return TestClass
+
+
+def test_results_are_cached(TestClass):
+    obj = TestClass()
+    assert obj.test("hello") is obj.test("hello")
+
+
+def test_cache_is_unique_to_instances(TestClass):
+    obj1 = TestClass()
+    obj2 = TestClass()
+    assert obj1.test("hello") is not obj2.test("hello")
+
+
+def test_cache_can_be_cleared(TestClass):
+    obj = TestClass()
+    result = obj.test("hello")
+    obj.test.cache_clear()
+    assert result is not obj.test("hello")
+
+
+def test_clearing_cache_only_affects_single_instance(TestClass):
+    obj1 = TestClass()
+    obj2 = TestClass()
+    result1 = obj1.test("hello")
+    result2 = obj2.test("hello")
+    obj1.test.cache_clear()
+    assert result1 is not obj1.test("hello")
+    assert result2 is obj2.test("hello")


### PR DESCRIPTION
Without caching here we emit unnecessarily verbose and duplicative SQL because any nodes which generate temporary tables or CTEs end up generating new ones each time they're referenced.

For instance, if you wrote a query to find a vaccination date for each patient and used that vaccination date in three places in your study we'd end up generating the same vaccination date query three times as three separate temporary tables (or CTEs).

In fact, the tables get out of hand so quickly that SQLite won't even execute the SQL anymore and dies with:

    sqlite3.OperationalError: too many FROM clause terms, max: 200

The solution is to generate the SQL once for each node and then reuse it each time the node is referenced. However this isn't quite as simple as slapping `@functools.cache` on the relevant method because we're also using `@singledispatchmethod` to handle the various different node types and the two don't play nicely together. So we have to make our own decorator which combines the two mechanisms and gives us both caching and single dispatch.

Closes #508