### PR TITLE
Trigger errors and log lines before creating output file

### DIFF
--- a/databuilder/itertools_utils.py
+++ b/databuilder/itertools_utils.py
@@ -1,0 +1,15 @@
+import itertools
+
+
+def eager_iterator(iterator):
+    """
+    Transparently wraps an iterator, but eagerly consumes the first item so as to
+    execute any generator set up code and trigger any errors which might occur
+    """
+    try:
+        first_item = next(iterator)
+    except StopIteration:
+        # If the original iterator was empty there's nothing more to do
+        return iterator
+    # Otherwise chain the first item back on to the front and continue
+    return itertools.chain([first_item], iterator)

--- a/tests/unit/test_itertools_utils.py
+++ b/tests/unit/test_itertools_utils.py
@@ -1,0 +1,34 @@
+import pytest
+
+from databuilder.itertools_utils import eager_iterator
+
+
+def test_eager_iterator():
+    results = eager_iterator(iter([0, 1, 2]))
+    assert list(results) == [0, 1, 2]
+
+
+def test_eager_iterator_works_on_empty_iterators():
+    results = eager_iterator(iter([]))
+    assert list(results) == []
+
+
+def test_eager_iterator_triggers_errors_early():
+    def generator_with_error():
+        raise ValueError("fail")
+        yield  # pragma: no cover
+
+    results = generator_with_error()
+    with pytest.raises(ValueError, match="^fail$"):
+        eager_iterator(results)
+
+
+def test_eager_iterator_still_mostly_lazy():
+    i = iter(range(3))
+    assert i.__length_hint__() == 3
+    # Check that making it eager consumes exactly one item
+    eager = eager_iterator(i)
+    assert i.__length_hint__() == 2
+    # Check that consuming the eager iterator consumes the rest of the items
+    assert list(eager) == [0, 1, 2]
+    assert i.__length_hint__() == 0


### PR DESCRIPTION
Because the `results` object is a generator we don't actually execute
any queries until we start consuming it. It gives nicer behaviour if we
start consuming it before creating the output file and writing the
headers so that any errors (or relevant log output) comes first.