### PR TITLE
Name test docker image differently from production

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -119,7 +119,7 @@ build-databuilder:
     set -euo pipefail
 
     [[ -v CI ]] && echo "::group::Build databuilder (click to view)" || echo "Build databuilder"
-    docker build . -t databuilder
+    docker build . -t databuilder-dev
     [[ -v CI ]] && echo "::endgroup::" || echo ""
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -116,7 +116,8 @@ def engine(request):
 @pytest.fixture(scope="session")
 def databuilder_image():
     project_dir = Path(databuilder.__file__).parents[1]
-    image = "databuilder"
+    # Note different name from production image to avoid confusion
+    image = "databuilder-dev"
     # We're deliberately choosing to shell out to the docker client here rather than use
     # the docker-py library to avoid possible difference in the build process (docker-py
     # doesn't seem to be particularly actively maintained)


### PR DESCRIPTION
There shouldn't be an actual clash here as the production images should
all be tagged `ghcr.io/opensafely-core/databuilder` rather than just
`databuilder`. But having them named differently avoids any potential
for confusion.