### PR TITLE
Databricks updates

### DIFF
--- a/.github/workflows/databricks.yml
+++ b/.github/workflows/databricks.yml
@@ -7,7 +7,7 @@ on:
       test_args:
         description: "Tests to run or other pytest args"
         required: true
-        default: "tests/backend/test_databricks.py"
+        default: "tests/spec -k 'spark'"
 
 jobs:
   test:
@@ -21,13 +21,14 @@ jobs:
       - uses: extractions/setup-just@v1
       - name: Login to databricks
         run: |
-            echo <<< EOF > ~/.databrickscfg
-            [DEFAULT]
+            echo -e \
+            "[DEFAULT]
             host = https://drtl-theta.cloud.databricks.com
             username = simon.davy@thedatalab.org
             password = ${{ secrets.DATABRICKS_PASSWORD }}
-            jobs-api-version = 2.0
-            EOF
+            jobs-api-version = 2.0" \
+            >> ~/.databrickscfg
+
       - name: Run Databricks tests
         run:
             just databricks-test ${{ github.event.inputs.test_args }}

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -193,21 +193,19 @@ First you need to set up your Databricks auth.
 
    `databricks configure`
 
-3. If using the NHSD sandbox, you will need to setup a cluster called `opensafely-test`, which you can do via the web UI via `Compute -> Create Cluster`, and just use all the default options.
+3. You will need to setup a cluster called `opensafely-test`, which you can do via the web UI via `Compute -> Create Cluster`, and just use all the default options.
 
 4. Test it's working with: `databricks clusters list`. If that doesn't error, you are set up.
 
 
 You should then be able to run tests against databricks with:
 
-    just databricks-test [tests/backends/test_databricks.py]
+    just databricks-test [tests/spec/ -k 'spark']
 
-Warning: running the full test suite takes a long time.
+Warning: running the full test suite (or even just all the spark specs tests) takes a long time (20+ mins using the NHSD Sandbox).
 
-Note: This command will ensure there is an active Databricks cluster, and then run the tests against it.
-When using Community Edition, it will create a cluster if needed but if a cluster is already up and running, it will use that.
-If it has terminated (after 2 hours of inactivity), it will delete the old one and create a new one.
-When using the NHSD sandbox, it will only use manually pre-created cluster called `opensafely-test`.
+Note: This command will ensure there is an active Databricks cluster, and then run the tests against it. By default it will use a manually pre-created cluster called `opensafely-test`; it will not create a cluster if one does not already exist.
+
 
 For more information about your Databricks cluster, you can use the dbx tool:
 
@@ -221,7 +219,7 @@ or
 ### Running Databricks test in Github CI
 
 You can manually run the tests in github by triggering the "Databricks CI" action.
-By default it will just run the `tests/backends/test_databricks.py`, but you can specify different arguments when you trigger it.
+By default it will just run the spark tests with `tests/spec -k 'spark'`, but you can specify different arguments when you trigger it.
 
 This CI uses simon.davy@thedatalab.org's Databricks account.
 

--- a/Justfile
+++ b/Justfile
@@ -204,9 +204,9 @@ test-all *ARGS: devenv generate-docs
 dbx *ARGS:
     @$BIN/python scripts/dbx {{ ARGS }}
 
-# ensure a working databricks cluster is set up
+# ensure a working databricks cluster is set up and running
 databricks-env: devenv
-    $BIN/python scripts/dbx create --wait --timeout 120
+    $BIN/python scripts/dbx start --wait --timeout 180
 
 databricks-test *ARGS: devenv databricks-env
     #!/usr/bin/env bash

--- a/databuilder/query_engines/spark_dialect.py
+++ b/databuilder/query_engines/spark_dialect.py
@@ -200,14 +200,18 @@ class SparkDialect(HiveHTTPDialect):
         string matching for this and the format of the error messages in the
         specific version of Spark/Hive we are using doesn't match. See:
 
