### PR TITLE
Raise error if a column on a dataset is reassigned

### DIFF
--- a/databuilder/query_language.py
+++ b/databuilder/query_language.py
@@ -36,6 +36,8 @@ class Dataset:
             raise AttributeError(
                 "Cannot set column 'population'; use set_population() instead"
             )
+        if getattr(self, name, None):
+            raise AttributeError(f"'{name}' is already set and cannot be reassigned")
         if not qm.has_one_row_per_patient(value.qm_node):
             raise TypeError(
                 f"Invalid column '{name}'. Dataset columns must return one row per patient"

--- a/databuilder/query_language.py
+++ b/databuilder/query_language.py
@@ -32,9 +32,14 @@ class Dataset:
         object.__setattr__(self, "population", population)
 
     def __setattr__(self, name, value):
-        # TODO raise proper errors here
-        assert name != "population"
-        assert qm.has_one_row_per_patient(value.qm_node), value.qm_node
+        if name == "population":
+            raise AttributeError(
+                "Cannot set column 'population'; use set_population() instead"
+            )
+        if not qm.has_one_row_per_patient(value.qm_node):
+            raise TypeError(
+                f"Invalid column '{name}'. Dataset columns must return one row per patient"
+            )
         super().__setattr__(name, value)
 
 

--- a/tests/unit/test_query_language.py
+++ b/tests/unit/test_query_language.py
@@ -28,6 +28,8 @@ from databuilder.query_model import (
 
 patients_schema = TableSchema(date_of_birth=date)
 patients = PatientFrame(SelectPatientTable("patients", patients_schema))
+events_schema = TableSchema(event_date=date)
+events = EventFrame(SelectTable("coded_events", events_schema))
 
 
 def test_dataset():
@@ -64,6 +66,19 @@ def test_dataset_preserves_variable_order():
 
     variables = list(compile(dataset).keys())
     assert variables == ["population", "foo", "baz", "bar"]
+
+
+def test_assign_population_variable():
+    dataset = Dataset()
+    with pytest.raises(AttributeError, match="Cannot set column 'population'"):
+        dataset.population = patients.exists_for_patient()
+
+
+def test_cannot_assign_frame_to_column():
+    dataset = Dataset()
+    dataset.set_population(patients.exists_for_patient())
+    with pytest.raises(TypeError, match="Invalid column 'event_date'"):
+        dataset.event_date = events.event_date
 
 
 # The problem: We'd like to test that operations on query language (QL) elements return

--- a/tests/unit/test_query_language.py
+++ b/tests/unit/test_query_language.py
@@ -74,6 +74,14 @@ def test_assign_population_variable():
         dataset.population = patients.exists_for_patient()
 
 
+def test_cannot_reassign_dataset_column():
+    dataset = Dataset()
+    dataset.set_population(patients.exists_for_patient())
+    dataset.foo = patients.date_of_birth.year
+    with pytest.raises(AttributeError, match="already set"):
+        dataset.foo = patients.date_of_birth.year + 100
+
+
 def test_cannot_assign_frame_to_column():
     dataset = Dataset()
     dataset.set_population(patients.exists_for_patient())


### PR DESCRIPTION
Fixes #617 

Raise an error to avoid users accidentally reassigning an existing column on a dataset. 

Also raises some more explanatory error messages for other invalid column assignments that were just being `assert`ed before - trying to set a column named `population` (instead of using `set_population()` and assigning a node with >1 row per patient as a column.