### PR TITLE
Add function to import and return all contracts/backends

### DIFF
--- a/databuilder/docs/backends.py
+++ b/databuilder/docs/backends.py
@@ -1,11 +1,13 @@
 import operator
 
 from ..backends.base import BaseBackend
+from ..module_utils import get_sibling_subclasses
 from .common import build_hierarchy
 
 
 def build_backends():
-    backends = sorted(BaseBackend.__subclasses__(), key=operator.attrgetter("__name__"))
+    backends = get_sibling_subclasses(BaseBackend)
+    backends.sort(key=operator.attrgetter("__name__"))
 
     for backend in backends:
         # get the full name for all implemented contracts the backend implements

--- a/databuilder/docs/contracts.py
+++ b/databuilder/docs/contracts.py
@@ -1,11 +1,12 @@
 from ..contracts.base import Column, TableContract
+from ..module_utils import get_sibling_subclasses
 from .common import build_hierarchy, reformat_docstring
 
 
 def build_contracts():
     """Build a dict representation for each Contract"""
 
-    for contract in TableContract.__subclasses__():
+    for contract in get_sibling_subclasses(TableContract):
         columns = {k: v for k, v in vars(contract).items() if isinstance(v, Column)}
         columns = [_build_column(name, instance) for name, instance in columns.items()]
 

--- a/databuilder/module_utils.py
+++ b/databuilder/module_utils.py
@@ -1,0 +1,30 @@
+import importlib
+import sys
+from pathlib import Path
+
+
+def get_sibling_subclasses(cls):
+    """
+    Return all subclasses of `cls` defined in modules which are siblings of the module
+    containing `cls`
+
+    For example, sibling subclasses of the class `databuilder.backends.base.BaseBackend`
+    include:
+
+        databuilder.backends.tpp.TPPBackend
+        databuilder.backends.graphet.GraphnetBackend
+        ...
+
+    This is useful for tests and for generating documentation, but isn't intended for
+    use in runtime code.
+    """
+    module_file = sys.modules[cls.__module__].__file__
+    module_names = [f.stem for f in Path(module_file).parent.glob("*.py")]
+    package = cls.__module__.rpartition(".")[0]
+    for module_name in module_names:
+        importlib.import_module(f"{package}.{module_name}")
+    return [
+        subclass
+        for subclass in cls.__subclasses__()
+        if subclass.__module__.startswith(f"{package}.")
+    ]

--- a/tests/backend_validation/test_validate_backends.py
+++ b/tests/backend_validation/test_validate_backends.py
@@ -1,8 +1,5 @@
-import importlib
-from pathlib import Path
-
-from databuilder import backends
 from databuilder.backends.base import BaseBackend
+from databuilder.module_utils import get_sibling_subclasses
 
 
 def test_validate_all_backends():
@@ -10,17 +7,7 @@ def test_validate_all_backends():
     Loops through all the backends, excluding test ones,
     and validates they meet any contract that they claim to
     """
-    # Import all modules inside `databuilder.backends`
-    module_names = [f.stem for f in Path(backends.__file__).parent.glob("*.py")]
-    for module_name in module_names:
-        importlib.import_module(f"{backends.__name__}.{module_name}")
-
-    backend_classes = [
-        backend
-        for backend in BaseBackend.__subclasses__()
-        if backend.__module__.startswith("databuilder.backends.")
-    ]
-
+    backend_classes = get_sibling_subclasses(BaseBackend)
     for backend in backend_classes:
         backend.validate_contracts()
 


### PR DESCRIPTION
Prior to this we had tests which implicitly relied on various contracts
and backends being imported beforehand. This worked when running the
full test suite but failed when these tests were run individually.