### PR TITLE
fix: Create documentation PR if docs change

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -8,7 +8,7 @@ on:
       - CI
     branches:
       - main
-    status:
+    types:
       - completed
 
 jobs:

--- a/.github/workflows/update-public-docs.yml
+++ b/.github/workflows/update-public-docs.yml
@@ -63,7 +63,6 @@ jobs:
 
       - name: Upload Release Asset
         if: ${{ steps.check_release_changed.outputs.DOCS_CHANGED }}
-        id: upload_release_asset
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -84,7 +83,7 @@ jobs:
 
       - name: Check if update branch exists
         if: ${{ steps.check_release_changed.outputs.DOCS_CHANGED }}
-        id: check-branch
+        id: check_branch
         run: |
           cd docs
           echo ::set-output name=branch-exists::`git ls-remote --heads origin ${BRANCH}`
@@ -95,7 +94,7 @@ jobs:
           cd docs
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
-          if [ -n "${{ steps.check-branch.outputs.branch-exists }}" ]; then
+          if [ -n "${{ steps.check_branch.outputs.branch-exists }}" ]; then
             echo "Checking out existing branch"
             git fetch origin $BRANCH
             git checkout $BRANCH
@@ -117,7 +116,6 @@ jobs:
       # Open a PR for this branch, if one isn't already open
       - name: Open PR
         if: ${{ steps.check_release_changed.outputs.DOCS_CHANGED }}
-        id: list-pr
         uses: actions/github-script@v6
         env:
           HEAD: "opensafely:${{env.BRANCH}}"
@@ -149,3 +147,5 @@ jobs:
                 base: 'main',
               });
             }
+
+            console.log(results.data.url)

--- a/.github/workflows/update-public-docs.yml
+++ b/.github/workflows/update-public-docs.yml
@@ -8,12 +8,15 @@ on:
       - Build and publish image
     branches:
       - main
-    status:
+    types:
       - completed
 
 jobs:
   update-public-docs:
     runs-on: ubuntu-latest
+
+    env:
+      BRANCH: update-docs-${{ github.sha }}
 
     steps:
       - uses: actions/checkout@v3
@@ -40,15 +43,15 @@ jobs:
             );
             return matching_asset.browser_download_url
 
-      - name: Check if docs have changed
-        id: check_docs
+      - name: Check if docs have changed since latest release
+        id: check_release_changed
         run: |
           curl -L ${{steps.latest_release.outputs.result}} > latest_release_public_docs.json
           echo "::set-output name=DOCS_CHANGED::$(cmp new_public_docs.json latest_release_public_docs.json)"
 
       - name: Create Release
-        if: ${{ steps.check_docs.outputs.DOCS_CHANGED }}
-        id: create-release
+        if: ${{ steps.check_release_changed.outputs.DOCS_CHANGED }}
+        id: create_release
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -59,31 +62,90 @@ jobs:
           prerelease: false
 
       - name: Upload Release Asset
-        if: ${{ steps.check_docs.outputs.DOCS_CHANGED }}
-        id: upload-release-asset
+        if: ${{ steps.check_release_changed.outputs.DOCS_CHANGED }}
+        id: upload_release_asset
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ steps.create-release.outputs.upload_url }}
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: ./new_public_docs.json
           asset_name: public_docs.json
           asset_content_type: application/json
 
-      - name: Trigger update in docs repo
-        if: ${{ steps.check_docs.outputs.DOCS_CHANGED }}
+      - name: Clone docs repo
+        if: ${{ steps.check_release_changed.outputs.DOCS_CHANGED }}
+        uses: actions/checkout@v3
+        with:
+          repository: opensafely/documentation
+          path: docs
+          ref: 'main'
+          token: ${{ secrets.DOCS_WRITE_TOKEN }}
+
+      - name: Check if update branch exists
+        if: ${{ steps.check_release_changed.outputs.DOCS_CHANGED }}
+        id: check-branch
+        run: |
+          cd docs
+          echo ::set-output name=branch-exists::`git ls-remote --heads origin ${BRANCH}`
+
+      - name: Create or checkout branch
+        if: ${{ steps.check_release_changed.outputs.DOCS_CHANGED }}
+        run: |
+          cd docs
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          if [ -n "${{ steps.check-branch.outputs.branch-exists }}" ]; then
+            echo "Checking out existing branch"
+            git fetch origin $BRANCH
+            git checkout $BRANCH
+          else
+            echo "Creating new branch"
+            git checkout -b $BRANCH
+          fi
+
+      - name: Commit new docs file
+        if: ${{ steps.check_release_changed.outputs.DOCS_CHANGED }}
+        run: |
+          echo ${{ steps.check_docs.outputs.DOCS_CHANGED }}
+          mv new_public_docs.json docs/public_docs.json
+          cd docs
+          git add public_docs.json
+          git commit -m "Update databuilder docs"
+          git push origin $BRANCH
+
+      # Open a PR for this branch, if one isn't already open
+      - name: Open PR
+        if: ${{ steps.check_release_changed.outputs.DOCS_CHANGED }}
+        id: list-pr
         uses: actions/github-script@v6
         env:
-          DOWNLOAD_URL: ${{ steps.upload-release-asset.outputs.browser_download_url }}
-          GITHUB_SHA: ${{ github.sha }}
+          HEAD: "opensafely:${{env.BRANCH}}"
+          OWNER: "opensafely"
+          REPO: "documentation"
+          BRANCH: ${{env.BRANCH}}
         with:
           github-token: ${{ secrets.DOCS_WRITE_TOKEN }}
           script: |
