### PR TITLE
feat: check and trigger update to public docs

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -17,14 +17,57 @@ jobs:
     env:
       image: ghcr.io/opensafely-core/databuilder
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           # Required to get previous tags
           fetch-depth: 0
 
-      - name: 'Get Previous tag'
-        id: previoustagref
-        uses: "WyriHaximus/github-action-get-previous-tag@8a0e045f02c0a3a04e1452df58b90fc7e555e950"
+      # Find the latest tag by fetching the first 20 tags in descending date order,
+      # and finding the first one that starts with "v"
+      - name: Get latest version tag
+        id: latest-version-tag
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const query = `query($owner:String!, $name:String!) {
+              repository(owner:$owner, name:$name) {
+                refs(refPrefix: "refs/tags/", first: 20, orderBy: {field: TAG_COMMIT_DATE, direction: DESC}) {
+                  edges {
+                    node {
+                      name
+                      target {
+                        oid
+                        ... on Tag {
+                          message
+                          commitUrl
+                          tagger {
+                            name
+                            email
+                            date
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }`;
+            const variables = {
+              owner: context.repo.owner,
+              name: context.repo.repo,
+            }
+            const result = await github.graphql(query, variables)
+            console.log(result.repository.refs.edges)
+            const latestVersionTagEdge = result.repository.refs.edges.find(
+              tag => tag.node.name.startsWith("v")
+              )
+            console.log(latestVersionTagEdge)
+            if(latestVersionTagEdge){
+              return latestVersionTagEdge.node.name
+            } else {
+              return "no-tag-found"
+            }
+          result-encoding: string
 
       - name: Previous commit
         id: previoustagcommit
@@ -32,21 +75,22 @@ jobs:
         # if we are not on a tag, should look like `v0.6.0-24-gbf6352d`
         run: echo ::set-output name=tag_describe::`git describe --tags`
 
-      - name: Verify whether we are on a tagged commit, allows us to short-circuit this workflow
+      - name: Verify whether we are on a tagged version commit, allows us to short-circuit this workflow
         id: taggedcommit
-        if: ${{ steps.previoustagcommit.outputs.tag_describe == steps.previoustagref.outputs.tag }}
+        if: ${{ steps.previoustagcommit.outputs.tag_describe == steps.latest-version-tag.outputs.result }}
         run: echo ::set-output name=tag::'y'
 
-      # 'Get Previous tag' should only get version tags, but let's verify that
-      - name: Fail if previous tag is not a version tag (i.e. it does not start with a v)
-        if: ${{ ! startsWith(steps.previoustagref.outputs.tag, 'v') }}
-        run: /bin/false
+      # Verify that 'Get latest version tag' returned a version tag
+      - name: Fail if no version tag found
+        if: ${{ steps.latest-version-tag.outputs.result == 'no-tag-found' }}
+        run: |
+          /bin/false
 
       # This relies on the tag having a version of the form vX.Y.Z
       - name: Build image
         if: ${{ startsWith(steps.taggedcommit.outputs.tag, 'y') }}
         run: |
-          PATCH="${{ steps.previoustagref.outputs.tag }}"
+          PATCH="${{ steps.latest-version-tag.outputs.result }}"
           MAJOR="${PATCH%%.*}"
           MINOR="${PATCH%.*}"
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: "actions/setup-python@v2"
         with:
           python-version: "3.9"
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: "actions/setup-python@v2"
         with:
           python-version: "3.9"
@@ -37,7 +37,7 @@ jobs:
   lint-dockerfile:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: hadolint/hadolint-action@v1.5.0
         with:
           failure-threshold: error
@@ -57,7 +57,7 @@ jobs:
     outputs:
       tag: ${{ steps.tag.outputs.new_version }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Bump version and push tag
@@ -72,7 +72,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: actions/setup-python@v2
       with:
         python-version: "3.9"

--- a/.github/workflows/update-public-docs.yml
+++ b/.github/workflows/update-public-docs.yml
@@ -25,19 +25,29 @@ jobs:
       - name: Generate new public docs file
         run: just generate-docs new_public_docs.json
 
-      - name: Clone docs repo
-        uses: actions/checkout@v3
+      - name: Get latest release
+        id: latest_release
+        uses: actions/github-script@v6
         with:
-          repository: opensafely/documentation
-          path: documentation
-          ref: main
+          script: |
+            response = await github.rest.repos.getLatestRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            })
+            const assets_response = await github.request(response.data.assets_url)
+            const matching_asset = assets_response.data.find(
+              asset => asset.browser_download_url.endsWith("public_docs.json")
+            );
+            return matching_asset.browser_download_url
 
       - name: Check if docs have changed
         id: check_docs
         run: |
