### PR TITLE
Make `schema` required in query model

### DIFF
--- a/databuilder/query_model.py
+++ b/databuilder/query_model.py
@@ -170,16 +170,13 @@ class Value(OneRowPerPatientSeries[T]):
 
 class SelectTable(ManyRowsPerPatientFrame):
     name: str
-    # A schema is a mapping from available column names to types which allows us to check
-    # that operations only use columns which actually exist and are of the correct type.
-    # It's optional because we don't *need* it to construct a query, but we're obviously
-    # more limited in the validation we can do without it.
-    schema: Optional[Mapping[str, type]] = None
+    # A schema is a mapping from column names to types
+    schema: Mapping[str, type]
 
 
 class SelectPatientTable(OneRowPerPatientFrame):
     name: str
-    schema: Optional[Mapping[str, type]] = None
+    schema: Mapping[str, type]
 
 
 class SelectColumn(Series):
@@ -722,12 +719,7 @@ def resolve_typevar_from_inputs(series, typevar):
 def get_typespec_for_select_column(column):
     # Find the table from which this SelectColumn operation draws
     root = get_root_frame(column.source)
-    # If it has a schema then that gives us the type of the resulting Series
-    if root.schema:
-        type_ = root.schema[column.name]
-    # Otherwise use the default type Any
-    else:
-        type_ = Any
+    type_ = root.schema[column.name]
     return Series[type_]
 
 

--- a/tests/unit/query_engines/test_sqlite.py
+++ b/tests/unit/query_engines/test_sqlite.py
@@ -9,45 +9,25 @@ from databuilder.query_model import (
     Value,
 )
 
+BOOLEAN_COLUMN = SelectColumn(SelectPatientTable("t", TableSchema(c=bool)), "c")
+
 
 class DummyBackend:
     def get_table_expression(self, _name, _schema):
-        return (
-            sqlalchemy.select([sqlalchemy.Column("c")])
-            .select_from(sqlalchemy.table("t"))
-            .subquery()
-        )
+        return sqlalchemy.table("t", sqlalchemy.Column("c", sqlalchemy.Boolean))
 
 
 def test_or_with_literal():
     # SQLAlchemy doesn't provide reverse bitwise operations, so `False | Column()` raises a `TypeError`.
     # See https://github.com/sqlalchemy/sqlalchemy/issues/5846.
     engine = SQLiteQueryEngine(None, DummyBackend())
-    engine.get_sql(
-        Function.Or(
-            Value(True), SelectColumn(SelectPatientTable("t", TableSchema(c=bool)), "c")
-        )
-    )
-    engine.get_sql(
-        Function.Or(
-            SelectColumn(SelectPatientTable("t", TableSchema(c=bool)), "c"), Value(True)
-        )
-    )
+    engine.get_sql(Function.Or(Value(True), BOOLEAN_COLUMN))
+    engine.get_sql(Function.Or(BOOLEAN_COLUMN, Value(True)))
 
 
 def test_and_with_literal():
     # SQLAlchemy doesn't provide reverse bitwise operations, so `True & Column()` raises a `TypeError`.
     # See https://github.com/sqlalchemy/sqlalchemy/issues/5846.
     engine = SQLiteQueryEngine(None, DummyBackend())
-    engine.get_sql(
-        Function.And(
-            Value(False),
-            SelectColumn(SelectPatientTable("t", TableSchema(c=bool)), "c"),
-        )
-    )
-    engine.get_sql(
-        Function.And(
-            SelectColumn(SelectPatientTable("t", TableSchema(c=bool)), "c"),
-            Value(False),
-        )
-    )
+    engine.get_sql(Function.And(Value(False), BOOLEAN_COLUMN))
+    engine.get_sql(Function.And(BOOLEAN_COLUMN, Value(False)))

--- a/tests/unit/query_engines/test_sqlite.py
+++ b/tests/unit/query_engines/test_sqlite.py
@@ -1,7 +1,13 @@
 import sqlalchemy
 
 from databuilder.query_engines.sqlite import SQLiteQueryEngine
-from databuilder.query_model import Function, SelectColumn, SelectPatientTable, Value
+from databuilder.query_model import (
+    Function,
+    SelectColumn,
+    SelectPatientTable,
+    TableSchema,
+    Value,
+)
 
 
 class DummyBackend:
@@ -17,8 +23,16 @@ def test_or_with_literal():
     # SQLAlchemy doesn't provide reverse bitwise operations, so `False | Column()` raises a `TypeError`.
     # See https://github.com/sqlalchemy/sqlalchemy/issues/5846.
     engine = SQLiteQueryEngine(None, DummyBackend())
-    engine.get_sql(Function.Or(Value(True), SelectColumn(SelectPatientTable("t"), "c")))
-    engine.get_sql(Function.Or(SelectColumn(SelectPatientTable("t"), "c"), Value(True)))
+    engine.get_sql(
+        Function.Or(
+            Value(True), SelectColumn(SelectPatientTable("t", TableSchema(c=bool)), "c")
+        )
+    )
+    engine.get_sql(
+        Function.Or(
+            SelectColumn(SelectPatientTable("t", TableSchema(c=bool)), "c"), Value(True)
+        )
+    )
 
 
 def test_and_with_literal():
@@ -26,8 +40,14 @@ def test_and_with_literal():
     # See https://github.com/sqlalchemy/sqlalchemy/issues/5846.
     engine = SQLiteQueryEngine(None, DummyBackend())
     engine.get_sql(
-        Function.And(Value(False), SelectColumn(SelectPatientTable("t"), "c"))
+        Function.And(
+            Value(False),
+            SelectColumn(SelectPatientTable("t", TableSchema(c=bool)), "c"),
+        )
     )
     engine.get_sql(
-        Function.And(SelectColumn(SelectPatientTable("t"), "c"), Value(False))
+        Function.And(
+            SelectColumn(SelectPatientTable("t", TableSchema(c=bool)), "c"),
+            Value(False),
+        )
     )

--- a/tests/unit/test_population_validation.py
+++ b/tests/unit/test_population_validation.py
@@ -45,12 +45,18 @@ def test_rejects_invalid_type():
 
 
 def test_accepts_basic_reasonable_population():
-    has_registration = AggregateByPatient.Exists(SelectTable("registrations"))
+    has_registration = AggregateByPatient.Exists(
+        SelectTable("registrations", schema=TableSchema(value=int))
+    )
     assert validate_population_definition(has_registration)
 
 
 def test_rejects_basic_unreasonable_population():
-    not_died = Function.Not(AggregateByPatient.Exists(SelectTable("ons_deaths")))
+    not_died = Function.Not(
+        AggregateByPatient.Exists(
+            SelectTable("ons_deaths", schema=TableSchema(value=int))
+        )
+    )
     with pytest.raises(ValidationError, match="must not evaluate as True for NULL"):
         validate_population_definition(not_died)
 