-        https://github.com/dropbox/PyHive/blob/b21c507a24/pyhive/sqlalchemy_hive.py#L275-L297
+        https://github.com/dropbox/PyHive/blob/release/0.6.5/pyhive/sqlalchemy_hive.py#L275-L297
         """
         connection = ConnectionWrapper(connection)
         try:
             return super()._get_table_columns(connection, table_name, schema)
-        except exc.OperationalError as e:
+        except (exc.OperationalError, exc.DatabaseError) as e:
             full_table = table_name if not schema else f"{schema}.{table_name}"
-            if "Table or view not found" in str(e):  # pragma: no cover
+            if "Table or view not found" in str(
+                e
+            ) or f"{full_table} doesn't exist" in str(
+                e
+            ):  # pragma: no cover
                 raise exc.NoSuchTableError(full_table)
             else:
                 raise

--- a/scripts/dbx
+++ b/scripts/dbx
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
 import configparser
-import json
 import os
 import subprocess
 import sys
 import time
+from urllib.parse import urljoin
 
 import click
 import requests
@@ -21,41 +21,6 @@ OUTPUT = True
 VENV = os.environ["VIRTUAL_ENV"]
 DATABRICKS_EXEC = f"{VENV}/bin/databricks"
 PYTHON = f"{VENV}/bin/python"
-
-# https://docs.databricks.com/dev-tools/api/latest/clusters.html#create
-# Create a cluster in Community Edition.
-CLUSTER_REQUEST = {
-    "cluster_name": "opensafely-test",
-    "spark_version": "7.3.x-scala2.12",
-    "spark_conf": {
-        # This was added to try work around a problem with deleting tables, we may not need it any more
-        "spark.sql.legacy.allowCreatingManagedTableUsingNonemptyLocation": "true",
-    },
-    "aws_attributes": {
-        "zone_id": "auto",
-        "first_on_demand": 0,
-        "availability": "ON_DEMAND",
-        "spot_bid_price_percent": 100,
-    },
-    "node_type_id": "dev-tier-node",
-    "driver_node_type_id": "dev-tier-node",
-    "spark_env_vars": {
-        "PYSPARK_PYTHON": "/databricks/python3/bin/python3",
-    },
-    "autotermination_minutes": 120,
-    "enable_elastic_disk": False,
-    "disk_spec": {
-        "disk_count": 0,
-    },
-    "enable_local_disk_encryption": False,
-    "instance_source": {
-        "node_type_id": "dev-tier-node",
-    },
-    "driver_instance_source": {
-        "node_type_id": "dev-tier-node",
-    },
-    "num_workers": 0,
-}
 
 
 def run(cmd, check=True, text=True, **kwargs):
@@ -116,7 +81,7 @@ def get_clusters():
     global CLUSTERS, ORGID
 
     resp = requests.get(
-        f"{HOST}/api/2.0/clusters/list",
+        urljoin(HOST, "/api/2.0/clusters/list"),
         auth=(USERNAME, PASSWORD),
     )
     resp.raise_for_status()
@@ -125,19 +90,12 @@ def get_clusters():
     ORGID = resp.headers["X-Databricks-Org-Id"]
 
 
-def _teardown(name):
-    if name not in CLUSTERS:
-        return
-
-    c = CLUSTERS[name]
-    echo(f"Tearing down {c}...")
-    databricks(["clusters", "permanent-delete", "--cluster-id", c.cluster_id])
-
-
 def _wait(name, timeout=90):
     echo(CLUSTERS[name])
     start = time.time()
-    while CLUSTERS[name].state == "PENDING":
+    # We need to wait if the state is TERMINATED, as the first try after starting may not
+    # register it as PENDING yet
+    while CLUSTERS[name].state in ["PENDING", "TERMINATED"]:
         if time.time() - start > timeout:
             sys.exit(f"timed out after {timeout}s waiting for cluster {name}")
         time.sleep(10)
@@ -149,11 +107,10 @@ def _wait(name, timeout=90):
 def cli():
     """Command for managing databricks cluster.
 
-    If ssing Databricks Community Edition, it will teardown/create a cluster for you.
-    If using the full SaaS, it will simply ensure it is running.
-
     The default cluster name is 'opensafely-test', but can be overridden with
     --name option or the DATABRICKS_CLUSTER env var.
+
+    It will ensure the cluster is running, but will not create it if it doesn't already exist.
 
     By default, it uses the DEFAULT profile of your databricks cli config, but
     this can be altered with the DATABRICKS_PROFILE env var.
@@ -167,17 +124,6 @@ name_option = click.option("--name", default="opensafely-test", help="name of cl
 
 @cli.command()
 @name_option
-def teardown(name):
-    """Teardown current cluster."""
-    if is_community_edition():
-        _teardown(name)
-    else:
-        click.echo("Cowardly refusing to terminate non-community edition cluster.")
-        sys.exit(1)
-
-
-@cli.command()
-@name_option
 @click.option(
     "--wait/--no-wait",
     default=False,
@@ -187,8 +133,8 @@ def teardown(name):
 @click.option(
     "--output-url/--no-output-url", default=False, help="only output the connection url"
 )
-def create(name, wait, output_url, timeout):
-    """Create a new cluster."""
+def start(name, wait, output_url, timeout):
+    """Ensure cluster is running."""
     global OUTPUT
 
     if output_url:
@@ -197,32 +143,22 @@ def create(name, wait, output_url, timeout):
     c = CLUSTERS.get(name)
 
     # it exists
-    if c and c.state in ("PENDING", "RUNNING"):
-        if output_url:
-            click.echo(c.url)
+    if c:
+        # it's running or starting up
+        if c.state in ("PENDING", "RUNNING"):
+            if output_url:
+                click.echo(c.url)
+            else:
+                echo(f"{HOST} {c}")
+            return
         else:
-            echo(c)
-        return
-
-    if is_community_edition():
-        # with community edition, it is best to destroy/create a new cluster,
-        # as restarting clusters does not seem to work well.
-        _teardown(name)
-        request = CLUSTER_REQUEST.copy()
-        request["cluster_name"] = name
-        request_json = json.dumps(request)
-        databricks(
-            ["clusters", "create", "--json-file", "/dev/stdin"],
-            input=request_json,
-            capture_output=output_url,
-        )
-    elif c:
-        # cluster exists, but is not running
-        databricks(["clusters", "start", "--cluster-id", c.cluster_id])
+            # cluster exists, but is not running or starting up
+            click.echo("Starting cluster")
+            databricks(["clusters", "start", "--cluster-id", c.cluster_id])
     else:
         click.echo(
-            "No {name} cluster found, and refusing to create one as not using Community Edition.\n"
-            "You will need to create one called 'opensafely-test' via the web UI."
+            f"No {name} cluster found.\n"
+            f"You will need to create one called '{name}' via the web UI."
         )
         sys.exit(1)
 


### PR DESCRIPTION
Update the databricks scripts, docs and ensure tests can run (`databricks-sql-connector` was recently upgraded from v0.9.0 to 2.0.2).

It appears that since the `dbx` script was first written, the allowed API calls for the Databricks community edition have been limited.  If using the community edition, you can fetch information about clusters, but can't create or terminate one.  The script and docs are updated accordingly, to note that you need to manually create the cluster in the web console for both community edition and sandbox.