### PR TITLE
Add rudimentary batch fetching support

### DIFF
--- a/databuilder/main.py
+++ b/databuilder/main.py
@@ -66,9 +66,19 @@ def dump_dataset_sql(
 def get_sql_strings(query_engine, variable_definitions):
     results_query = query_engine.get_query(variable_definitions)
     setup_queries, cleanup_queries = get_setup_and_cleanup_queries(results_query)
-    all_queries = setup_queries + [results_query] + cleanup_queries
     dialect = query_engine.sqlalchemy_dialect()
-    return [clause_as_str(query, dialect) for query in all_queries]
+    sql_strings = []
+
+    for n, query in enumerate(setup_queries, start=1):
+        sql = clause_as_str(query, dialect)
+        sql_strings.append(f"-- Setup query {n:03} / {len(setup_queries):03}\n{sql}")
+
+    sql = clause_as_str(results_query, dialect)
+    sql_strings.append(f"-- Results query\n{sql}")
+
+    assert not cleanup_queries, "Support these once tests exercise them"
+
+    return sql_strings
 
 
 def open_output_file(output_file):

--- a/databuilder/main.py
+++ b/databuilder/main.py
@@ -31,7 +31,7 @@ def generate_dataset(
     column_specs = get_column_specs(variable_definitions)
 
     query_engine = get_query_engine(db_url, backend_id, query_engine_id, environ)
-    results = query_engine.execute_query(variable_definitions)
+    results = query_engine.get_results(variable_definitions)
     write_dataset_csv(column_specs, results, dataset_file)
 
 

--- a/databuilder/main.py
+++ b/databuilder/main.py
@@ -8,7 +8,7 @@ import structlog
 
 from databuilder.column_specs import get_column_specs
 from databuilder.query_language import Dataset
-from databuilder.sqlalchemy_utils import clause_as_str
+from databuilder.sqlalchemy_utils import clause_as_str, get_setup_and_cleanup_queries
 
 from . import query_language as ql
 from .validate_dummy_data import validate_dummy_data_file, validate_file_types_match
@@ -64,9 +64,8 @@ def dump_dataset_sql(
 
 
 def get_sql_strings(query_engine, variable_definitions):
-    setup_queries, results_query, cleanup_queries = query_engine.get_queries(
-        variable_definitions
-    )
+    results_query = query_engine.get_query(variable_definitions)
+    setup_queries, cleanup_queries = get_setup_and_cleanup_queries(results_query)
     all_queries = setup_queries + [results_query] + cleanup_queries
     dialect = query_engine.sqlalchemy_dialect()
     return [clause_as_str(query, dialect) for query in all_queries]

--- a/databuilder/main.py
+++ b/databuilder/main.py
@@ -31,8 +31,8 @@ def generate_dataset(
     column_specs = get_column_specs(variable_definitions)
 
     query_engine = get_query_engine(db_url, backend_id, query_engine_id, environ)
-    with query_engine.execute_query(variable_definitions) as results:
-        write_dataset_csv(column_specs, results, dataset_file)
+    results = query_engine.execute_query(variable_definitions)
+    write_dataset_csv(column_specs, results, dataset_file)
 
 
 def pass_dummy_data(definition_file, dataset_file, dummy_data_file):

--- a/databuilder/query_engines/base.py
+++ b/databuilder/query_engines/base.py
@@ -16,7 +16,7 @@ class BaseQueryEngine:
         self.backend = backend
         self.config = config or {}
 
-    def execute_query(self, variable_definitions):
+    def get_results(self, variable_definitions):
         """
         `variable_definitions` is a dictionary mapping output column names to
         query model graphs which specify the queries used to populate them

--- a/databuilder/query_engines/base_sql.py
+++ b/databuilder/query_engines/base_sql.py
@@ -485,7 +485,7 @@ class BaseSQLQueryEngine(BaseQueryEngine):
             query = query.where(sqlalchemy.and_(*where_clauses))
         return query
 
-    def execute_query(self, variable_definitions):
+    def get_results(self, variable_definitions):
         setup_queries, results_query, cleanup_queries = self.get_queries(
             variable_definitions
         )

--- a/databuilder/query_engines/base_sql.py
+++ b/databuilder/query_engines/base_sql.py
@@ -1,4 +1,3 @@
-import contextlib
 from functools import cached_property
 
 import sqlalchemy
@@ -486,7 +485,6 @@ class BaseSQLQueryEngine(BaseQueryEngine):
             query = query.where(sqlalchemy.and_(*where_clauses))
         return query
 
-    @contextlib.contextmanager
     def execute_query(self, variable_definitions):
         setup_queries, results_query, cleanup_queries = self.get_queries(
             variable_definitions
@@ -495,7 +493,7 @@ class BaseSQLQueryEngine(BaseQueryEngine):
             for setup_query in setup_queries:
                 cursor.execute(setup_query)
 
-            yield cursor.execute(results_query)
+            yield from cursor.execute(results_query)
 
             assert not cleanup_queries, "Support these once tests exercise them"
 

--- a/databuilder/query_engines/base_sql.py
+++ b/databuilder/query_engines/base_sql.py
@@ -489,11 +489,11 @@ class BaseSQLQueryEngine(BaseQueryEngine):
         setup_queries, results_query, cleanup_queries = self.get_queries(
             variable_definitions
         )
-        with self.engine.connect() as cursor:
+        with self.engine.connect() as connection:
             for setup_query in setup_queries:
-                cursor.execute(setup_query)
+                connection.execute(setup_query)
 
-            yield from cursor.execute(results_query)
+            yield from connection.execute(results_query)
 
             assert not cleanup_queries, "Support these once tests exercise them"
 

--- a/databuilder/query_engines/mssql.py
+++ b/databuilder/query_engines/mssql.py
@@ -33,6 +33,15 @@ class MSSQLQueryEngine(BaseSQLQueryEngine):
             self.next_intermediate_table_name(), query, index_col="patient_id"
         )
 
+    def get_query(self, variable_definitions):
+        results_query = super().get_query(variable_definitions)
+        # Write results to a temporary table and select them from there. This allows us
+        # to use more efficient/robust mechanisms to retrieve the results.
+        results_table = temporary_table_from_query(
+            "#results", results_query, index_col="patient_id"
+        )
+        return sqlalchemy.select(results_table)
+
 
 def temporary_table_from_query(table_name, query, index_col=0):
     # Define a table object with the same columns as the query

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -65,10 +65,10 @@ class QueryEngineFixture:
         query_engine = self.query_engine_class(
             self.database.host_url(), **engine_kwargs
         )
-        with query_engine.execute_query(variables) as results:
-            # We don't explicitly order the results and not all databases naturally
-            # return in the same order
-            return sorted(map(dict, results), key=lambda i: i["patient_id"])
+        results = query_engine.execute_query(variables)
+        # We don't explicitly order the results and not all databases naturally
+        # return in the same order
+        return sorted(map(dict, results), key=lambda i: i["patient_id"])
 
     def dump_dataset_sql(self, dataset, **engine_kwargs):
         variables = compile(dataset)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -65,7 +65,7 @@ class QueryEngineFixture:
         query_engine = self.query_engine_class(
             self.database.host_url(), **engine_kwargs
         )
-        results = query_engine.execute_query(variables)
+        results = query_engine.get_results(variables)
         # We don't explicitly order the results and not all databases naturally
         # return in the same order
         return sorted(map(dict, results), key=lambda i: i["patient_id"])

--- a/tests/integration/test_sqlalchemy_utils.py
+++ b/tests/integration/test_sqlalchemy_utils.py
@@ -1,0 +1,35 @@
+import pytest
+import sqlalchemy
+import sqlalchemy.orm
+
+from databuilder.sqlalchemy_utils import fetch_table_in_batches
+
+Base = sqlalchemy.orm.declarative_base()
+
+
+class SomeTable(Base):
+    __tablename__ = "some_table"
+    pk = sqlalchemy.Column(sqlalchemy.Integer, primary_key=True)
+    foo = sqlalchemy.Column(sqlalchemy.String)
+
+
+def test_fetch_table_in_batches(engine):
+    if engine.name == "in_memory":
+        pytest.skip("SQL tests do not apply to in-memory engine")
+
+    table_size = 15
+    batch_size = 6
+
+    table_data = [(i, f"foo{i}") for i in range(table_size)]
+
+    engine.setup([SomeTable(pk=row[0], foo=row[1]) for row in table_data])
+
+    table = SomeTable.__table__
+
+    with engine.sqlalchemy_engine().connect() as connection:
+        results = fetch_table_in_batches(
+            connection, table, table.c.pk, batch_size=batch_size
+        )
+        results = list(results)
+
+    assert results == table_data

--- a/tests/lib/in_memory/engine.py
+++ b/tests/lib/in_memory/engine.py
@@ -18,7 +18,7 @@ class InMemoryQueryEngine(BaseQueryEngine):
     tests, and a to provide a reference implementation for other engines.
     """
 
-    def execute_query(self, variable_definitions):
+    def get_results(self, variable_definitions):
         name_to_col = {
             "patient_id": Column(
                 {patient: [patient] for patient in self.all_patients},

--- a/tests/lib/in_memory/engine.py
+++ b/tests/lib/in_memory/engine.py
@@ -1,4 +1,3 @@
-import contextlib
 import datetime
 import operator
 
@@ -19,7 +18,6 @@ class InMemoryQueryEngine(BaseQueryEngine):
     tests, and a to provide a reference implementation for other engines.
     """
 
-    @contextlib.contextmanager
     def execute_query(self, variable_definitions):
         name_to_col = {
             "patient_id": Column(
@@ -35,12 +33,10 @@ class InMemoryQueryEngine(BaseQueryEngine):
 
         table = Table(name_to_col)
         table = table.filter(table["population"])
-        records = []
+
         for record in table.to_records():
             del record["population"]
-            records.append(record)
-
-        yield records
+            yield record
 
     @property
     def database(self):

--- a/tests/unit/test_sqlalchemy_utils.py
+++ b/tests/unit/test_sqlalchemy_utils.py
@@ -5,6 +5,7 @@ from sqlalchemy.dialects.sqlite.pysqlite import SQLiteDialect_pysqlite
 from databuilder.sqlalchemy_utils import (
     GeneratedTable,
     clause_as_str,
+    fetch_table_in_batches,
     get_setup_and_cleanup_queries,
     is_predicate,
 )
@@ -148,3 +149,52 @@ def test_clause_as_str_wtih_create_index():
     # Check that our workaround is effective
     query_str = clause_as_str(create_index, dialect)
     assert query_str == "CREATE INDEX ix_foo_bar ON foo (bar)"
+
+
+@pytest.mark.parametrize(
+    "table_size,batch_size,expected_query_count",
+    [
+        (20, 5, 5),  # 4 batches of results, plus one to confirm there are no more
+        (20, 6, 4),  # 4th batch will be part empty so we know it's the final one
+        (0, 10, 1),  # 1 query to confirm there are no results
+        (9, 1, 10),  # a batch size of 1 is obviously silly but it ought to work
+    ],
+)
+def test_fetch_table_in_batches(table_size, batch_size, expected_query_count):
+    table_data = [(i, f"foo{i}") for i in range(table_size)]
+
+    # Pretend to be a SQL connection that understands just two forms of query
+    class FakeConnection:
+        call_count = 0
+
+        def execute(self, query):
+            self.call_count += 1
+            compiled = query.compile()
+            sql = str(compiled).replace("\n", "").strip()
+            params = compiled.params
+
+            if sql == "SELECT t.pk, t.foo FROM t ORDER BY t.pk LIMIT :param_1":
+                limit = params["param_1"]
+                return table_data[:limit]
+            elif sql == (
+                "SELECT t.pk, t.foo FROM t WHERE t.pk > :pk_1 "
+                "ORDER BY t.pk LIMIT :param_1"
+            ):
+                limit, min_pk = params["param_1"], params["pk_1"]
+                return [row for row in table_data if row[0] > min_pk][:limit]
+            else:
+                assert False, f"Unexpected SQL: {sql}"
+
+    table = sqlalchemy.table(
+        "t",
+        sqlalchemy.Column("pk"),
+        sqlalchemy.Column("foo"),
+    )
+
+    connection = FakeConnection()
+
+    results = fetch_table_in_batches(
+        connection, table, table.c.pk, batch_size=batch_size
+    )
+    assert list(results) == table_data
+    assert connection.call_count == expected_query_count


### PR DESCRIPTION
This adds bare bones support to the MSSQL engine for writing the results of query to a temporary table and then fetching them in batches.

As yet, it makes no attempt to gracefully handle errors and retry; but it should hopefully be enough to attempt some work with "real sized" data. 