### PR TITLE
Pass environment to query engines as config

### DIFF
--- a/databuilder/__main__.py
+++ b/databuilder/__main__.py
@@ -28,7 +28,7 @@ def main(args, environ=None):
                 dataset_file=options.output,
                 db_url=database_url,
                 backend_id=environ.get("OPENSAFELY_BACKEND"),
-                temporary_database=environ.get("TEMP_DATABASE_NAME"),
+                environ=environ,
             )
         elif dummy_data_file:
             pass_dummy_data(options.dataset_definition, options.output, dummy_data_file)
@@ -52,6 +52,7 @@ def main(args, environ=None):
         test_connection(
             backend_id=options.backend,
             url=options.url,
+            environ=environ,
         )
     elif options.which == "print-help":
         parser.print_help()

--- a/databuilder/__main__.py
+++ b/databuilder/__main__.py
@@ -12,18 +12,14 @@ from .main import (
 )
 
 
-def main(args=None):
-    parser = build_parser()
+def main(args, environ=None):
+    environ = environ or {}
 
-    if args is None:
-        # allow the passing in of args, for testing, but otherwise look them
-        # up.  This saves a lot of laborious mocking in tests.
-        args = sys.argv[1:]  # pragma: no cover
-
+    parser = build_parser(environ)
     options = parser.parse_args(args)
 
     if options.which == "generate-dataset":
-        database_url = os.environ.get("DATABASE_URL")
+        database_url = environ.get("DATABASE_URL")
         dummy_data_file = options.dummy_data_file
 
         if database_url:
@@ -31,8 +27,8 @@ def main(args=None):
                 definition_file=options.dataset_definition,
                 dataset_file=options.output,
                 db_url=database_url,
-                backend_id=os.environ.get("OPENSAFELY_BACKEND"),
-                temporary_database=os.environ.get("TEMP_DATABASE_NAME"),
+                backend_id=environ.get("OPENSAFELY_BACKEND"),
+                temporary_database=environ.get("TEMP_DATABASE_NAME"),
             )
         elif dummy_data_file:
             pass_dummy_data(options.dataset_definition, options.output, dummy_data_file)
@@ -63,22 +59,22 @@ def main(args=None):
         assert False, f"Unhandled subcommand: {options.which}"
 
 
-def build_parser():
+def build_parser(environ):
     parser = ArgumentParser(
         prog="databuilder", description="Generate datasets in OpenSAFELY"
     )
     parser.set_defaults(which="print-help")
 
     subparsers = parser.add_subparsers(help="sub-command help")
-    add_generate_dataset(subparsers)
-    add_dump_dataset_sql(subparsers)
-    add_generate_measures(subparsers)
-    add_test_connection(subparsers)
+    add_generate_dataset(subparsers, environ)
+    add_dump_dataset_sql(subparsers, environ)
+    add_generate_measures(subparsers, environ)
+    add_test_connection(subparsers, environ)
 
     return parser
 
 
-def add_generate_dataset(subparsers):
+def add_generate_dataset(subparsers, environ):
     parser = subparsers.add_parser("generate-dataset", help="Generate a dataset")
     parser.set_defaults(which="generate-dataset")
     parser.add_argument(
@@ -98,7 +94,7 @@ def add_generate_dataset(subparsers):
     )
 
 
-def add_dump_dataset_sql(subparsers):
+def add_dump_dataset_sql(subparsers, environ):
     parser = subparsers.add_parser(
         "dump-dataset-sql",
         help="Validate the dataset definition against the specified backend",
@@ -121,7 +117,7 @@ def add_dump_dataset_sql(subparsers):
     )
 
 
-def add_generate_measures(subparsers):
+def add_generate_measures(subparsers, environ):
     parser = subparsers.add_parser(
         "generate-measures", help="Generate measures from a dataset"
     )
@@ -143,7 +139,7 @@ def add_generate_measures(subparsers):
     )
 
 
-def add_test_connection(subparsers):
+def add_test_connection(subparsers, environ):
     parser = subparsers.add_parser(
         "test-connection", help="test the database connection configuration"
     )
@@ -152,13 +148,13 @@ def add_test_connection(subparsers):
         "--backend",
         "-b",
         help="backend type to test",
-        default=os.environ.get("BACKEND", os.environ.get("OPENSAFELY_BACKEND")),
+        default=environ.get("BACKEND", environ.get("OPENSAFELY_BACKEND")),
     )
     parser.add_argument(
         "--url",
         "-u",
         help="db url",
-        default=os.environ.get("DATABASE_URL"),
+        default=environ.get("DATABASE_URL"),
     )
 
 
@@ -172,4 +168,4 @@ def existing_python_file(value):
 
 
 if __name__ == "__main__":
-    main()
+    main(sys.argv[1:], environ=os.environ)

--- a/databuilder/main.py
+++ b/databuilder/main.py
@@ -19,15 +19,13 @@ def generate_dataset(
     dataset_file,
     backend_id,
     db_url,
-    temporary_database,
+    environ,
 ):
     log.info(f"Generating dataset for {str(definition_file)}")
 
     dataset_definition = load_definition(definition_file)
     backend = import_string(backend_id)()
-    query_engine = backend.query_engine_class(
-        db_url, backend, temporary_database=temporary_database
-    )
+    query_engine = backend.query_engine_class(db_url, backend, config=environ)
     backend.validate_contracts()
     results = extract(dataset_definition, query_engine)
 
