### PR TITLE
fix: use import_module for specs toc

### DIFF
--- a/databuilder/docs/specs.py
+++ b/databuilder/docs/specs.py
@@ -1,8 +1,6 @@
 import inspect
 from importlib import import_module
 
-from tests.spec import toc
-
 
 def build_specs():
     """Return data describing the specs for use in documentation.
@@ -12,7 +10,7 @@ def build_specs():
       * each chapter is split into sections, with one section per test module
       * each section is split into paragraphs, with one paragraph per test function
     """
-
+    toc = import_module("tests.spec.toc")
     return [
         build_chapter(str(ix + 1), package_name, module_names)
         for ix, (package_name, module_names) in enumerate(toc.contents.items())


### PR DESCRIPTION
The scripts for automatic docs generation from spec tests need to use `import_module`, rather than direct imports.  Tthis is already the case for most imports, but there is one direct import for `tests.spec.toc` which is currently breaking docs generation when run from the documentation repo (which runs `python -m databuilder.docs` with the installed pip package)  