### PR TITLE
Make comparisons between Value node type-sensitive

### DIFF
--- a/databuilder/query_model.py
+++ b/databuilder/query_model.py
@@ -157,6 +157,16 @@ class AggregatedSeries(OneRowPerPatientSeries):
 class Value(OneRowPerPatientSeries[T]):
     value: T
 
+    # Python treats certain differently typed values as equal (e.g. `1 == True` and `10
+    # == 10.0`) but we need to be stricter about types because some of the databases we
+    # run against are strict
+    def __eq__(self, other):
+        if other.__class__ is self.__class__:
+            if self.value.__class__ is not other.value.__class__:
+                return False
+            return self.value == other.value
+        return NotImplemented
+
 
 class SelectTable(ManyRowsPerPatientFrame):
     name: str

--- a/tests/unit/test_query_model.py
+++ b/tests/unit/test_query_model.py
@@ -400,3 +400,9 @@ def test_any_type_acts_as_an_escape_hatch():
         value: Any
 
     assert SomeInternalOperation(value=mixed_set)
+
+
+def test_comparions_between_value_nodes_are_strict():
+    assert Value(10) == Value(10)
+    assert Value(10) != Value(10.0)
+    assert Value(1) != Value(True)


### PR DESCRIPTION
Python treats certain differently typed values as equal (e.g. `1 == True` and `10 == 10.0`) but some of the databases we run against care about the difference between e.g. integers and floats. Because of the caching mechanism used in the BaseSQLQueryEngine, `Value` nodes which compare equal will always produce the same SQL. This means that `Value(10)` can produce SQL corresponding to `Value(10.0)`, if the latter node happens to have been processed and cached first.

The fix here is to define a custom equality method for `Value` which checks the types as well.