### PR TITLE
Use pytest fixture to build docker image for tests

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -153,7 +153,7 @@ test-backend-validation *ARGS: devenv
     $BIN/python -m pytest tests/backend_validation {{ ARGS }}
 
 # Run the databuilder-in-docker tests only. Optional args are passed to pytest.
-test-docker *ARGS: devenv build-databuilder
+test-docker *ARGS: devenv
     $BIN/python -m pytest tests/docker {{ ARGS }}
 
 # Run the integration tests only. Optional args are passed to pytest.
@@ -184,7 +184,7 @@ test-generative *ARGS: devenv
     $BIN/python -m pytest tests/generative {{ ARGS }}
 
 # Run by CI. Run all tests, checking code coverage. Optional args are passed to pytest.
-test-all *ARGS: devenv build-databuilder generate-docs
+test-all *ARGS: devenv generate-docs
     #!/usr/bin/env bash
     set -euo pipefail
 

--- a/tests/docker/conftest.py
+++ b/tests/docker/conftest.py
@@ -4,12 +4,12 @@ import pytest
 
 
 @pytest.fixture
-def run_in_container(tmpdir, containers):
+def run_in_container(tmpdir, containers, databuilder_image):
     workspace = Path(tmpdir.mkdir("workspace"))
 
     def run(command):
         output = containers.run_fg(
-            image="databuilder:latest",
+            image=databuilder_image,
             command=command,
             volumes={workspace: {"bind": "/workspace", "mode": "rw"}},
         )

--- a/tests/lib/study.py
+++ b/tests/lib/study.py
@@ -52,10 +52,11 @@ def fetch_repo(repo, root):
 
 
 class Study:
-    def __init__(self, root, monkeypatch, containers):
+    def __init__(self, root, monkeypatch, containers, image):
         self._root = root
         self._monkeypatch = monkeypatch
         self._containers = containers
+        self._image = image
 
     def setup_from_repo(self, repo, definition_path):
         self._workspace = fetch_repo(repo, self._root)
@@ -128,7 +129,7 @@ class Study:
     def _run_in_docker(self, command, environment=None):
         environment = environment or {}
         self._containers.run_fg(
-            image="databuilder:latest",
+            image=self._image,
             command=command,
             environment=environment,
             volumes={self._workspace: {"bind": "/workspace", "mode": "rw"}},


### PR DESCRIPTION
This means that the image gets rebuilt if and only if we're running
tests that exercise it. We previously attempted to handle this in the
Justfile, but it's not possible to do this accurately and it led to some
confusing local test failures.