-            const { DOWNLOAD_URL, GITHUB_SHA } = process.env
-            await github.rest.actions.createWorkflowDispatch({
-              owner: 'opensafely',
-              repo: 'documentation',
-              workflow_id: 'update_databuilder_docs.yml',
-              ref: 'main',
-              inputs: {'download_url': DOWNLOAD_URL, 'branch_tag': GITHUB_SHA}
-            })
+            const { HEAD, OWNER, REPO, BRANCH } = process.env;
+
+            pull_requests = await github.rest.pulls.list({
+              owner: OWNER,
+              repo: REPO,
+              state: 'open',
+              head: HEAD,
+              base: 'main',
+            });
+
+            if (pull_requests.data.length > 0) {
+              console.log("Open pull request already exists")
+              console.log(pull_requests.data[0])
+            } else {
+              result = await github.rest.pulls.create({
+                title: 'Update databuilder docs',
+                owner: OWNER,
+                repo: REPO,
+                head: BRANCH,
+                base: 'main',
+              });
+            }

--- a/.github/workflows/update-public-docs.yml
+++ b/.github/workflows/update-public-docs.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      BRANCH: update-docs-${{ github.sha }}
+      BRANCH: autoupdate-databuilder-docs
 
     steps:
       - uses: actions/checkout@v3
@@ -73,7 +73,6 @@ jobs:
           asset_content_type: application/json
 
       - name: Clone docs repo
-        if: ${{ steps.check_release_changed.outputs.DOCS_CHANGED }}
         uses: actions/checkout@v3
         with:
           repository: opensafely/documentation
@@ -82,14 +81,12 @@ jobs:
           token: ${{ secrets.DOCS_WRITE_TOKEN }}
 
       - name: Check if update branch exists
-        if: ${{ steps.check_release_changed.outputs.DOCS_CHANGED }}
         id: check_branch
         run: |
           cd docs
           echo ::set-output name=branch-exists::`git ls-remote --heads origin ${BRANCH}`
 
       - name: Create or checkout branch
-        if: ${{ steps.check_release_changed.outputs.DOCS_CHANGED }}
         run: |
           cd docs
           git config --local user.email "action@github.com"
@@ -103,19 +100,24 @@ jobs:
             git checkout -b $BRANCH
           fi
 
-      - name: Commit new docs file
-        if: ${{ steps.check_release_changed.outputs.DOCS_CHANGED }}
+      - name: Check if docs have changed on docs PR branch
+        id: check_docs_changed
         run: |
-          echo ${{ steps.check_docs.outputs.DOCS_CHANGED }}
+          echo "::set-output name=DOCS_CHANGED::$(cmp new_public_docs.json docs/public_docs.json)"
+
+      - name: Commit new docs file
+        if: ${{ steps.check_docs_changed.outputs.DOCS_CHANGED }}
+        run: |
+          echo ${{ steps.check_docs_changed.outputs.DOCS_CHANGED }}
           mv new_public_docs.json docs/public_docs.json
           cd docs
           git add public_docs.json
-          git commit -m "Update databuilder docs"
+          git commit -m "Update databuilder docs from ${{ github.sha }}"
           git push origin $BRANCH
 
       # Open a PR for this branch, if one isn't already open
       - name: Open PR
-        if: ${{ steps.check_release_changed.outputs.DOCS_CHANGED }}
+        if: ${{ steps.check_docs_changed.outputs.DOCS_CHANGED }}
         uses: actions/github-script@v6
         env:
           HEAD: "opensafely:${{env.BRANCH}}"
@@ -146,6 +148,5 @@ jobs:
                 head: BRANCH,
                 base: 'main',
               });
+              console.log(result.data.url)
             }
-
-            console.log(results.data.url)

--- a/.github/workflows/update-public-docs.yml
+++ b/.github/workflows/update-public-docs.yml
@@ -80,18 +80,12 @@ jobs:
           ref: 'main'
           token: ${{ secrets.DOCS_WRITE_TOKEN }}
 
-      - name: Check if update branch exists
-        id: check_branch
-        run: |
-          cd docs
-          echo ::set-output name=branch-exists::`git ls-remote --heads origin ${BRANCH}`
-
       - name: Create or checkout branch
         run: |
           cd docs
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
-          if [ -n "${{ steps.check_branch.outputs.branch-exists }}" ]; then
+          if test -n "$(git ls-remote --heads origin $BRANCH)"; then
             echo "Checking out existing branch"
             git fetch origin $BRANCH
             git checkout $BRANCH


### PR DESCRIPTION
This PR moves the checking and updating of the automatically generally documentation entirely to this repo (see also https://github.com/opensafely/documentation/pull/881).  

[Workflow run](https://github.com/opensafely-core/databuilder/runs/7433064373?check_suite_focus=true
) with changes needed to public docs since previous release (this was triggered on pushes to this update-docs-workflow branch)

The workflow created [this release](https://github.com/opensafely-core/databuilder/releases/tag/docs-metadata-9ffd278abb5c5915965522d6333dc9942cb3bb9e)
and [this PR](https://github.com/opensafely/documentation/pull/877) in the docs repo, which has triggered all the necessary PR workflows.

[This](https://github.com/opensafely-core/databuilder/runs/7432988181?check_suite_focus=true) is a previous run, testing when the docs hadn't changed since the latest release.