### PR TITLE
fix: Handle NULLs and bools correctly in CSV engine

### DIFF
--- a/databuilder/sqlalchemy_types.py
+++ b/databuilder/sqlalchemy_types.py
@@ -45,7 +45,6 @@ class DateTime(sqlalchemy.types.TypeDecorator):
 TYPE_MAP = {
     bool: Boolean,
     datetime.date: Date,
-    datetime.datetime: DateTime,
     float: Float,
     int: Integer,
     str: Text,

--- a/tests/integration/query_engines/test_csv.py
+++ b/tests/integration/query_engines/test_csv.py
@@ -7,7 +7,7 @@ from sqlalchemy.orm import Session, declarative_base
 from databuilder.ehrql import Dataset
 from databuilder.query_engines.csv import CSVQueryEngine, orm_instances_from_csv_lines
 from databuilder.query_language import compile
-from databuilder.sqlalchemy_types import Integer, type_from_python_type
+from databuilder.sqlalchemy_types import TYPE_MAP, Integer, type_from_python_type
 from databuilder.tables import EventFrame, PatientFrame, Series, table
 
 
@@ -123,3 +123,11 @@ def test_orm_instances_from_csv_lines(type_, csv_value, expected_value):
         result = session.query(Model.value).scalar()
 
     assert result == expected_value
+
+
+def test_orm_instances_from_csv_lines_params_are_exhaustive():
+    # This is dirty but useful, I think. It checks that the parameters to the test
+    # include at least one of every type in `sqlalchemy_types`.
+    params = test_orm_instances_from_csv_lines.pytestmark[0].args[1]
+    types = [arg[0] for arg in params]
+    assert set(types) == set(TYPE_MAP)

--- a/tests/integration/query_engines/test_csv.py
+++ b/tests/integration/query_engines/test_csv.py
@@ -1,8 +1,13 @@
 import datetime
 
+import pytest
+import sqlalchemy
+from sqlalchemy.orm import Session, declarative_base
+
 from databuilder.ehrql import Dataset
-from databuilder.query_engines.csv import CSVQueryEngine
+from databuilder.query_engines.csv import CSVQueryEngine, orm_instances_from_csv_lines
 from databuilder.query_language import compile
+from databuilder.sqlalchemy_types import Integer, type_from_python_type
 from databuilder.tables import EventFrame, PatientFrame, Series, table
 
 
@@ -12,21 +17,22 @@ def test_csv_query_engine(tmp_path):
             [
                 # Columns like `extra_column` which aren't in the schema should just be
                 # ignored
-                "patient_id,sex,top_score,extra_column",
-                "1,M,100,a",
-                "2,F,200,b",
+                "patient_id,sex,extra_column",
+                "1,M,a",
+                "2,F,b",
+                "3,,",
             ]
         ),
     )
     tmp_path.joinpath("events.csv").write_text(
         "\n".join(
             [
-                "patient_id,date,code",
-                "1,2000-01-01,abc",
-                "1,2000-02-01,def",
-                "1,2000-03-01,def",
-                "2,2001-01-01,abc",
-                "2,2001-02-01,def",
+                "patient_id,score",
+                "1,2",
+                "1,3",
+                "1,4",
+                "2,5",
+                "2,10",
             ]
         ),
     )
@@ -34,22 +40,16 @@ def test_csv_query_engine(tmp_path):
     @table
     class patients(PatientFrame):
         sex = Series(str)
-        top_score = Series(int)
 
     @table
     class events(EventFrame):
-        date = Series(datetime.date)
-        code = Series(str)
+        score = Series(int)
         # Columns in the schema which aren't in the CSV should just end up NULL
         expected_missing = Series(bool)
 
     dataset = Dataset()
     dataset.sex = patients.sex
-    # Check that ints are imported correctly as ints
-    dataset.score = patients.top_score + 1000
-    dataset.latest_abc = (
-        events.take(events.code == "def").sort_by(events.date).first_for_patient().date
-    )
+    dataset.total_score = events.score.sum_for_patient()
     # Check that missing columns end up NULL
     dataset.missing = events.take(events.expected_missing.is_null()).count_for_patient()
 
@@ -60,8 +60,9 @@ def test_csv_query_engine(tmp_path):
     results = query_engine.get_results(variable_definitions)
 
     assert list(results) == [
-        (1, "M", 1100, datetime.date(2000, 2, 1), 3),
-        (2, "F", 1200, datetime.date(2001, 2, 1), 2),
+        (1, "M", 9, 3),
+        (2, "F", 15, 2),
+        (3, None, None, 0),
     ]
 
 
@@ -89,3 +90,36 @@ def test_csv_query_engine_create_missing(tmp_path):
 
     assert tmp_path.joinpath("patients.csv").read_text() == "patient_id,sex\n"
     assert tmp_path.joinpath("events.csv").read_text() == "patient_id,date,code\n"
+
+
+@pytest.mark.parametrize(
+    "type_,csv_value,expected_value",
+    [
+        (bool, '""', None),
+        (bool, "0", False),
+        (bool, "1", True),
+        (int, "123", 123),
+        (float, "1.23", 1.23),
+        (str, "foo", "foo"),
+        (datetime.date, "2020-10-20", datetime.date(2020, 10, 20)),
+    ],
+)
+def test_orm_instances_from_csv_lines(type_, csv_value, expected_value):
+    column_type = type_from_python_type(type_)
+
+    class Model(declarative_base()):
+        __tablename__ = "test"
+        pk = sqlalchemy.Column(Integer(), primary_key=True)
+        value = sqlalchemy.Column(column_type)
+
+    csv_lines = ["value", csv_value]
+    instances = orm_instances_from_csv_lines(Model, csv_lines)
+
+    engine = CSVQueryEngine(None).engine
+    Model.metadata.create_all(engine)
+    with Session(engine) as session:
+        session.add_all(instances)
+        session.flush()
+        result = session.query(Model.value).scalar()
+
+    assert result == expected_value

--- a/tests/unit/test_sqlalchemy_types.py
+++ b/tests/unit/test_sqlalchemy_types.py
@@ -12,7 +12,6 @@ from databuilder.sqlalchemy_types import type_from_python_type
     [
         (bool, types.Boolean),
         (datetime.date, types.Date),
-        (datetime.datetime, types.DateTime),
         (float, types.Float),
         (int, types.Integer),
         (str, types.Text),


### PR DESCRIPTION
As well as fixing this specific issue it adds a check that our tests cover all the supported "primitive" types, which would have caught this problem earlier.

This check involves a bit of reaching in to pytests's internals but I think the ick-factor is worth it here. There are multiple places in the codebase where we have to specifically handle these different types, and I want to cover them all using this pattern so that if we ever add new types we'll know immediately what needs changing.

Closes #684