### PR TITLE
Make various CLI improvements

### DIFF
--- a/databuilder/__main__.py
+++ b/databuilder/__main__.py
@@ -32,8 +32,8 @@ def main(args, environ=None):
                 definition_file=options.dataset_definition,
                 dataset_file=options.output,
                 db_url=database_url,
-                backend_id=environ.get("OPENSAFELY_BACKEND"),
-                query_engine_id=environ.get("OPENSAFELY_QUERY_ENGINE"),
+                backend_id=options.backend,
+                query_engine_id=options.query_engine,
                 environ=environ,
             )
         elif dummy_data_file:
@@ -100,6 +100,16 @@ def add_generate_dataset(subparsers, environ):
         "--dummy-data-file",
         help="Provide dummy data from a file to be validated and used as the dataset",
         type=Path,
+    )
+    parser.add_argument(
+        "--query-engine",
+        type=str,
+        default=environ.get("OPENSAFELY_QUERY_ENGINE"),
+    )
+    parser.add_argument(
+        "--backend",
+        type=str,
+        default=environ.get("OPENSAFELY_BACKEND"),
     )
 
 

--- a/databuilder/__main__.py
+++ b/databuilder/__main__.py
@@ -24,23 +24,23 @@ def main(args, environ=None):
     options = parser.parse_args(args)
 
     if options.which == "generate-dataset":
-        database_url = environ.get("DATABASE_URL")
-        dummy_data_file = options.dummy_data_file
-
-        if database_url:
+        if options.dsn:
             generate_dataset(
                 definition_file=options.dataset_definition,
                 dataset_file=options.output,
-                db_url=database_url,
+                db_url=options.dsn,
                 backend_id=options.backend,
                 query_engine_id=options.query_engine,
                 environ=environ,
             )
-        elif dummy_data_file:
-            pass_dummy_data(options.dataset_definition, options.output, dummy_data_file)
+        elif options.dummy_data_file:
+            pass_dummy_data(
+                options.dataset_definition, options.output, options.dummy_data_file
+            )
         else:
             parser.error(
-                "error: either --dummy-data-file or DATABASE_URL environment variable is required"
+                "error: one of --dummy-data-file, --dsn or DATABASE_URL environment "
+                "variable is required"
             )
     elif options.which == "dump-dataset-sql":
         dump_dataset_sql(
@@ -110,6 +110,12 @@ def add_generate_dataset(subparsers, environ):
         "--backend",
         type=str,
         default=environ.get("OPENSAFELY_BACKEND"),
+    )
+    parser.add_argument(
+        "--dsn",
+        help="Data Source Name: URL of remote database, or path to data on disk",
+        type=str,
+        default=environ.get("DATABASE_URL"),
     )
 
 

