### PR TITLE
Override paragraph titles

### DIFF
--- a/databuilder/docs/specs.py
+++ b/databuilder/docs/specs.py
@@ -63,16 +63,17 @@ def build_section(section_id, package_name, module_name):
     )
 
 
+def get_title_for_test_fn(test_fn):
+    return test_fn.__name__.removeprefix("test_").replace("_", " ").capitalize()
+
+
 def build_paragraph(paragraph_id, test_fn):
     """Return dict containing details of a single paragraph.
 
     There is a paragraph for each test function.
     """
 
-    # Extract the paragraph title from the test function name.  NB we may want more
-    # control over the title, in which case we could record it in the function
-    # docstring.
-    title = test_fn.__name__.removeprefix("test_").replace("_", " ").capitalize()
+    title = get_title_for_test_fn(test_fn)
 
     # Capture the arguments that the test function is called with.
     capturer = ArgCapturer()

--- a/databuilder/docs/specs.py
+++ b/databuilder/docs/specs.py
@@ -64,6 +64,8 @@ def build_section(section_id, package_name, module_name):
 
 
 def get_title_for_test_fn(test_fn):
+    if hasattr(test_fn, "title"):
+        return test_fn.title
     return test_fn.__name__.removeprefix("test_").replace("_", " ").capitalize()
 
 

--- a/tests/spec/test_specs.py
+++ b/tests/spec/test_specs.py
@@ -55,6 +55,9 @@ def test_take_with_expr():
     pass
 
 
+test_take_with_expr.title = "Take rows that match an expression"
+
+
 def test_take_with_constant_true():
     pass
 
@@ -62,7 +65,7 @@ def test_take_with_constant_true():
 @pytest.mark.parametrize(
     "test_fn,title",
     [
-        (test_take_with_expr, "Take with expr"),
+        (test_take_with_expr, "Take rows that match an expression"),
         (test_take_with_constant_true, "Take with constant true"),
     ],
 )

--- a/tests/spec/test_specs.py
+++ b/tests/spec/test_specs.py
@@ -1,7 +1,10 @@
+import pytest
+
 from databuilder.docs.specs import (
     build_chapter,
     build_section,
     concatenate_optional_text,
+    get_title_for_test_fn,
 )
 
 
@@ -46,3 +49,22 @@ def test_build_section():
             ), "paragraph text found when no docstring present"
             continue
         assert False, "expected paragraph ids not found"
+
+
+def test_take_with_expr():
+    pass
+
+
+def test_take_with_constant_true():
+    pass
+
+
+@pytest.mark.parametrize(
+    "test_fn,title",
+    [
+        (test_take_with_expr, "Take with expr"),
+        (test_take_with_constant_true, "Take with constant true"),
+    ],
+)
+def test_get_title_for_test_fn(test_fn, title):
+    assert get_title_for_test_fn(test_fn) == title


### PR DESCRIPTION
This allows us to override paragraph titles in the ehrQL reference documentation.

Closes opensafely/documentation#774