-          echo "::set-output name=DOCS_CHANGED::$(cmp new_public_docs.json documentation/public_docs.json)"
+          curl -L ${{steps.latest_release.outputs.result}} > latest_release_public_docs.json
+          echo "::set-output name=DOCS_CHANGED::$(cmp new_public_docs.json latest_release_public_docs.json)"
 
       - name: Create Release
+        if: ${{ steps.check_docs.outputs.DOCS_CHANGED }}
         id: create-release
         uses: actions/create-release@v1
         env:
@@ -49,6 +59,7 @@ jobs:
           prerelease: false
 
       - name: Upload Release Asset
+        if: ${{ steps.check_docs.outputs.DOCS_CHANGED }}
         id: upload-release-asset
         uses: actions/upload-release-asset@v1
         env:

--- a/.github/workflows/update-public-docs.yml
+++ b/.github/workflows/update-public-docs.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
   workflow_run:
     workflows:
-      - CI
+      - Build and publish image
     branches:
       - main
     status:

--- a/.github/workflows/update-public-docs.yml
+++ b/.github/workflows/update-public-docs.yml
@@ -1,0 +1,78 @@
+---
+name: Update public docs
+
+on:
+  workflow_dispatch:
+  workflow_run:
+    workflows:
+      - CI
+    branches:
+      - main
+    status:
+      - completed
+
+jobs:
+  update-public-docs:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: "actions/setup-python@v2"
+        with:
+          python-version: "3.9"
+      - uses: extractions/setup-just@v1
+
+      - name: Generate new public docs file
+        run: just generate-docs new_public_docs.json
+
+      - name: Clone docs repo
+        uses: actions/checkout@v3
+        with:
+          repository: opensafely/documentation
+          path: documentation
+          ref: main
+
+      - name: Check if docs have changed
+        id: check_docs
+        run: |
+          echo "::set-output name=DOCS_CHANGED::$(cmp new_public_docs.json documentation/public_docs.json)"
+
+      - name: Create Release
+        id: create-release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: docs-metadata-${{ github.sha }}
+          release_name: Databuilder public docs metadata for ${{ github.sha }}
+          draft: false
+          prerelease: false
+
+      - name: Upload Release Asset
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create-release.outputs.upload_url }}
+          asset_path: ./new_public_docs.json
+          asset_name: public_docs.json
+          asset_content_type: application/json
+
+      - name: Trigger update in docs repo
+        if: ${{ steps.check_docs.outputs.DOCS_CHANGED }}
+        uses: actions/github-script@v6
+        env:
+          DOWNLOAD_URL: ${{ steps.upload-release-asset.outputs.browser_download_url }}
+          GITHUB_SHA: ${{ github.sha }}
+        with:
+          github-token: ${{ secrets.DOCS_WRITE_TOKEN }}
+          script: |
+            const { DOWNLOAD_URL, GITHUB_SHA } = process.env
+            await github.rest.actions.createWorkflowDispatch({
+              owner: 'opensafely',
+              repo: 'documentation',
+              workflow_id: 'update_databuilder_docs.yml',
+              ref: 'main',
+              inputs: {'download_url': DOWNLOAD_URL, 'branch_tag': GITHUB_SHA}
+            })

--- a/Justfile
+++ b/Justfile
@@ -213,6 +213,6 @@ databricks-test *ARGS: devenv databricks-env
     export DATABRICKS_URL="$($BIN/python scripts/dbx url)"
     just test {{ ARGS }}
 
-generate-docs: devenv
-    $BIN/python -m databuilder.docs >public_docs.json
+generate-docs OUTPUT_FILE="public_docs.json": devenv
+    $BIN/python -m databuilder.docs > {{ OUTPUT_FILE }}
     echo "Generated data for documentation."


### PR DESCRIPTION
Add a new workflow that runs after a completed CI workflow on main to:
1) generate the documentation json 
2) clone the docs repo and compare the public_docs.json there to the newly generated one
3) If it's changed, create a new release and upload the new json file as a release asset
4) trigger a workflow dispatch on the documentation repo, sending the download url for the release asset as an input

Goes along with the docs PR: https://github.com/opensafely/documentation/pull/855