### PR TITLE
Remove backend registration mechanism

### DIFF
--- a/databuilder/__main__.py
+++ b/databuilder/__main__.py
@@ -3,7 +3,6 @@ import sys
 from argparse import ArgumentParser, ArgumentTypeError
 from pathlib import Path
 
-from .backends import BACKENDS
 from .main import (
     generate_dataset,
     generate_measures,
@@ -55,7 +54,7 @@ def main(args=None):
         )
     elif options.which == "test-connection":
         test_connection(
-            backend=options.backend,
+            backend_id=options.backend,
             url=options.url,
         )
     elif options.which == "print-help":
@@ -108,7 +107,6 @@ def add_dump_dataset_sql(subparsers):
     parser.add_argument(
         "backend",
         type=str,
-        choices=BACKENDS,  # allow all registered backend subclasses
     )
     parser.add_argument(
         "--dataset-definition",

--- a/databuilder/backends/__init__.py
+++ b/databuilder/backends/__init__.py
@@ -1,7 +1,0 @@
-# All backends need to be imported here so they get registered
-from .base import BACKENDS
-from .databricks import DatabricksBackend
-from .graphnet import GraphnetBackend
-from .tpp import TPPBackend
-
-__all__ = ("BACKENDS", "DatabricksBackend", "TPPBackend", "GraphnetBackend")

--- a/databuilder/backends/base.py
+++ b/databuilder/backends/base.py
@@ -2,27 +2,16 @@ import sqlalchemy
 
 from databuilder.sqlalchemy_types import TYPES_BY_NAME, type_from_python_type
 
-# Mutable global for storing registered backends
-BACKENDS = {}
-
-
-def register_backend(backend_class):
-    BACKENDS[backend_class.backend_id] = backend_class
-
 
 class BaseBackend:
-    backend_id = None
     query_engine_class = None
     patient_join_column = None
     tables = None
 
     def __init_subclass__(cls, **kwargs):
-        assert cls.backend_id is not None
         assert cls.query_engine_class is not None
         assert cls.patient_join_column is not None
 
-        # Register each Backend by its id so we can identify it from an environment variable
-        register_backend(cls)
         # Make sure each Backend knows what its tables are
         cls.tables = {}
         for name, value in vars(cls).items():

--- a/databuilder/backends/databricks.py
+++ b/databuilder/backends/databricks.py
@@ -6,7 +6,6 @@ from .base import BaseBackend, Column, MappedTable, QueryTable
 class DatabricksBackend(BaseBackend):
     """Backend for working with data in Databricks."""
 
-    backend_id = "databricks"
     query_engine_class = SparkQueryEngine
     patient_join_column = "patient_id"
 

--- a/databuilder/backends/graphnet.py
+++ b/databuilder/backends/graphnet.py
@@ -6,7 +6,6 @@ from .base import BaseBackend, Column, MappedTable
 class GraphnetBackend(BaseBackend):
     """Backend for working with data in Graphnet."""
 
-    backend_id = "graphnet"
     query_engine_class = MSSQLQueryEngine
     patient_join_column = "Patient_ID"
 

--- a/databuilder/backends/tpp.py
+++ b/databuilder/backends/tpp.py
@@ -69,7 +69,6 @@ def string_split(ref, delim):
 class TPPBackend(BaseBackend):
     """Backend for working with data in TPP."""
 
-    backend_id = "tpp"
     query_engine_class = MSSQLQueryEngine
     patient_join_column = "Patient_ID"
 

--- a/scripts/dbx
+++ b/scripts/dbx
@@ -268,7 +268,7 @@ def test(name):
             "databuilder",
             "test-connection",
             "-b",
-            "databricks",
+            "databuilder.backends.databricks.DatabricksBackend",
             "-u",
             c.url,
         ]

--- a/tests/acceptance/test_age_distribution_study.py
+++ b/tests/acceptance/test_age_distribution_study.py
@@ -12,7 +12,7 @@ def test_generate_dataset(study, mssql_database):
     study.setup_from_repo(
         "opensafely/test-age-distribution", "analysis/dataset_definition.py"
     )
-    study.generate(mssql_database, "tpp")
+    study.generate(mssql_database, "databuilder.backends.tpp.TPPBackend")
     results = study.results()
 
     assert len(results) == 1

--- a/tests/acceptance/test_embedded_study.py
+++ b/tests/acceptance/test_embedded_study.py
@@ -39,7 +39,7 @@ def test_generate_dataset(study, mssql_database):
     )
 
     study.setup_from_string(trivial_dataset_definition)
-    study.generate(mssql_database, "tpp")
+    study.generate(mssql_database, "databuilder.backends.tpp.TPPBackend")
     results = study.results()
 
     assert len(results) == 2

--- a/tests/backend_validation/test_validate_backends.py
+++ b/tests/backend_validation/test_validate_backends.py
@@ -1,3 +1,7 @@
+import importlib
+from pathlib import Path
+
+from databuilder import backends
 from databuilder.backends.base import BaseBackend
 
 
