### PR TITLE
Rework `dump-dataset-sql` command

### DIFF
--- a/databuilder/__main__.py
+++ b/databuilder/__main__.py
@@ -4,11 +4,11 @@ from argparse import ArgumentParser, ArgumentTypeError
 from pathlib import Path
 
 from .main import (
+    dump_dataset_sql,
     generate_dataset,
     generate_measures,
     pass_dummy_data,
     test_connection,
-    validate_dataset,
 )
 
 
@@ -37,7 +37,7 @@ def main(args, environ=None):
                 "error: either --dummy-data-file or DATABASE_URL environment variable is required"
             )
     elif options.which == "dump-dataset-sql":
-        validate_dataset(
+        dump_dataset_sql(
             options.dataset_definition,
             options.output,
             backend_id=options.backend,

--- a/databuilder/__main__.py
+++ b/databuilder/__main__.py
@@ -41,6 +41,8 @@ def main(args, environ=None):
             options.dataset_definition,
             options.output,
             backend_id=options.backend,
+            query_engine_id=options.query_engine,
+            environ=environ,
         )
     elif options.which == "generate-measures":
         generate_measures(
@@ -98,23 +100,29 @@ def add_generate_dataset(subparsers, environ):
 def add_dump_dataset_sql(subparsers, environ):
     parser = subparsers.add_parser(
         "dump-dataset-sql",
-        help="Validate the dataset definition against the specified backend",
+        help=(
+            "Output the SQL that would be executed to fetch the results of the "
+            "dataset definition"
+        ),
     )
     parser.set_defaults(which="dump-dataset-sql")
     parser.add_argument(
-        "backend",
+        "--query-engine",
         type=str,
     )
     parser.add_argument(
-        "--dataset-definition",
-        help="The path of the file where the dataset is defined",
-        type=existing_python_file,
-        required=True,
+        "--backend",
+        type=str,
     )
     parser.add_argument(
         "--output",
-        help="Path and filename (or pattern) of the file(s) where the output will be written",
+        help="SQL output file (outputs to console by default)",
         type=Path,
+    )
+    parser.add_argument(
+        "dataset_definition",
+        help="Path of Python file where dataset is defined",
+        type=existing_python_file,
     )
 
 

--- a/databuilder/main.py
+++ b/databuilder/main.py
@@ -2,7 +2,7 @@ import csv
 import importlib.util
 import shutil
 import sys
-from contextlib import contextmanager
+from contextlib import contextmanager, nullcontext
 
 import structlog
 
@@ -44,12 +44,13 @@ def pass_dummy_data(definition_file, dataset_file, dummy_data_file):
     shutil.copyfile(dummy_data_file, dataset_file)
 
 
-def dump_dataset_sql(definition_file, output_file, backend_id):
+def dump_dataset_sql(
+    definition_file, output_file, backend_id, query_engine_id, environ
+):
     log.info(f"Generating SQL for {str(definition_file)}")
 
     dataset_definition = load_definition(definition_file)
-    backend = import_string(backend_id)()
-    query_engine = backend.query_engine_class(None, backend)
+    query_engine = get_query_engine(backend_id, query_engine_id, environ)
 
     variable_definitions = ql.compile(dataset_definition)
     setup_queries, results_query, cleanup_queries = query_engine.get_queries(
@@ -58,10 +59,41 @@ def dump_dataset_sql(definition_file, output_file, backend_id):
     all_queries = setup_queries + [results_query] + cleanup_queries
     log.info("SQL generation succeeded")
 
-    output_file.parent.mkdir(parents=True, exist_ok=True)
-    with output_file.open(mode="w") as f:
+    with open_output_file(output_file) as f:
         for query in all_queries:
             f.write(f"{str(query)}\n")
+
+
+def open_output_file(output_file):
+    # If a file path is supplied, create it and open for writing
+    if output_file:
+        output_file.parent.mkdir(parents=True, exist_ok=True)
+        return output_file.open(mode="w")
+    # Otherwise return `stdout` wrapped in a no-op context manager
+    else:
+        return nullcontext(sys.stdout)
+
+
+def get_query_engine(backend_id, query_engine_id, environ):
+    # Load backend if supplied
+    if backend_id:
+        backend = import_string(backend_id)()
+    else:
+        backend = None
+
+    # If there's an explictly specified query engine class use that
+    if query_engine_id:
+        query_engine_class = import_string(query_engine_id)
+    # Otherwise use whatever the backend specifies
+    elif backend:
+        query_engine_class = backend.query_engine_class
+    # Default to using SQLite
+    else:
+        query_engine_class = import_string(
+            "databuilder.query_engines.sqlite.SQLiteQueryEngine"
+        )
+
+    return query_engine_class(dsn=None, backend=backend, config=environ)
 
 
 def generate_measures(

--- a/databuilder/main.py
+++ b/databuilder/main.py
@@ -44,14 +44,14 @@ def pass_dummy_data(definition_file, dataset_file, dummy_data_file):
     shutil.copyfile(dummy_data_file, dataset_file)
 
 
-def validate_dataset(definition_file, output_file, backend_id):
-    log.info(f"Validating dataset for {str(definition_file)}")
+def dump_dataset_sql(definition_file, output_file, backend_id):
+    log.info(f"Generating SQL for {str(definition_file)}")
 
     dataset_definition = load_definition(definition_file)
     backend = import_string(backend_id)()
     query_engine = backend.query_engine_class(None, backend)
     results = validate(dataset_definition, query_engine)
-    log.info("Validation succeeded")
+    log.info("SQL generation succeeded")
 
     output_file.parent.mkdir(parents=True, exist_ok=True)
     with output_file.open(mode="w") as f:

--- a/databuilder/query_engines/spark_dialect.py
+++ b/databuilder/query_engines/spark_dialect.py
@@ -40,6 +40,7 @@ def visit_create_temporary_view_as(element, compiler, **kw):
 class SparkDate(sqlalchemy.types.TypeDecorator):
     cache_ok = True
     impl = sqlalchemy.types.Date
+    text_type = sqlalchemy.types.Text()
 
     def process_result_value(self, value, dialect):
         """
@@ -63,6 +64,16 @@ class SparkDate(sqlalchemy.types.TypeDecorator):
         explicity cast them to dates
         """
         return cast(bindvalue, type_=self)
+
+    def process_literal_param(self, value, dialect):
+        """
+        Convert a Python value into an escaped string suitable for interpolating
+        directly into an SQL string
+        """
+        value_str = value.isoformat()
+        # Use the Text literal processor to quote and escape the string value
+        literal_processor = self.text_type.literal_processor(dialect)
+        return literal_processor(value_str)
 
 
 class SparkDateTime(sqlalchemy.types.TypeDecorator):

--- a/databuilder/sqlalchemy_utils.py
+++ b/databuilder/sqlalchemy_utils.py
@@ -122,3 +122,12 @@ def get_generated_tables(clause):
 
 def flatten_iter(nested_iters):
     return [i for sub_iter in nested_iters for i in sub_iter]
+
+
+def clause_as_str(clause, dialect):
+    """
+    Return a SQL clause as a string in the supplied SQL dialect with any included
+    parameters interpolated in
+    """
+    compiled = clause.compile(dialect=dialect, compile_kwargs={"literal_binds": True})
+    return str(compiled).strip()

--- a/databuilder/sqlalchemy_utils.py
+++ b/databuilder/sqlalchemy_utils.py
@@ -129,5 +129,18 @@ def clause_as_str(clause, dialect):
     Return a SQL clause as a string in the supplied SQL dialect with any included
     parameters interpolated in
     """
-    compiled = clause.compile(dialect=dialect, compile_kwargs={"literal_binds": True})
-    return str(compiled).strip()
+    # This is an awkward workaround for the fact that some constructs, e.g. CreateIndex,
+    # blow up if you try to compile them with `literal_binds = True` because they don't
+    # accept the `literal_binds` keyword. I _think_ this is just a bug in SQLAlchemy,
+    # but one that hasn't be noticed because index definitions don't tend to take
+    # paramters. In any case, the workaround here is that we compile a parameterised
+    # version of the query first, and then recompile with `literal_binds` only if it
+    # actually has parameters.
+    compiled = clause.compile(dialect=dialect)
+    if not compiled.params:
+        return str(compiled).strip()
+    else:
+        compiled = clause.compile(
+            dialect=dialect, compile_kwargs={"literal_binds": True}
+        )
+        return str(compiled).strip()

--- a/tests/acceptance/test_embedded_study.py
+++ b/tests/acceptance/test_embedded_study.py
@@ -51,32 +51,32 @@ def test_generate_dataset(study, mssql_database):
     assert {r["year"] for r in results} == {"1943", "1999"}
 
 
-def test_validate_dataset_happy_path(study, mssql_database):
+def test_dump_dataset_sql_happy_path(study, mssql_database):
     study.setup_from_string(trivial_dataset_definition)
-    study.validate()
+    study.dump_dataset_sql()
 
 
-def test_validate_dataset_error_path(study, mssql_database):
+def test_dump_dataset_sql_error_path(study, mssql_database):
     study.setup_from_string(invalid_dataset_definition)
     with pytest.raises(NameError):
-        study.validate()
+        study.dump_dataset_sql()
 
 
-def test_validate_dataset_with_no_dataset_attribute(study, mssql_database):
+def test_dump_dataset_sql_with_no_dataset_attribute(study, mssql_database):
     study.setup_from_string(no_dataset_attribute_dataset_definition)
     with pytest.raises(
         AttributeError, match="A dataset definition must define one 'dataset'"
     ):
-        study.validate()
+        study.dump_dataset_sql()
 
 
-def test_validate_dataset_attribute_invalid(study, mssql_database):
+def test_dump_dataset_sql_attribute_invalid(study, mssql_database):
     study.setup_from_string(invalid_dataset_attribute_dataset_definition)
     with pytest.raises(
         AssertionError,
         match="'dataset' must be an instance of databuilder.query_language.Dataset()",
     ):
-        study.validate()
+        study.dump_dataset_sql()
 
 
 def test_validate_dummy_data_happy_path(tmp_path):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import pytest
 
 import databuilder
+from databuilder.main import get_sql_strings
 from databuilder.query_engines.mssql import MSSQLQueryEngine
 from databuilder.query_engines.spark import SparkQueryEngine
 from databuilder.query_engines.sqlite import SQLiteQueryEngine
@@ -68,6 +69,11 @@ class QueryEngineFixture:
             # We don't explicitly order the results and not all databases naturally
             # return in the same order
             return sorted(map(dict, results), key=lambda i: i["patient_id"])
+
+    def dump_dataset_sql(self, dataset, **engine_kwargs):
+        variables = compile(dataset)
+        query_engine = self.query_engine_class(dsn=None, **engine_kwargs)
+        return get_sql_strings(query_engine, variables)
 
     def sqlalchemy_engine(self):
         return self.query_engine_class(self.database.host_url()).engine

--- a/tests/docker/test_cli.py
+++ b/tests/docker/test_cli.py
@@ -15,9 +15,9 @@ def test_generate_dataset_in_container(study, mssql_database):
     assert results[0]["year"] == "1943"
 
 
-def test_validate_dataset_definition_in_container(study):
+def test_dump_dataset_sql_in_container(study):
     study.setup_from_string(fixtures.trivial_dataset_definition)
-    study.validate_in_docker()
+    study.dump_dataset_sql_in_docker()
     # non-zero exit raises an exception
 
 

--- a/tests/lib/study.py
+++ b/tests/lib/study.py
@@ -120,11 +120,11 @@ class Study:
     def _dump_dataset_sql_command(definition, output):
         return [
             "dump-dataset-sql",
-            "--dataset-definition",
-            str(definition),
+            "--backend",
+            "databuilder.backends.tpp.TPPBackend",
             "--output",
             str(output),
-            "databuilder.backends.tpp.TPPBackend",
+            str(definition),
         ]
 
     def _docker_path(self, path):

--- a/tests/lib/study.py
+++ b/tests/lib/study.py
@@ -103,21 +103,21 @@ class Study:
             str(dataset),
         ]
 
-    def validate(self):
-        self._output_path = self._workspace / "validation.out"
-        main(self._validate_command(self._definition_path, self._output_path))
+    def dump_dataset_sql(self):
+        self._output_path = self._workspace / "queries.sql"
+        main(self._dump_dataset_sql_command(self._definition_path, self._output_path))
 
-    def validate_in_docker(self):
-        self._output_path = self._workspace / "validation.out"
+    def dump_dataset_sql_in_docker(self):
+        self._output_path = self._workspace / "queries.sql"
         self._run_in_docker(
-            command=self._validate_command(
+            command=self._dump_dataset_sql_command(
                 self._docker_path(self._definition_path),
                 self._docker_path(self._output_path),
             )
         )
 
     @staticmethod
-    def _validate_command(definition, output):
+    def _dump_dataset_sql_command(definition, output):
         return [
             "dump-dataset-sql",
             "--dataset-definition",

--- a/tests/spec/conftest.py
+++ b/tests/spec/conftest.py
@@ -7,9 +7,11 @@ from databuilder.query_language import Dataset
 from . import tables
 
 
-@pytest.fixture
+@pytest.fixture(params=["execute", "dump_sql"])
 def spec_test(request, engine):
-    def run_test(table_data, series, expected_results, population=None):
+
+    # Test that we can insert the data, run the query, and get the expected results
+    def run_test_execute(table_data, series, expected_results, population=None):
         # Create SQLAlchemy model instances for each row of each table in table_data.
         input_data = []
         for table, s in table_data.items():
@@ -23,22 +25,45 @@ def spec_test(request, engine):
         # Populate database tables.
         engine.setup(*input_data)
 
-        # To reduce noise in the tests we provide a default population which contains
-        # all patients in tables p and e
-        if population is None:
-            population = tables.p.exists_for_patient() | tables.e.exists_for_patient()
-
         # Create a Dataset with the specified population and a single variable which is
         # the series under test.
-        dataset = Dataset()
-        dataset.set_population(population)
+        dataset = make_dataset(population)
         dataset.v = series
 
         # Extract data, and check it's as expected.
         results = {r["patient_id"]: r["v"] for r in engine.extract(dataset)}
         assert results == expected_results
 
-    return run_test
+    # Test that we can generate SQL with literal parmeters for debugging purposes
+    def run_test_dump_sql(table_data, series, expected_results, population=None):
+        # Create a Dataset with the specified population and a single variable which is
+        # the series under test.
+        dataset = make_dataset(population)
+        dataset.v = series
+
+        # Check that we can generate SQL without error
+        assert engine.dump_dataset_sql(dataset)
+
+    mode = request.param
+
+    if mode == "execute":
+        return run_test_execute
+    elif mode == "dump_sql":
+        if engine.name == "in_memory":
+            pytest.skip("in_memory engine produces no SQL")
+        return run_test_dump_sql
+    else:
+        assert False
+
+
+def make_dataset(population=None):
+    # To reduce noise in the tests we provide a default population which contains all
+    # patients in tables p and e
+    if population is None:
+        population = tables.p.exists_for_patient() | tables.e.exists_for_patient()
+    dataset = Dataset()
+    dataset.set_population(population)
+    return dataset
 
 
 def parse_table(schema, s):

--- a/tests/unit/test___main__.py
+++ b/tests/unit/test___main__.py
@@ -82,7 +82,7 @@ def test_generate_dataset_without_database_url_or_dummy_data(capsys, tmp_path):
 
 def test_dump_dataset_sql(mocker, tmp_path):
     # Verify that the dump dataset sql subcommand can be invoked.
-    patched = mocker.patch("databuilder.__main__.validate_dataset")
+    patched = mocker.patch("databuilder.__main__.dump_dataset_sql")
     dataset_definition_path = tmp_path / "dataset.py"
     dataset_definition_path.touch()
     argv = [

--- a/tests/unit/test___main__.py
+++ b/tests/unit/test___main__.py
@@ -87,9 +87,9 @@ def test_dump_dataset_sql(mocker, tmp_path):
     dataset_definition_path.touch()
     argv = [
         "dump-dataset-sql",
-        "--dataset-definition",
-        str(dataset_definition_path),
+        "--backend",
         "databuilder.backends.tpp.TPPBackend",
+        str(dataset_definition_path),
     ]
     main(argv)
     patched.assert_called_once()

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1,0 +1,64 @@
+import dataclasses
+
+from databuilder.main import get_query_engine, open_output_file
+from databuilder.query_engines.sqlite import SQLiteQueryEngine
+
+
+@dataclasses.dataclass
+class DummyQueryEngine:
+    dsn: str
+    backend: object
+    config: dict
+
+
+class DummyBackend:
+    query_engine_class = DummyQueryEngine
+
+
+def test_get_query_engine_defaults():
+    query_engine = get_query_engine(backend_id=None, query_engine_id=None, environ={})
+    assert isinstance(query_engine, SQLiteQueryEngine)
+
+
+def test_get_query_engine_with_query_engine():
+    query_engine_id = f"{DummyQueryEngine.__module__}.{DummyQueryEngine.__name__}"
+    query_engine = get_query_engine(
+        backend_id=None, query_engine_id=query_engine_id, environ={}
+    )
+    assert isinstance(query_engine, DummyQueryEngine)
+    assert query_engine.backend is None
+    assert query_engine.config == {}
+
+
+def test_get_query_engine_with_backend():
+    backend_id = f"{DummyBackend.__module__}.{DummyBackend.__name__}"
+    query_engine = get_query_engine(
+        backend_id=backend_id, query_engine_id=None, environ={}
+    )
+    assert isinstance(query_engine, DummyQueryEngine)
+    assert isinstance(query_engine.backend, DummyBackend)
+    assert query_engine.config == {}
+
+
+def test_get_query_engine_with_backend_and_query_engine():
+    backend_id = f"{DummyBackend.__module__}.{DummyBackend.__name__}"
+    query_engine_id = "databuilder.query_engines.sqlite.SQLiteQueryEngine"
+    query_engine = get_query_engine(
+        backend_id=backend_id, query_engine_id=query_engine_id, environ={}
+    )
+    assert isinstance(query_engine, SQLiteQueryEngine)
+    assert isinstance(query_engine.backend, DummyBackend)
+    assert query_engine.config == {}
+
+
+def test_open_output_file(tmp_path):
+    test_file = tmp_path / "testdir" / "file.txt"
+    with open_output_file(test_file) as f:
+        f.write("hello")
+    assert test_file.read_text() == "hello"
+
+
+def test_open_output_file_with_stdout(capsys):
+    with open_output_file(None) as f:
+        f.write("hello")
+    assert capsys.readouterr().out == "hello"

--- a/tests/unit/test_sqlalchemy_utils.py
+++ b/tests/unit/test_sqlalchemy_utils.py
@@ -1,8 +1,10 @@
 import pytest
 import sqlalchemy
+from sqlalchemy.dialects.sqlite.pysqlite import SQLiteDialect_pysqlite
 
 from databuilder.sqlalchemy_utils import (
     GeneratedTable,
+    clause_as_str,
     get_setup_and_cleanup_queries,
     is_predicate,
 )
@@ -121,3 +123,11 @@ def _queries_as_strs(query):
         + [str(query).strip()]
         + [str(q).strip() for q in cleanup_queries]
     )
+
+
+def test_clause_as_str():
+    table = sqlalchemy.table("foo", sqlalchemy.Column("bar"))
+    query = sqlalchemy.select(table.c.bar).where(table.c.bar > 100)
+    dialect = SQLiteDialect_pysqlite()
+    query_str = clause_as_str(query, dialect)
+    assert query_str == "SELECT foo.bar \nFROM foo \nWHERE foo.bar > 100"

--- a/tests/unit/test_sqlalchemy_utils.py
+++ b/tests/unit/test_sqlalchemy_utils.py
@@ -131,3 +131,13 @@ def test_clause_as_str():
     dialect = SQLiteDialect_pysqlite()
     query_str = clause_as_str(query, dialect)
     assert query_str == "SELECT foo.bar \nFROM foo \nWHERE foo.bar > 100"
+
+
+# Converting CreateIndex to a string blows up without a special workaround
+def test_clause_as_str_wtih_create_index():
+    table = sqlalchemy.Table("foo", sqlalchemy.MetaData(), sqlalchemy.Column("bar"))
+    index = sqlalchemy.Index(None, table.c.bar)
+    create_index = sqlalchemy.schema.CreateIndex(index)
+    dialect = SQLiteDialect_pysqlite()
+    query_str = clause_as_str(create_index, dialect)
+    assert query_str == "CREATE INDEX ix_foo_bar ON foo (bar)"


### PR DESCRIPTION
This turned into a larger change than I originally intended, but I think (hope) it's going to pay off over the long term. The aim here is to make it as ergonomic as possible to inspect the SQL corresponding to a particular dataset definition for debugging purposes.

To that end, I've changed the syntax of `dump-dataset-sql` so that the only required argument is now the dataset file itself. This makes the minimum invocation:

    databuilder dump-dataset-sql path/to/dataset_definition.py

This compiles the dataset definition using the SQLite query engine and the default backend which assumes that the SQL schema exactly matches the contract schema. The resulting SQL is written to stdout.

The `--backend` and `--query-engine` arguments allow specifying either or both of the backend and query engine to use.

The `--output` argument allows writing the output directly to a file, if that's easier than redirecting.

The other important change is that the SQL now contains literal values rather than placeholders (e.g., `foo > 100` rather than `foo > :param_1`. This means it can be executed directly in a db shell, or passed to other tools which will only accept valid SQL.