@@ -67,11 +65,11 @@ def generate_measures(
     raise NotImplementedError
 
 
-def test_connection(backend_id, url):
+def test_connection(backend_id, url, environ):
     from sqlalchemy import select
 
     backend = import_string(backend_id)()
-    query_engine = backend.query_engine_class(url, backend)
+    query_engine = backend.query_engine_class(url, backend, config=environ)
     with query_engine.engine.connect() as connection:
         connection.execute(select(1))
     print("SUCCESS")

--- a/databuilder/query_engines/base.py
+++ b/databuilder/query_engines/base.py
@@ -5,16 +5,16 @@ class BaseQueryEngine:
     language (SQL, pandas dataframes etc).
     """
 
-    def __init__(self, dsn, backend=None, temporary_database=None):
+    def __init__(self, dsn, backend=None, config=None):
         """
         `dsn` is  Data Source Name — a string (usually a URL) which provides connection
             details to a data source (usually a RDBMS)
         `backend` is an optional Backend instance
+        `config` is an optional dictionary of config values
         """
         self.dsn = dsn
         self.backend = backend
-        # TODO: Not sure this belongs here but let's worry about that later
-        self.temporary_database = temporary_database
+        self.config = config or {}
 
     def execute_query(self, variable_definitions):
         """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -128,5 +128,5 @@ def databuilder_image():
 
 
 @pytest.fixture
-def study(tmp_path, monkeypatch, containers, databuilder_image):
-    return Study(tmp_path, monkeypatch, containers, databuilder_image)
+def study(tmp_path, containers, databuilder_image):
+    return Study(tmp_path, containers, databuilder_image)

--- a/tests/integration/test___main__.py
+++ b/tests/integration/test___main__.py
@@ -1,10 +1,12 @@
 from databuilder.__main__ import main
 
 
-def test_test_connection(monkeypatch, mssql_database, capsys):
-    monkeypatch.setenv("BACKEND", "databuilder.backends.tpp.TPPBackend")
-    monkeypatch.setenv("DATABASE_URL", mssql_database.host_url())
+def test_test_connection(mssql_database, capsys):
+    env = {
+        "BACKEND": "databuilder.backends.tpp.TPPBackend",
+        "DATABASE_URL": mssql_database.host_url(),
+    }
     argv = ["test-connection"]
-    main(argv)
+    main(argv, env)
     out, _ = capsys.readouterr()
     assert "SUCCESS" in out

--- a/tests/lib/study.py
+++ b/tests/lib/study.py
@@ -52,9 +52,8 @@ def fetch_repo(repo, root):
 
 
 class Study:
-    def __init__(self, root, monkeypatch, containers, image):
+    def __init__(self, root, containers, image):
         self._root = root
-        self._monkeypatch = monkeypatch
         self._containers = containers
         self._image = image
 
@@ -70,10 +69,15 @@ class Study:
     def generate(self, database, backend):
         self._dataset_path = self._workspace / "dataset.csv"
 
-        self._monkeypatch.setenv("DATABASE_URL", database.host_url())
-        self._monkeypatch.setenv("OPENSAFELY_BACKEND", backend)
+        env = {
+            "DATABASE_URL": database.host_url(),
+            "OPENSAFELY_BACKEND": backend,
+        }
 
-        main(self._generate_command(self._definition_path, self._dataset_path))
+        main(
+            self._generate_command(self._definition_path, self._dataset_path),
+            environ=env,
+        )
 
     def generate_in_docker(self, database, backend):
         self._dataset_path = self._workspace / "dataset.csv"

--- a/tests/unit/test___main__.py
+++ b/tests/unit/test___main__.py
@@ -10,11 +10,11 @@ def test_no_args(capsys):
     assert "usage: databuilder" in captured.out
 
 
-def test_generate_dataset(mocker, monkeypatch, tmp_path):
+def test_generate_dataset(mocker, tmp_path):
     # Verify that the generate_dataset subcommand can be invoked when
     # DATABASE_URL is set.
     patched = mocker.patch("databuilder.__main__.generate_dataset")
-    monkeypatch.setenv("DATABASE_URL", "scheme:path")
+    env = {"DATABASE_URL": "scheme:path"}
     dataset_definition_path = tmp_path / "dataset.py"
     dataset_definition_path.touch()
     argv = [
@@ -22,7 +22,7 @@ def test_generate_dataset(mocker, monkeypatch, tmp_path):
         "--dataset-definition",
         str(dataset_definition_path),
     ]
-    main(argv)
+    main(argv, env)
     patched.assert_called_once()
 
 
@@ -43,12 +43,10 @@ def test_pass_dummy_data(mocker, tmp_path):
     patched.assert_called_once()
 
 
-def test_generate_dataset_if_both_db_url_and_dummy_data_are_provided(
-    mocker, monkeypatch, tmp_path
-):
+def test_generate_dataset_if_both_db_url_and_dummy_data_are_provided(mocker, tmp_path):
     # This happens when studies with dummy data are run in the backend.
     patched = mocker.patch("databuilder.__main__.generate_dataset")
-    monkeypatch.setenv("DATABASE_URL", "scheme:path")
+    env = {"DATABASE_URL": "scheme:path"}
     dataset_definition_path = tmp_path / "dataset.py"
     dataset_definition_path.touch()
     argv = [
@@ -58,7 +56,7 @@ def test_generate_dataset_if_both_db_url_and_dummy_data_are_provided(
         "--dummy-data-file",
         str(tmp_path / "dummy-data.csv"),
     ]
-    main(argv)
+    main(argv, env)
     patched.assert_called_once()
 
 


### PR DESCRIPTION
Previously we passed just the value of `TEMP_DATABASE_NAME`. But this
isn't relevant to all query engines and we can't predict in advance what
kind of config options different query engines will require. Also, these
aren't part of the user facing API so I think it would be preferrable
not to expose them via the CLI in any case.

Relates to https://github.com/opensafely-core/databuilder/issues/547