@@ -6,14 +10,19 @@ def test_validate_all_backends():
     Loops through all the backends, excluding test ones,
     and validates they meet any contract that they claim to
     """
-    backends = [
+    # Import all modules inside `databuilder.backends`
+    module_names = [f.stem for f in Path(backends.__file__).parent.glob("*.py")]
+    for module_name in module_names:
+        importlib.import_module(f"{backends.__name__}.{module_name}")
+
+    backend_classes = [
         backend
         for backend in BaseBackend.__subclasses__()
         if backend.__module__.startswith("databuilder.backends.")
     ]
 
-    for backend in backends:
+    for backend in backend_classes:
         backend.validate_contracts()
 
     # Checks at least 3 backends
-    assert len(backends) >= 3
+    assert len(backend_classes) >= 3

--- a/tests/docker/test_cli.py
+++ b/tests/docker/test_cli.py
@@ -8,7 +8,7 @@ def test_generate_dataset_in_container(study, mssql_database):
     mssql_database.setup(patient(dob=datetime(1943, 5, 5)))
 
     study.setup_from_string(fixtures.trivial_dataset_definition)
-    study.generate_in_docker(mssql_database, "tpp")
+    study.generate_in_docker(mssql_database, "databuilder.backends.tpp.TPPBackend")
     results = study.results()
 
     assert len(results) == 1

--- a/tests/docker/test_drivers.py
+++ b/tests/docker/test_drivers.py
@@ -7,8 +7,8 @@ def test_driver_in_container(run_in_container, engine):
         pytest.skip()
 
     backends = {
-        "mssql": "tpp",
-        "spark": "databricks",
+        "mssql": "databuilder.backends.tpp.TPPBackend",
+        "spark": "databuilder.backends.databricks.DatabricksBackend",
     }
 
     if engine.name not in backends:

--- a/tests/integration/backends/test_base.py
+++ b/tests/integration/backends/test_base.py
@@ -25,7 +25,6 @@ covid_tests = build_event_table(
 
 
 class TestBackend(BaseBackend):
-    backend_id = "tests_integration_backends_test_base"
     query_engine_class = BaseSQLQueryEngine
     patient_join_column = "patient_id"
 

--- a/tests/integration/test___main__.py
+++ b/tests/integration/test___main__.py
@@ -2,7 +2,7 @@ from databuilder.__main__ import main
 
 
 def test_test_connection(monkeypatch, mssql_database, capsys):
-    monkeypatch.setenv("BACKEND", "tpp")
+    monkeypatch.setenv("BACKEND", "databuilder.backends.tpp.TPPBackend")
     monkeypatch.setenv("DATABASE_URL", mssql_database.host_url())
     argv = ["test-connection"]
     main(argv)

--- a/tests/lib/study.py
+++ b/tests/lib/study.py
@@ -119,7 +119,7 @@ class Study:
             str(definition),
             "--output",
             str(output),
-            "tpp",
+            "databuilder.backends.tpp.TPPBackend",
         ]
 
     def _docker_path(self, path):

--- a/tests/unit/backends/test_base.py
+++ b/tests/unit/backends/test_base.py
@@ -20,7 +20,6 @@ class DummyContract:
 
 
 class TestBackend(BaseBackend):
-    backend_id = "tests_unit_test_backends"
     query_engine_class = BaseSQLQueryEngine
     patient_join_column = "PatientId"
 

--- a/tests/unit/contracts/test_base.py
+++ b/tests/unit/contracts/test_base.py
@@ -18,7 +18,6 @@ class PatientsContract(TableContract):
 
 def test_validate_implementation_success():
     class GoodBackend(BaseBackend):
-        backend_id = "good_test_backend"
         query_engine_class = BaseSQLQueryEngine
         patient_join_column = "patient_id"
 
@@ -36,7 +35,6 @@ def test_validate_implementation_success():
 
 def test_validate_implementation_failure_misnamed_table():
     class BadBackend(BaseBackend):
-        backend_id = "bad_test_backend"
         query_engine_class = BaseSQLQueryEngine
         patient_join_column = "patient_id"
 
@@ -56,7 +54,6 @@ def test_validate_implementation_failure_misnamed_table():
 
 def test_validate_implementation_failure_missing_column():
     class BadBackend(BaseBackend):
-        backend_id = "bad_test_backend"
         query_engine_class = BaseSQLQueryEngine
         patient_join_column = "patient_id"
 
@@ -74,7 +71,6 @@ def test_validate_implementation_failure_missing_column():
 
 def test_validate_implementation_failure_invalid_type():
     class BadBackend(BaseBackend):
-        backend_id = "bad_test_backend"
         query_engine_class = BaseSQLQueryEngine
         patient_join_column = "patient_id"
 

--- a/tests/unit/test___main__.py
+++ b/tests/unit/test___main__.py
@@ -91,7 +91,7 @@ def test_dump_dataset_sql(mocker, tmp_path):
         "dump-dataset-sql",
         "--dataset-definition",
         str(dataset_definition_path),
-        "tpp",
+        "databuilder.backends.tpp.TPPBackend",
     ]
     main(argv)
     patched.assert_called_once()


### PR DESCRIPTION
The effect of this PR is that rather than specifying a backend using an
alias like:

    OPENSAFELY_BACKEND='tpp'

The backend is instead specified using its full dotted path:

    OPENSAFELY_BACKEND='databuilder.backends.tpp.TPPBackend'

This fixes a [circular import][1] problem, removes some code, and at the
same time makes it possible to use databuilder with backends definitions
that aren't bundled within databuilder itself.

I don't currently anticipate users needing to supply backend names
themselves on the command line, so the extra verbosity shouldn't be a
problem here. But if it turns out they do need to do so then we can
define a mapping of short aliases to full dotted paths for commonly used
backends.

Closes #561

[1]: https://github.com/opensafely-core/databuilder/issues/561