### PR TITLE
feat: Add placeholder tutorial tables

### DIFF
--- a/databuilder/tables/examples/tutorial.py
+++ b/databuilder/tables/examples/tutorial.py
@@ -1,0 +1,15 @@
+from databuilder.contracts.universal import patients
+from databuilder.contracts.wip import (
+    clinical_events,
+    hospitalisations,
+    patient_address,
+    prescriptions,
+)
+
+__all__ = [
+    "clinical_events",
+    "hospitalisations",
+    "patient_address",
+    "patients",
+    "prescriptions",
+]


### PR DESCRIPTION
This PR makes the `import` statements required in the documentation tutorial code work available.

It seems a reasonable time to introduce them now, though they may change or even be separated out from the existing contracts in future[^1], because:

* the addition to the existing code is small and self-contained
* merging should permit easier running of tutorial code either via the released Docker image and OpenSAFELY CLI (pending changes to the examples)

[^1]: We _might_ want to separate in future to insulate the tutorial from changes to existing contracts (which is likely). I'm undecided right now, and this isn't an immediate problem.