### PR TITLE
Check GitHub Actions versions with Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,10 @@ updates:
     open-pull-requests-limit: 20
     commit-message:
       prefix: "chore: "
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore: "


### PR DESCRIPTION
Noticed that this wasn't configured when looking at
c24b7fc4c2cf3255e22cc167a3f2c366cf588acf.