### PR TITLE
Use `get_column_specs` when generating CSV output

### DIFF
--- a/databuilder/column_specs.py
+++ b/databuilder/column_specs.py
@@ -1,0 +1,25 @@
+import dataclasses
+
+from databuilder.query_model import get_series_type
+
+
+@dataclasses.dataclass(frozen=True)
+class ColumnSpec:
+    type: type  # noqa: A003
+    nullable: bool = True
+
+
+def get_column_specs(variable_definitions):
+    """
+    Given a dict of variable definitions return a dict of ColumnSpec objects, given the
+    types (and other associated metadata) of all the columns in the output
+    """
+    # TODO: It may not be universally true that IDs are ints. Internally the EMIS IDs
+    # are SHA512 hashes stored as hex strings which we convert to ints. But we can't
+    # guarantee always to be able to pull this trick.
+    column_specs = {"patient_id": ColumnSpec(int, nullable=False)}
+    for name, series in variable_definitions.items():
+        if name == "population":
+            continue
+        column_specs[name] = ColumnSpec(get_series_type(series), nullable=True)
+    return column_specs

--- a/databuilder/validate_dummy_data.py
+++ b/databuilder/validate_dummy_data.py
@@ -1,21 +1,14 @@
 import csv
-import dataclasses
 import datetime
 import functools
 import gzip
 
 from databuilder import query_language as ql
-from databuilder.query_model import get_series_type
+from databuilder.column_specs import get_column_specs
 
 
 class ValidationError(Exception):
     pass
-
-
-@dataclasses.dataclass(frozen=True)
-class ColumnSpec:
-    type: type  # noqa: A003
-    nullable: bool = True
 
 
 def validate_file_types_match(dummy_filename, output_filename):
@@ -50,18 +43,6 @@ def get_file_type(filename):
         gzipped = False
     extension = suffixes[-1] if suffixes else ""
     return extension, gzipped
-
-
-def get_column_specs(variable_definitions):
-    # TODO: It may not be universally true that IDs are ints. Internally the EMIS IDs
-    # are SHA512 hashes stored as hex strings which we convert to ints. But we can't
-    # guarantee always to be able to pull this trick.
-    column_specs = {"patient_id": ColumnSpec(int, nullable=False)}
-    for name, series in variable_definitions.items():
-        if name == "population":
-            continue
-        column_specs[name] = ColumnSpec(get_series_type(series), nullable=True)
-    return column_specs
 
 
 def validate_csv_against_spec(csv_file, column_specs):

--- a/tests/unit/test_column_specs.py
+++ b/tests/unit/test_column_specs.py
@@ -1,0 +1,24 @@
+import datetime
+
+from databuilder.column_specs import ColumnSpec, get_column_specs
+from databuilder.query_model import (
+    AggregateByPatient,
+    SelectColumn,
+    SelectPatientTable,
+    TableSchema,
+)
+
+
+def test_get_column_specs():
+    patients = SelectPatientTable(
+        "patients", schema=TableSchema({"date_of_birth": datetime.date})
+    )
+    variables = dict(
+        population=AggregateByPatient.Exists(patients),
+        dob=SelectColumn(patients, "date_of_birth"),
+    )
+    column_specs = get_column_specs(variables)
+    assert column_specs == {
+        "patient_id": ColumnSpec(type=int, nullable=False),
+        "dob": ColumnSpec(type=datetime.date, nullable=True),
+    }

--- a/tests/unit/test_validate_dummy_data.py
+++ b/tests/unit/test_validate_dummy_data.py
@@ -4,10 +4,10 @@ from pathlib import Path
 
 import pytest
 
+from databuilder.column_specs import ColumnSpec
 from databuilder.query_language import Dataset
 from databuilder.tables import patients
 from databuilder.validate_dummy_data import (
-    ColumnSpec,
     ValidationError,
     validate_csv_against_spec,
     validate_dummy_data_file,


### PR DESCRIPTION
This moves the `get_column_specs` function (previously internal to the dummy data validation code) into its own module and uses it to obtain the output column names when writing CSV, rather then inferring them from the database results object.

`get_column_specs` takes a dict of variable definitions and returns a dict of `ColumnSpec` objects which give the types (and other associated metadata) of the output columns.

The only immediate practical consequence of this is that we now always write the header row, even if the set of results is empty. But the architectural change here is needed to support binary output formats where we need the type metadata before we can start writing out results.