### PR TITLE
Allow `Any` type to be used as an escape hatch

### DIFF
--- a/databuilder/query_model.py
+++ b/databuilder/query_model.py
@@ -562,6 +562,12 @@ def validate_types(node):
     # values so we create a single context object to share between all fields
     typevar_context = {}
     for field in dataclasses.fields(node):
+        target_typespec = field.type
+        # Bail out early if there's no type-checking to be done; this allows us to work
+        # with values that `get_typespec` cant' handle in cases where we don't actually
+        # care about the type.
+        if target_typespec is Any:
+            continue
         value = getattr(node, field.name)
         # This might look a bit backward: instead of checking whether the value is of
         # the expected type, we convert the value to a type specification and check that
@@ -572,7 +578,6 @@ def validate_types(node):
         # approach to type checking doesn't work. There may well be a more elegant
         # alternative approach here, but this works for now.
         typespec = get_typespec(value)
-        target_typespec = field.type
         if not type_matches(typespec, target_typespec, typevar_context):
             # Try to make errors a bit more helpful by resolving TypeVars if we can.
             # This means that if validation fails because e.g. `T` has been bound to

--- a/databuilder/query_model_transforms.py
+++ b/databuilder/query_model_transforms.py
@@ -20,7 +20,11 @@ from databuilder.query_model import PickOneRowPerPatient, SelectColumn, get_inpu
 
 
 class PickOneRowPerPatientWithColumns(PickOneRowPerPatient):
-    selected_columns: frozenset[Any]
+    # The actual type here is `frozenset[Series]` but our type-checking code can't
+    # currently handle the mixed type sets we get here (e.g. `Series[bool]` and
+    # `Series[int]`). We've decided that, as this is an internal class not part of the
+    # public API, it's not worth complicating the type-checking code for this use case.
+    selected_columns: Any
 
 
 def apply_transforms(variables):

--- a/tests/unit/test_query_model.py
+++ b/tests/unit/test_query_model.py
@@ -376,3 +376,27 @@ def test_cannot_define_operation_returning_any_type(queries):
 
     with pytest.raises(AssertionError, match=r"never return Series\[Any\]"):
         get_series_type(BadOperation(queries.vaccination_count))
+
+
+def test_any_type_acts_as_an_escape_hatch():
+    # In the `query_model_transforms` module we define new node types which are purely
+    # for internal use by the query engines and don't form part of the public query
+    # model API. We sometimes want to use types here without having to add support for
+    # them in the type checking system, which is already "cleverer" than anyone would
+    # like. This test ensures that `Any` can be used as an escape hatch.
+
+    mixed_set = {1, 2.0, "three"}
+
+    # Confirm that we can't validate heterogeneous sets
+    class SomePublicOperation(Series):
+        value: set[Any]
+
+    with pytest.raises(TypeError, match=r"Sets must be of homogeneous type"):
+        SomePublicOperation(value=mixed_set)
+
+    # Confirm that we can nevertheless use such a value as long as we don't care what
+    # type it is
+    class SomeInternalOperation(Series):
+        value: Any
+
+    assert SomeInternalOperation(value=mixed_set)


### PR DESCRIPTION
This fixes a bug whereby attempting to select two columns of different types following a pick-one-row operation blows up with a type error.

The issue is that when we construct the internal query model node `PickOoneRowPerPatientWithColumns` we collect the selected column objects into a frozenset and make that a node attribute. Then, during type validation, we call `get_typespec()` on this attribute to determine its type specification. But this can't cope with sets containing more than one type (e.g. `Series[bool]` and `Series[date]`) so it blows up.

We _could_ teach `get_typespec()` to be cleverer and work out the common ancestor class for heterogeneous sets like this. But that involves adding complexity to an already very complex system and I'm not sure there's sufficient benefit here. While strict type checking is essential for the public surface of the query model, I don't think it's so essential for the purely internal classes.

So instead we just ensure that the `Any` type functions as an escape hatch which shortcuts all the type checking behaviour and change the type annotation of the problematic attribute to `Any`.