### PR TITLE
Fix CASE expressions using boolean columns on MSSQL

### DIFF
--- a/tests/spec/case_expressions/test_case.py
+++ b/tests/spec/case_expressions/test_case.py
@@ -17,7 +17,7 @@ table_data = {
 }
 
 
-def test_case(spec_test):
+def test_case_with_expression(spec_test):
     spec_test(
         table_data,
         case(
@@ -48,5 +48,32 @@ def test_case_with_default(spec_test):
             3: 0,
             4: 100,
             5: 0,
+        },
+    )
+
+
+def test_case_with_boolean_column(spec_test):
+    table_data = {
+        p: """
+              | i1 | b1
+            --+----+----
+            1 | 6  | T
+            2 | 7  | F
+            3 | 9  | F
+            4 |
+            """,
+    }
+
+    spec_test(
+        table_data,
+        case(
+            when(p.b1).then(p.i1),
+            when(p.i1 > 8).then(100),
+        ),
+        {
+            1: 6,
+            2: None,
+            3: 100,
+            4: None,
         },
     )


### PR DESCRIPTION
This is the other half of the problem solved in [#501][1]: there are
contexts in which MSSQL requires a predicate and will not accept a
boolean expression.

I hadn't realised this was an issue because SQLAlchmey was being clever
and automatically applying the right transformation when a boolean
column was used as the subject of a WHERE clause. However it does not
automatically do this for CASE ... WHEN clauses.

At present we apply these transforms for all SQL engines (including
SQLite and Spark) even though it's only MSSQL which needs them. It would
be easy enough to refactor things so that only MSSQL got this behaviour,
but it doesn't seem worth the small amount of extra complexity at this
stage.

[1]: https://github.com/opensafely-core/databuilder/pull/501/commits/a6f7797e226c99525fa752bad5d8aa405b90d22b