### PR TITLE
chore: Add extra spacing between sentences

### DIFF
--- a/databuilder/contracts/universal.py
+++ b/databuilder/contracts/universal.py
@@ -28,7 +28,7 @@ class Patients(TableContract):
     date_of_death = Column(
         type=types.Date(),
         description=(
-            "Patient's year and month of death, provided in format YYYY-MM-01."
+            "Patient's year and month of death, provided in format YYYY-MM-01. "
             "The day will always be the first of the month."
         ),
         constraints=[FirstOfMonthConstraint()],


### PR DESCRIPTION
This will avoid the text appearing in the documentation reference as:

> …in format YYYY-MM-01.The day…