### PR TITLE
Run generative tests against MSSQL

### DIFF
--- a/tests/generative/test_query_model.py
+++ b/tests/generative/test_query_model.py
@@ -76,9 +76,16 @@ def run_test(query_engines, data, variable):
         "v": variable,
     }
 
-    in_mem_results = run_with(query_engines["in_memory"], instances, variables)
-    sqlite_results = run_with(query_engines["sqlite"], instances, variables)
-    assert in_mem_results == sqlite_results
+    results = [
+        (name, run_with(engine, instances, variables))
+        for name, engine in query_engines.items()
+    ]
+
+    first_name, first_results = results[0]
+    for other_name, other_results in results[1:]:
+        assert (
+            first_results == other_results
+        ), f"Mismatch between {first_name} and {other_name}"
 
 
 def run_with(engine, instances, variables):


### PR DESCRIPTION
I still don't know exactly what the issue was here, but refactoring things so that we re-use the same `Database` instance across tests seems to have fixed whatever was causing the file descriptor exhaustion problem.

As part of the refactoring we now use the same parametrized `engine` fixture as the other tests so that adding new engine types here automatically includes them in the generative tests.

Closes #509