--- a/databuilder/__main__.py
+++ b/databuilder/__main__.py
@@ -93,7 +93,7 @@ def add_generate_dataset(subparsers, environ):
     )
     parser.add_argument(
         "--output",
-        help="Path of the file where the dataset will be written",
+        help="Path of the file where the dataset will be written (console by default)",
         type=Path,
     )
     parser.add_argument(

--- a/databuilder/__main__.py
+++ b/databuilder/__main__.py
@@ -28,7 +28,7 @@ def main(args, environ=None):
             generate_dataset(
                 definition_file=options.dataset_definition,
                 dataset_file=options.output,
-                db_url=options.dsn,
+                dsn=options.dsn,
                 backend_id=options.backend,
                 query_engine_id=options.query_engine,
                 environ=environ,

--- a/databuilder/__main__.py
+++ b/databuilder/__main__.py
@@ -87,7 +87,7 @@ def add_generate_dataset(subparsers, environ):
     parser = subparsers.add_parser("generate-dataset", help="Generate a dataset")
     parser.set_defaults(which="generate-dataset")
     parser.add_argument(
-        "--dataset-definition",
+        "dataset_definition",
         help="The path of the file where the dataset is defined",
         type=existing_python_file,
     )

--- a/databuilder/__main__.py
+++ b/databuilder/__main__.py
@@ -12,6 +12,11 @@ from .main import (
 )
 
 
+def entrypoint():
+    # This is covered by the Docker tests but they're not recorded for coverage
+    return main(sys.argv[1:], environ=os.environ)  # pragma: no cover
+
+
 def main(args, environ=None):
     environ = environ or {}
 
@@ -180,4 +185,4 @@ def existing_python_file(value):
 
 
 if __name__ == "__main__":
-    main(sys.argv[1:], environ=os.environ)
+    entrypoint()

--- a/databuilder/__main__.py
+++ b/databuilder/__main__.py
@@ -87,29 +87,9 @@ def add_generate_dataset(subparsers, environ):
     parser = subparsers.add_parser("generate-dataset", help="Generate a dataset")
     parser.set_defaults(which="generate-dataset")
     parser.add_argument(
-        "dataset_definition",
-        help="The path of the file where the dataset is defined",
-        type=existing_python_file,
-    )
-    parser.add_argument(
         "--output",
         help="Path of the file where the dataset will be written (console by default)",
         type=Path,
-    )
-    parser.add_argument(
-        "--dummy-data-file",
-        help="Provide dummy data from a file to be validated and used as the dataset",
-        type=Path,
-    )
-    parser.add_argument(
-        "--query-engine",
-        type=str,
-        default=environ.get("OPENSAFELY_QUERY_ENGINE"),
-    )
-    parser.add_argument(
-        "--backend",
-        type=str,
-        default=environ.get("OPENSAFELY_BACKEND"),
     )
     parser.add_argument(
         "--dsn",
@@ -117,6 +97,12 @@ def add_generate_dataset(subparsers, environ):
         type=str,
         default=environ.get("DATABASE_URL"),
     )
+    parser.add_argument(
+        "--dummy-data-file",
+        help="Provide dummy data from a file to be validated and used as the dataset",
+        type=Path,
+    )
+    add_common_dataset_arguments(parser, environ)
 
 
 def add_dump_dataset_sql(subparsers, environ):
@@ -129,6 +115,20 @@ def add_dump_dataset_sql(subparsers, environ):
     )
     parser.set_defaults(which="dump-dataset-sql")
     parser.add_argument(
+        "--output",
+        help="SQL output file (outputs to console by default)",
+        type=Path,
+    )
+    add_common_dataset_arguments(parser, environ)
+
+
+def add_common_dataset_arguments(parser, environ):
+    parser.add_argument(
+        "dataset_definition",
+        help="The path of the file where the dataset is defined",
+        type=existing_python_file,
+    )
+    parser.add_argument(
         "--query-engine",
         type=str,
         default=environ.get("OPENSAFELY_QUERY_ENGINE"),
@@ -137,16 +137,6 @@ def add_dump_dataset_sql(subparsers, environ):
         "--backend",
         type=str,
         default=environ.get("OPENSAFELY_BACKEND"),
-    )
-    parser.add_argument(
-        "--output",
-        help="SQL output file (outputs to console by default)",
-        type=Path,
-    )
-    parser.add_argument(
-        "dataset_definition",
-        help="Path of Python file where dataset is defined",
-        type=existing_python_file,
     )
 
 

--- a/databuilder/__main__.py
+++ b/databuilder/__main__.py
@@ -150,7 +150,7 @@ def add_generate_measures(subparsers, environ):
         type=Path,
     )
     parser.add_argument(
-        "--dataset-definition",
+        "dataset_definition",
         help="The path of the file where the dataset is defined",
         type=existing_python_file,
     )

