### PR TITLE
Add error checking to load_definition function

### DIFF
--- a/databuilder/main.py
+++ b/databuilder/main.py
@@ -148,9 +148,8 @@ def load_definition(definition_file):
             if exc_tb.tb_frame.f_globals["__name__"] == "dataset":
                 print(f"Error Type: {exc_type}")
                 print(f"File: {exc_tb.tb_frame.f_code.co_filename}")
-                print(
-                    f"Line number {exc_tb.tb_frame.f_code.co_firstlineno}: {exc_value}"
-                )
+                print(f"Line number {exc_tb.tb_lineno}: {exc_value}")
+                sys.exit(2)
             exc_tb = exc_tb.tb_next
         sys.exit(2)
 

--- a/databuilder/main.py
+++ b/databuilder/main.py
@@ -144,14 +144,22 @@ def load_definition(definition_file):
         module = load_module(definition_file)
     except Exception:
         exc_type, exc_value, exc_tb = sys.exc_info()
+
+        print("Traceback (most recent call last):")
         while exc_tb:
+            # this comes from the load_module() func and ties it to the dataset module
             if exc_tb.tb_frame.f_globals["__name__"] == "dataset":
-                print(f"Error Type: {exc_type}")
-                print(f"File: {exc_tb.tb_frame.f_code.co_filename}")
-                print(f"Line number {exc_tb.tb_lineno}: {exc_value}")
-                sys.exit(2)
+                print(
+                    f"File {exc_tb.tb_frame.f_code.co_filename}, line {exc_tb.tb_lineno}, in {exc_tb.tb_frame.f_code.co_name}"
+                )
+                if exc_tb.tb_next.tb_frame.f_globals["__name__"] is not None:
+                    print(f"{exc_type.__name__}: {exc_value}")
+                    # force an exit at the end of traceback from dataset
+                    sys.exit(1)
+                else:
+                    print(f"  {exc_tb.tb_next.tb_frame.f_code.co_name}")
             exc_tb = exc_tb.tb_next
-        sys.exit(2)
+        sys.exit(1)
 
     try:
         dataset = module.dataset

--- a/databuilder/main.py
+++ b/databuilder/main.py
@@ -140,11 +140,25 @@ def test_connection(backend_class, url, environ):
 
 
 def load_definition(definition_file):
-    module = load_module(definition_file)
+    try:
+        module = load_module(definition_file)
+    except Exception:
+        exc_type, exc_value, exc_tb = sys.exc_info()
+        while exc_tb:
+            if exc_tb.tb_frame.f_globals["__name__"] == "dataset":
+                print(f"Error Type: {exc_type}")
+                print(f"File: {exc_tb.tb_frame.f_code.co_filename}")
+                print(
+                    f"Line number {exc_tb.tb_frame.f_code.co_firstlineno}: {exc_value}"
+                )
+            exc_tb = exc_tb.tb_next
+        sys.exit(2)
+
     try:
         dataset = module.dataset
     except AttributeError:
         raise AttributeError("A dataset definition must define one 'dataset'")
+
     assert isinstance(
         dataset, Dataset
     ), "'dataset' must be an instance of databuilder.query_language.Dataset()"


### PR DESCRIPTION
This is a replacement of #609 

This [ticket](#533) involves returning sensible and useful error messages to the user when they type in a command such as `python -m databuilder generate-dataset dataset_definition.py --dsn csvs`. This changes aims to pick up code that is incorrect in the dataset-definition python file -in this case, `dataset_definition.py`. 

We discussed as a team and decided that we wanted a partial traceback that started with the user input and missed out the error being propagated through multiple internal functions with the databuilder architecture. It was not enough however to just take the last 2-3 lines of the traceback however as the error could be within a function defined in the data definition file.

The sorts of error we might see in a dataset-definition file include:

- Variable does not exist

`dataset_definition.py`
```python
asdf
```

- Incorrect dataset construction

`dataset_definition.py`
```python
from databuilder.query_language import Dataset, build_patient_table

table = build_patient_table("table", {"i": int, "b": bool})

dataset = Dataset()
dataset.v = table.i + table.b
```

## What I have done
Thanks to the previous review by @evansd, I have moved the code into `load_definition(). The code then walks the traceback stack until it finds one where the origin is from the dataset code. 

This allows the following message to print to the screen (respectively as above):

```bash
Error Type: <class 'NameError'>
File: dataset_definition.py
Line number 1: name 'asdf' is not defined
```

```bash
Error Type: <class 'ImportError'>
File: dataset_definition.py
Line number 1: cannot import name 'build_patient_table' from 'databuilder.query_language' (/Users/carolinemorton/Documents/Datalab-Github/databuilder/databuilder/query_language.py)
```