--- a/tests/unit/test_query_model.py
+++ b/tests/unit/test_query_model.py
@@ -15,7 +15,6 @@ from databuilder.query_model import (
     PickOneRowPerPatient,
     Position,
     SelectColumn,
-    SelectPatientTable,
     SelectTable,
     Series,
     Sort,
@@ -112,7 +111,7 @@ def test_query_reprs_round_trip(queries):
 
 # The simple, happy case: combining series derived directly from the same frame
 def test_combining_series_from_same_frame_is_ok():
-    events = SelectTable("events")
+    events = SelectTable("events", TableSchema(value_1=int, value_2=int))
     value_1 = SelectColumn(events, "value_1")
     value_2 = SelectColumn(events, "value_2")
     assert Function.GT(value_1, value_2)
@@ -121,8 +120,8 @@ def test_combining_series_from_same_frame_is_ok():
 # We can also combine with a one-row-per-patient series derived from a different frame
 # because we know we can always join by patient_id
 def test_combining_a_patient_level_series_from_a_different_frame_is_ok():
-    events = SelectTable("events")
-    vaccinations = SelectTable("vaccinations")
+    events = SelectTable("events", EVENTS_SCHEMA)
+    vaccinations = SelectTable("vaccinations", EVENTS_SCHEMA)
     event_date = SelectColumn(events, "date")
     vaccination_date = SelectColumn(vaccinations, "date")
     # This makes a one-row-per-patient series which can be combined arbitrarily with
@@ -133,8 +132,8 @@ def test_combining_a_patient_level_series_from_a_different_frame_is_ok():
 
 # But we can't combine many-rows-per-patient series derived from different frames
 def test_combining_non_patient_level_series_from_different_frames_throws_error():
-    events = SelectTable("events")
-    vaccinations = SelectTable("vaccinations")
+    events = SelectTable("events", EVENTS_SCHEMA)
+    vaccinations = SelectTable("vaccinations", EVENTS_SCHEMA)
     event_date = SelectColumn(events, "date")
     vaccination_date = SelectColumn(vaccinations, "date")
     with pytest.raises(DomainMismatchError):
@@ -144,8 +143,8 @@ def test_combining_non_patient_level_series_from_different_frames_throws_error()
 # And in particular, we can't filter a Frame using a predicate (boolean Series) derived
 # from a different Frame
 def test_filtering_one_frame_by_a_condition_derived_from_another_throws_error():
-    events = SelectTable("events")
-    vaccinations = SelectTable("vaccinations")
+    events = SelectTable("events", EVENTS_SCHEMA)
+    vaccinations = SelectTable("vaccinations", EVENTS_SCHEMA)
     vaccine_code = SelectColumn(vaccinations, "code")
     filter_condition = Function.EQ(vaccine_code, Value("abc123"))
     with pytest.raises(DomainMismatchError):
@@ -154,8 +153,8 @@ def test_filtering_one_frame_by_a_condition_derived_from_another_throws_error():
 
 # And ditto for sort
 def test_sorting_one_frame_by_a_series_derived_from_another_throws_an_error():
-    events = SelectTable("events")
-    vaccinations = SelectTable("vaccinations")
+    events = SelectTable("events", EVENTS_SCHEMA)
+    vaccinations = SelectTable("vaccinations", EVENTS_SCHEMA)
     vaccine_code = SelectColumn(vaccinations, "code")
     with pytest.raises(DomainMismatchError):
         Sort(events, vaccine_code)
@@ -308,7 +307,7 @@ def test_domain_get_node_fails_for_patient_domain():
 
 
 def test_cannot_pick_row_from_unsorted_table():
-    events = SelectTable("events")
+    events = SelectTable("events", EVENTS_SCHEMA)
     with pytest.raises(TypeValidationError):
         PickOneRowPerPatient(events, Position.FIRST)  # type: ignore
 
@@ -321,7 +320,7 @@ def test_cannot_sort_by_non_comparable_type():
 
 
 def test_cannot_pass_argument_without_wrapping_in_value():
-    events = SelectTable("events")
+    events = SelectTable("events", EVENTS_SCHEMA)
     date = SelectColumn(events, "date")
     with pytest.raises(TypeValidationError):
         Function.EQ(date, datetime.date(2020, 1, 1))  # type: ignore
@@ -332,39 +331,6 @@ def test_cannot_compare_date_and_int():
     date = SelectColumn(events, "date")
     with pytest.raises(TypeValidationError):
         Function.EQ(date, Value(2000))
-
-
-def test_can_compare_columns_of_unknown_type():
-    # Without the schema the Query Model doesn't know that the "date" column contains a
-    # date, so it assumes the user knows what they're doing
-    events = SelectTable("events")
-    date = SelectColumn(events, "date")
-    assert get_series_type(date) == Any
-    assert Function.EQ(date, Value(2000))
-
-
-def test_infer_types_where_possible_even_without_schema():
-    events = SelectTable("events")
-    event_count = AggregateByPatient.Count(events)
-    # Even though we've got no schema we know that Count always returns an int
-    assert get_series_type(event_count) == int
-    # And therefore it should be an error to compare it to a string
-    with pytest.raises(TypeValidationError):
-        Function.EQ(event_count, Value("some_string"))
-
-
-def test_combination_of_typed_and_untyped_series():
-    # We're checking here that the type-checking can correctly combine typed series (`IsNull` has type `bool`) and
-    # untyped ones (`SelectColumn` has type `Any` because no schema is provided).
-    assert Function.EQ(
-        lhs=Function.IsNull(Value(None)),
-        rhs=SelectColumn(SelectPatientTable("p0"), "b1"),
-    )
-
-    assert Function.EQ(
-        lhs=SelectColumn(SelectPatientTable("p0"), "b1"),
-        rhs=Function.IsNull(Value(None)),
-    )
 
 
 def test_cannot_define_operation_returning_any_type(queries):


### PR DESCRIPTION
We previously thought that we might support a "schemaless" mode of databuilder where it would let you reference any tables and columns you liked and just assume you were doing the right thing with types. But in practice this turns out not to be easy to support, and not all that useful in any case given that schemas are lightweight and easy to define. As things currently stand, schemas are required in both ehrQL and the query engines so having them optional in the query model is pointless in any case. This PR makes them required and fixes up the few tests that this affects.