### PR TITLE
Use `Function` class instead of magic `func` namespace

### DIFF
--- a/databuilder/query_engines/spark.py
+++ b/databuilder/query_engines/spark.py
@@ -1,4 +1,5 @@
 import sqlalchemy
+from sqlalchemy.sql.functions import Function as SQLFunction
 
 from databuilder import sqlalchemy_types
 from databuilder.query_engines.base_sql import BaseSQLQueryEngine
@@ -10,15 +11,11 @@ class SparkQueryEngine(BaseSQLQueryEngine):
     sqlalchemy_dialect = SparkDialect
 
     def get_date_part(self, date, part):
-        func = sqlalchemy.func
-        get_part = {"YEAR": func.year, "MONTH": func.month, "DAY": func.day}[part]
-        # Tell SQLAlchemy that the result is an int without doing any CASTing in the SQL
-        return sqlalchemy.type_coerce(get_part(date), sqlalchemy_types.Integer())
+        assert part in {"YEAR", "MONTH", "DAY"}
+        return SQLFunction(part, date, type_=sqlalchemy_types.Integer)
 
     def date_add_days(self, date, num_days):
-        new_date = sqlalchemy.func.date_add(date, num_days)
-        # Tell SQLAlchemy that the result is a date without doing any CASTing in the SQL
-        return sqlalchemy.type_coerce(new_date, sqlalchemy_types.Date())
+        return SQLFunction("DATE_ADD", date, num_days, type_=sqlalchemy_types.Date)
 
     def reify_query(self, query):
         # Define a table object with the same columns as the query

--- a/databuilder/query_engines/sqlite.py
+++ b/databuilder/query_engines/sqlite.py
@@ -1,5 +1,6 @@
 import sqlalchemy
 from sqlalchemy.dialects.sqlite.pysqlite import SQLiteDialect_pysqlite
+from sqlalchemy.sql.functions import Function as SQLFunction
 
 from databuilder import sqlalchemy_types
 from databuilder.query_engines.base_sql import BaseSQLQueryEngine
@@ -10,12 +11,10 @@ class SQLiteQueryEngine(BaseSQLQueryEngine):
 
     def get_date_part(self, date, part):
         format_str = {"YEAR": "%Y", "MONTH": "%m", "DAY": "%d"}[part]
-        part_as_str = sqlalchemy.func.strftime(format_str, date)
-        return sqlalchemy.cast(part_as_str, sqlalchemy_types.Integer())
+        part_as_str = SQLFunction("STRFTIME", format_str, date)
+        return sqlalchemy.cast(part_as_str, sqlalchemy_types.Integer)
 
     def date_add_days(self, date, num_days):
-        num_days_str = sqlalchemy.cast(num_days, sqlalchemy_types.String())
+        num_days_str = sqlalchemy.cast(num_days, sqlalchemy_types.String)
         modifier = num_days_str.concat(" days")
-        new_date = sqlalchemy.func.date(date, modifier)
-        # Tell SQLAlchemy that the result is a date without doing any CASTing in the SQL
-        return sqlalchemy.type_coerce(new_date, sqlalchemy_types.Date())
+        return SQLFunction("DATE", date, modifier, type_=sqlalchemy_types.Date)


### PR DESCRIPTION
This makes it clear that the function names are just arbitrary strings,
rather than being explicitly defined SQLAlchemy objects. It also lets us
supply the return type directly rather than having to faff around with
`type_coerce`.