### PR TITLE
Allow `take/drop` to accept boolean constants

### DIFF
--- a/databuilder/query_language.py
+++ b/databuilder/query_language.py
@@ -379,7 +379,7 @@ class EventFrame(Frame):
         return EventFrame(
             qm.Filter(
                 source=self.qm_node,
-                condition=series.qm_node,
+                condition=_convert(series),
             )
         )
 
@@ -388,8 +388,8 @@ class EventFrame(Frame):
             qm.Filter(
                 source=self.qm_node,
                 condition=qm.Function.Or(
-                    lhs=qm.Function.Not(series.qm_node),
-                    rhs=qm.Function.IsNull(series.qm_node),
+                    lhs=qm.Function.Not(_convert(series)),
+                    rhs=qm.Function.IsNull(_convert(series)),
                 ),
             )
         )
@@ -402,7 +402,7 @@ class EventFrame(Frame):
         for series in reversed(order_series):
             qm_node = qm.Sort(
                 source=qm_node,
-                sort_by=series.qm_node,
+                sort_by=_convert(series),
             )
         return SortedEventFrame(qm_node)
 

--- a/tests/spec/filter/test_drop.py
+++ b/tests/spec/filter/test_drop.py
@@ -54,3 +54,45 @@ def test_drop_with_expr(spec_test):
             3: 301,
         },
     )
+
+
+def test_drop_with_constant_true(spec_test):
+    table_data = {
+        e: """
+              |  i1
+            --+----
+            1 | 101
+            1 | 102
+            2 | 201
+        """,
+    }
+
+    spec_test(
+        table_data,
+        e.drop(True).count_for_patient(),
+        {
+            1: 0,
+            2: 0,
+        },
+    )
+
+
+def test_drop_with_constant_false(spec_test):
+    table_data = {
+        e: """
+              |  i1
+            --+----
+            1 | 101
+            1 | 102
+            2 | 201
+        """,
+    }
+
+    spec_test(
+        table_data,
+        e.drop(False).count_for_patient(),
+        {
+            1: 2,
+            2: 1,
+        },
+    )

--- a/tests/spec/filter/test_take.py
+++ b/tests/spec/filter/test_take.py
@@ -58,6 +58,48 @@ def test_take_with_expr(spec_test):
     )
 
 
+def test_take_with_constant_true(spec_test):
+    table_data = {
+        e: """
+              |  i1
+            --+----
+            1 | 101
+            1 | 102
+            2 | 201
+        """,
+    }
+
+    spec_test(
+        table_data,
+        e.take(True).count_for_patient(),
+        {
+            1: 2,
+            2: 1,
+        },
+    )
+
+
+def test_take_with_constant_false(spec_test):
+    table_data = {
+        e: """
+              |  i1
+            --+----
+            1 | 101
+            1 | 102
+            2 | 201
+        """,
+    }
+
+    spec_test(
+        table_data,
+        e.take(False).count_for_patient(),
+        {
+            1: 0,
+            2: 0,
+        },
+    )
+
+
 @pytest.mark.xfail_in_memory
 def test_chain_multiple_takes(spec_test):
     table_data = {


### PR DESCRIPTION
This might look a bit pointless, but it turns out to be convenient to be
able to have a no-op filter condition that can be used as a default to
avoid having to add an extra conditional e.g.
```py
    def some_function(where=True):
        filtered = frame.take(where)
        ...
```

Without this you'd need to something like:
```py
    def some_function(where=None):
        if where is None:
            filtered = frame
        else:
            filtered = frame.take(where)
        ...
```

This involves passing all arguments to ehrQL methods through `_convert`
rather than assuming they are series objects.