### PR TITLE
Fix query model transform code

### DIFF
--- a/databuilder/query_model_transforms.py
+++ b/databuilder/query_model_transforms.py
@@ -47,13 +47,16 @@ def get_reverse_index(nodes):
     index = {}
     for node in nodes:
         populate_reverse_index(index, node)
-    return index
+    return {node: references.values() for node, references in index.items()}
 
 
 def populate_reverse_index(index, node):
-    index.setdefault(node, set())
+    index.setdefault(node, {})
     for subnode in get_input_nodes(node):
-        index.setdefault(subnode, set()).add(node)
+        references = index.setdefault(subnode, {})
+        # Index nodes by their object ID so as to disambiguate distnct objects which
+        # compare equal
+        references[id(node)] = node
         populate_reverse_index(index, subnode)
 
 

--- a/tests/unit/test_query_model_transforms.py
+++ b/tests/unit/test_query_model_transforms.py
@@ -24,6 +24,9 @@ def test_pick_one_row_per_patient_transform():
     variables = dict(
         first_code=SelectColumn(first_event, "code"),
         first_value=SelectColumn(first_event, "value"),
+        # Create a new distinct colum object with the same value as the first column:
+        # equal but not identical objects expose bugs in the query model transformation
+        first_code_again=SelectColumn(first_event, "code"),
     )
 
     first_event_with_columns = PickOneRowPerPatientWithColumns(
@@ -45,6 +48,7 @@ def test_pick_one_row_per_patient_transform():
     expected = {
         "first_code": SelectColumn(first_event_with_columns, "code"),
         "first_value": SelectColumn(first_event_with_columns, "value"),
+        "first_code_again": SelectColumn(first_event_with_columns, "code"),
     }
 
     transformed = apply_transforms(variables)

--- a/tests/unit/test_query_model_transforms.py
+++ b/tests/unit/test_query_model_transforms.py
@@ -1,9 +1,12 @@
+import datetime
+
 from databuilder.query_model import (
     PickOneRowPerPatient,
     Position,
     SelectColumn,
     SelectTable,
     Sort,
+    TableSchema,
 )
 from databuilder.query_model_transforms import (
     PickOneRowPerPatientWithColumns,
@@ -12,7 +15,9 @@ from databuilder.query_model_transforms import (
 
 
 def test_pick_one_row_per_patient_transform():
-    events = SelectTable("events")
+    events = SelectTable(
+        "events", schema=TableSchema(date=datetime.date, code=str, value=float)
+    )
     date = SelectColumn(events, "date")
     by_date = Sort(events, date)
     first_event = PickOneRowPerPatient(by_date, Position.FIRST)


### PR DESCRIPTION
Previously we were using `set()` to collect query model nodes. But query models can contain distinct objects that hash and compare equal. Usually we don't care about this (equal objects can happily substitute for one another) but when start mutating these objects then it matters which specific objects were mutating.

We now collect nodes using their `id()` to ensure that we get all of them.

Who'd have thought that force-mutating frozen objects would have led to problems?

What this obviously shows is the need for a better approach here. But this fix will have to do for now.