--- a/databuilder/__main__.py
+++ b/databuilder/__main__.py
@@ -93,7 +93,7 @@ def add_generate_dataset(subparsers, environ):
     )
     parser.add_argument(
         "--output",
-        help="Path and filename (or pattern) of the file(s) where the dataset will be written",
+        help="Path of the file where the dataset will be written",
         type=Path,
     )
     parser.add_argument(

--- a/databuilder/main.py
+++ b/databuilder/main.py
@@ -20,7 +20,7 @@ log = structlog.getLogger()
 def generate_dataset(
     definition_file,
     dataset_file,
-    db_url,
+    dsn,
     backend_id,
     query_engine_id,
     environ,
@@ -31,7 +31,7 @@ def generate_dataset(
     variable_definitions = ql.compile(dataset_definition)
     column_specs = get_column_specs(variable_definitions)
 
-    query_engine = get_query_engine(db_url, backend_id, query_engine_id, environ)
+    query_engine = get_query_engine(dsn, backend_id, query_engine_id, environ)
     results = query_engine.get_results(variable_definitions)
     # Because `results` is a generator we won't actually execute any queries until we
     # start consuming it. But we want to make sure we trigger any errors (or relevant

--- a/databuilder/main.py
+++ b/databuilder/main.py
@@ -179,8 +179,7 @@ def import_string(dotted_path):
 
 def write_dataset_csv(column_specs, results, dataset_file):
     headers = list(column_specs.keys())
-    dataset_file.parent.mkdir(parents=True, exist_ok=True)
-    with dataset_file.open(mode="w") as f:
+    with open_output_file(dataset_file) as f:
         writer = csv.writer(f)
         writer.writerow(headers)
         writer.writerows(results)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
 ]
 
 [project.scripts]
-databuilder = "databuilder.__main__:main"
+databuilder = "databuilder.__main__:entrypoint"
 
 [project.urls]
 Home = "https://opensafely.org"

--- a/tests/acceptance/test_embedded_study.py
+++ b/tests/acceptance/test_embedded_study.py
@@ -27,7 +27,6 @@ class DummyDataStudy:
         main(
             [
                 "generate-dataset",
-                "--dataset-definition",
                 str(self.dataset_definition_path),
                 "--output",
                 str(self.dataset_path),

--- a/tests/integration/test___main__.py
+++ b/tests/integration/test___main__.py
@@ -1,4 +1,14 @@
-from databuilder.__main__ import main
+from databuilder.__main__ import (
+    BACKEND_ALIASES,
+    QUERY_ENGINE_ALIASES,
+    backend_from_id,
+    main,
+    query_engine_from_id,
+)
+from databuilder.backends.base import BaseBackend
+from databuilder.module_utils import get_sibling_subclasses
+from databuilder.query_engines.base import BaseQueryEngine
+from databuilder.query_engines.base_sql import BaseSQLQueryEngine
 
 
 def test_test_connection(mssql_database, capsys):
@@ -10,3 +20,28 @@ def test_test_connection(mssql_database, capsys):
     main(argv, env)
     out, _ = capsys.readouterr()
     assert "SUCCESS" in out
+
+
+def test_all_query_engine_aliases_are_importable():
+    for alias in QUERY_ENGINE_ALIASES.keys():
+        assert query_engine_from_id(alias)
+
+
+def test_all_backend_aliases_are_importable():
+    for alias in BACKEND_ALIASES.keys():
+        assert backend_from_id(alias)
+
+
+def test_all_query_engines_have_an_alias():
+    for cls in get_sibling_subclasses(BaseSQLQueryEngine):
+        name = f"{cls.__module__}.{cls.__name__}"
+        assert name in QUERY_ENGINE_ALIASES.values(), f"No alias defined for {cls}"
+    # We don't currently have any production query engines which aren't SQL query
+    # engines, but shout if this changes
+    assert get_sibling_subclasses(BaseQueryEngine) == [BaseSQLQueryEngine]
+
+
+def test_all_backends_have_an_alias():
+    for cls in get_sibling_subclasses(BaseBackend):
+        name = f"{cls.__module__}.{cls.__name__}"
+        assert name in BACKEND_ALIASES.values(), f"No alias defined for {cls}"

--- a/tests/lib/study.py
+++ b/tests/lib/study.py
@@ -97,7 +97,6 @@ class Study:
     def _generate_command(definition, dataset):
         return [
             "generate-dataset",
-            "--dataset-definition",
             str(definition),
             "--output",
             str(dataset),

--- a/tests/unit/test___main__.py
+++ b/tests/unit/test___main__.py
@@ -71,7 +71,7 @@ def test_generate_dataset_without_database_url_or_dummy_data(capsys, tmp_path):
         main(argv)
     captured = capsys.readouterr()
     assert (
-        "either --dummy-data-file or DATABASE_URL environment variable is required"
+        "one of --dummy-data-file, --dsn or DATABASE_URL environment variable is required"
         in captured.err
     )
 

--- a/tests/unit/test___main__.py
+++ b/tests/unit/test___main__.py
@@ -19,7 +19,6 @@ def test_generate_dataset(mocker, tmp_path):
     dataset_definition_path.touch()
     argv = [
         "generate-dataset",
-        "--dataset-definition",
         str(dataset_definition_path),
     ]
     main(argv, env)
@@ -34,7 +33,6 @@ def test_pass_dummy_data(mocker, tmp_path):
     dataset_definition_path.touch()
     argv = [
         "generate-dataset",
-        "--dataset-definition",
         str(dataset_definition_path),
         "--dummy-data-file",
         str(tmp_path / "dummy-data.csv"),
@@ -51,7 +49,6 @@ def test_generate_dataset_if_both_db_url_and_dummy_data_are_provided(mocker, tmp
     dataset_definition_path.touch()
     argv = [
         "generate-dataset",
-        "--dataset-definition",
         str(dataset_definition_path),
         "--dummy-data-file",
         str(tmp_path / "dummy-data.csv"),
@@ -68,7 +65,6 @@ def test_generate_dataset_without_database_url_or_dummy_data(capsys, tmp_path):
     dataset_definition_path.touch()
     argv = [
         "generate-dataset",
-        "--dataset-definition",
         str(dataset_definition_path),
     ]
     with pytest.raises(SystemExit):
@@ -115,7 +111,6 @@ def test_existing_python_file_missing_file(capsys, tmp_path):
     dataset_definition_path = tmp_path / "dataset.py"
     argv = [
         "generate-dataset",
-        "--dataset-definition",
         str(dataset_definition_path),
     ]
     with pytest.raises(SystemExit):
@@ -131,7 +126,6 @@ def test_existing_python_file_unpythonic_file(capsys, tmp_path):
     dataset_definition_path.touch()
     argv = [
         "generate-dataset",
-        "--dataset-definition",
         str(dataset_definition_path),
     ]
     with pytest.raises(SystemExit):

--- a/tests/unit/test___main__.py
+++ b/tests/unit/test___main__.py
@@ -41,7 +41,7 @@ def test_pass_dummy_data(mocker, tmp_path):
     patched.assert_called_once()
 
 
-def test_generate_dataset_if_both_db_url_and_dummy_data_are_provided(mocker, tmp_path):
+def test_generate_dataset_if_both_dsn_and_dummy_data_are_provided(mocker, tmp_path):
     # This happens when studies with dummy data are run in the backend.
     patched = mocker.patch("databuilder.__main__.generate_dataset")
     env = {"DATABASE_URL": "scheme:path"}
@@ -57,7 +57,7 @@ def test_generate_dataset_if_both_db_url_and_dummy_data_are_provided(mocker, tmp
     patched.assert_called_once()
 
 
-def test_generate_dataset_without_database_url_or_dummy_data(capsys, tmp_path):
+def test_generate_dataset_without_dsn_or_dummy_data(capsys, tmp_path):
     # Verify that a helpful message is shown when the generate_dataset
     # subcommand is invoked but DATABASE_URL is not set and --dummy-data-file
     # is not provided.

--- a/tests/unit/test___main__.py
+++ b/tests/unit/test___main__.py
@@ -168,6 +168,11 @@ def test_query_engine_from_id():
     assert query_engine_from_id(engine_id) is DummyQueryEngine
 
 
+def test_query_engine_from_id_missing_alias():
+    with pytest.raises(ArgumentTypeError, match="must be one of"):
+        query_engine_from_id("missing")
+
+
 def test_query_engine_from_id_wrong_type():
     with pytest.raises(ArgumentTypeError, match="is not a valid query engine"):
         query_engine_from_id("pathlib.Path")
@@ -181,6 +186,11 @@ class DummyBackend:
 def test_backend_from_id():
     engine_id = f"{DummyBackend.__module__}.{DummyBackend.__name__}"
     assert backend_from_id(engine_id) is DummyBackend
+
+
+def test_backend_from_id_missing_alias():
+    with pytest.raises(ArgumentTypeError, match="must be one of"):
+        backend_from_id("missing")
 
 
 def test_backend_from_id_wrong_type():

--- a/tests/unit/test___main__.py
+++ b/tests/unit/test___main__.py
@@ -98,7 +98,6 @@ def test_generate_measures(mocker, tmp_path):
     dataset_definition_path.touch()
     argv = [
         "generate-measures",
-        "--dataset-definition",
         str(dataset_definition_path),
     ]
     main(argv)

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1,7 +1,7 @@
 import dataclasses
 
 from databuilder.main import get_query_engine, open_output_file
-from databuilder.query_engines.sqlite import SQLiteQueryEngine
+from databuilder.query_engines.csv import CSVQueryEngine
 
 
 @dataclasses.dataclass
@@ -17,15 +17,14 @@ class DummyBackend:
 
 def test_get_query_engine_defaults():
     query_engine = get_query_engine(
-        dsn=None, backend_id=None, query_engine_id=None, environ={}
+        dsn=None, backend_class=None, query_engine_class=None, environ={}
     )
-    assert isinstance(query_engine, SQLiteQueryEngine)
+    assert isinstance(query_engine, CSVQueryEngine)
 
 
 def test_get_query_engine_with_query_engine():
-    query_engine_id = f"{DummyQueryEngine.__module__}.{DummyQueryEngine.__name__}"
     query_engine = get_query_engine(
-        dsn=None, backend_id=None, query_engine_id=query_engine_id, environ={}
+        dsn=None, backend_class=None, query_engine_class=DummyQueryEngine, environ={}
     )
     assert isinstance(query_engine, DummyQueryEngine)
     assert query_engine.backend is None
@@ -33,9 +32,8 @@ def test_get_query_engine_with_query_engine():
 
 
 def test_get_query_engine_with_backend():
-    backend_id = f"{DummyBackend.__module__}.{DummyBackend.__name__}"
     query_engine = get_query_engine(
-        dsn=None, backend_id=backend_id, query_engine_id=None, environ={}
+        dsn=None, backend_class=DummyBackend, query_engine_class=None, environ={}
     )
     assert isinstance(query_engine, DummyQueryEngine)
     assert isinstance(query_engine.backend, DummyBackend)
@@ -43,12 +41,13 @@ def test_get_query_engine_with_backend():
 
 
 def test_get_query_engine_with_backend_and_query_engine():
-    backend_id = f"{DummyBackend.__module__}.{DummyBackend.__name__}"
-    query_engine_id = "databuilder.query_engines.sqlite.SQLiteQueryEngine"
     query_engine = get_query_engine(
-        dsn=None, backend_id=backend_id, query_engine_id=query_engine_id, environ={}
+        dsn=None,
+        backend_class=DummyBackend,
+        query_engine_class=CSVQueryEngine,
+        environ={},
     )
-    assert isinstance(query_engine, SQLiteQueryEngine)
+    assert isinstance(query_engine, CSVQueryEngine)
     assert isinstance(query_engine.backend, DummyBackend)
     assert query_engine.config == {}
 


### PR DESCRIPTION
This PR is a bit of a grab bag of various things. See the commit sequence for the full details, but the highlights are:
 * Fix package script entrypoint so you can run `databuilder ...` locally instead of `python -m databuilder ...`.
   Note: you'll need to run `pip install --editable .` first.
 * Do away with `--dataset-definition` so you can just write: `generate-dataset path/to/file.py`.
 * Add `--query-engine` and `--backend` arguments to `generate-dataset` so you don't have to use environment variables.
 * Add a `--dsn` argument to `--generate-dataset` instead of having to set `DATABASE_URL`. 
 * Write CSV to stdout by default if no `--output` argument is supplied.
 * Raise helpful errors if you supply the wrong thing to `--backend` or `--query-engine` (see [#566](https://github.com/opensafely-core/databuilder/issues/566)).
 * Add short aliases for the bundled backends and query engines so you don't have to specify the full dottted path every time.
 * List the available backends and query engines in help/error messages (see [#646](https://github.com/opensafely-core/databuilder/issues/646)).

The upshot is that you should hopefully be able to generate a dataset using the local CSV engine with just:

    databuilder generate-dataset path/to/file.py --dsn path/to/csvs

And you could see the SQL that will be run against the TPP backend using:

    databuilder dump-dataset-sql path/to/file.py --backend tpp