### PR TITLE
Add public namespaces

### DIFF
--- a/databuilder/contracts/universal.py
+++ b/databuilder/contracts/universal.py
@@ -1,11 +1,12 @@
 import datetime
 
-from databuilder.query_language import PatientFrame, Series, table
-
-from .constraints import (
+from databuilder.tables import (
     CategoricalConstraint,
     FirstOfMonthConstraint,
     NotNullConstraint,
+    PatientFrame,
+    Series,
+    table,
 )
 
 __all__ = ["patients"]

--- a/databuilder/contracts/wip.py
+++ b/databuilder/contracts/wip.py
@@ -1,11 +1,13 @@
 import datetime
 
-from databuilder.query_language import EventFrame, PatientFrame, Series, table
-
-from .constraints import (
+from databuilder.tables import (
     CategoricalConstraint,
+    EventFrame,
     FirstOfMonthConstraint,
     NotNullConstraint,
+    PatientFrame,
+    Series,
+    table,
 )
 
 

--- a/databuilder/ehrql.py
+++ b/databuilder/ehrql.py
@@ -1,0 +1,9 @@
+from databuilder.codes import codelist_from_csv
+from databuilder.query_language import Dataset, case, when
+
+__all__ = [
+    "codelist_from_csv",
+    "Dataset",
+    "case",
+    "when",
+]

--- a/databuilder/main.py
+++ b/databuilder/main.py
@@ -9,10 +9,9 @@ import structlog
 
 from databuilder.column_specs import get_column_specs
 from databuilder.itertools_utils import eager_iterator
-from databuilder.query_language import Dataset
+from databuilder.query_language import Dataset, compile
 from databuilder.sqlalchemy_utils import clause_as_str, get_setup_and_cleanup_queries
 
-from . import query_language as ql
 from .validate_dummy_data import validate_dummy_data_file, validate_file_types_match
 
 log = structlog.getLogger()
@@ -30,7 +29,7 @@ def generate_dataset(
 
     log.info(f"Generating dataset for {str(definition_file)}")
     dataset_definition = load_definition(definition_file)
-    variable_definitions = ql.compile(dataset_definition)
+    variable_definitions = compile(dataset_definition)
     column_specs = get_column_specs(variable_definitions)
 
     query_engine = get_query_engine(dsn, backend_class, query_engine_class, environ)
@@ -62,7 +61,7 @@ def dump_dataset_sql(
     dataset_definition = load_definition(definition_file)
     query_engine = get_query_engine(None, backend_class, query_engine_class, environ)
 
-    variable_definitions = ql.compile(dataset_definition)
+    variable_definitions = compile(dataset_definition)
     all_query_strings = get_sql_strings(query_engine, variable_definitions)
     log.info("SQL generation succeeded")
 

--- a/databuilder/main.py
+++ b/databuilder/main.py
@@ -146,7 +146,7 @@ def load_definition(definition_file):
         raise AttributeError("A dataset definition must define one 'dataset'")
     assert isinstance(
         dataset, Dataset
-    ), "'dataset' must be an instance of databuilder.query_language.Dataset()"
+    ), "'dataset' must be an instance of databuilder.ehrql.Dataset()"
     return dataset
 
 

--- a/databuilder/tables/__init__.py
+++ b/databuilder/tables/__init__.py
@@ -1,12 +1,27 @@
-# TODO: This should probably be removed altogether but it's being used by the test
-# study, and possibly by other example code others have written so I don't now is quite
-# the right time to remove it.
-# [1]: https://github.com/opensafely/test-age-distribution
 import datetime
 
-from databuilder.query_language import PatientFrame, Series, table
+from databuilder.contracts.constraints import (
+    CategoricalConstraint,
+    FirstOfMonthConstraint,
+    NotNullConstraint,
+    UniqueConstraint,
+)
+from databuilder.query_language import EventFrame, PatientFrame, Series, table
+
+__all__ = [
+    "CategoricalConstraint",
+    "FirstOfMonthConstraint",
+    "NotNullConstraint",
+    "UniqueConstraint",
+    "EventFrame",
+    "PatientFrame",
+    "Series",
+    "table",
+]
 
 
+# TODO: This is destined for removal see:
+# https://github.com/opensafely-core/databuilder/issues/701
 @table
 class patients(PatientFrame):
     date_of_birth = Series(datetime.date)

--- a/databuilder/validate_dummy_data.py
+++ b/databuilder/validate_dummy_data.py
@@ -3,8 +3,8 @@ import datetime
 import functools
 import gzip
 
-from databuilder import query_language as ql
 from databuilder.column_specs import get_column_specs
+from databuilder.query_language import compile
 
 
 class ValidationError(Exception):
@@ -22,7 +22,7 @@ def validate_file_types_match(dummy_filename, output_filename):
 
 
 def validate_dummy_data_file(dataset_definition, filename):
-    variable_definitions = ql.compile(dataset_definition)
+    variable_definitions = compile(dataset_definition)
     column_specs = get_column_specs(variable_definitions)
 
     file_type, gzipped = get_file_type(filename)

--- a/tests/acceptance/comparative_booster_study/dataset_definition.py
+++ b/tests/acceptance/comparative_booster_study/dataset_definition.py
@@ -1,7 +1,7 @@
 import json
 from pathlib import Path
 
-from databuilder.query_language import Dataset, case, when
+from databuilder.ehrql import Dataset, case, when
 
 from . import codelists, schema
 from .codelists import combine_codelists

--- a/tests/acceptance/comparative_booster_study/schema.py
+++ b/tests/acceptance/comparative_booster_study/schema.py
@@ -4,7 +4,7 @@ import sqlalchemy.orm
 
 from databuilder.codes import CTV3Code, ICD10Code, SNOMEDCTCode
 from databuilder.orm_factory import orm_class_from_ql_table
-from databuilder.query_language import EventFrame, PatientFrame, Series, table
+from databuilder.tables import EventFrame, PatientFrame, Series, table
 
 Base = sqlalchemy.orm.declarative_base()
 

--- a/tests/acceptance/comparative_booster_study/test_variables_lib.py
+++ b/tests/acceptance/comparative_booster_study/test_variables_lib.py
@@ -4,8 +4,9 @@ from types import SimpleNamespace
 import pytest
 import sqlalchemy.orm
 
+from databuilder.ehrql import Dataset
 from databuilder.orm_factory import orm_class_from_ql_table
-from databuilder.query_language import Dataset, EventFrame, Series, table
+from databuilder.query_language import EventFrame, Series, table
 
 from .variables_lib import create_sequential_variables
 

--- a/tests/acceptance/comparative_booster_study/variables_lib.py
+++ b/tests/acceptance/comparative_booster_study/variables_lib.py
@@ -2,7 +2,7 @@ import operator
 from functools import reduce
 
 from databuilder.codes import CTV3Code, ICD10Code
-from databuilder.query_language import case, when
+from databuilder.ehrql import case, when
 
 from . import schema
 

--- a/tests/acceptance/test_embedded_study.py
+++ b/tests/acceptance/test_embedded_study.py
@@ -76,7 +76,7 @@ def test_dump_dataset_sql_attribute_invalid(study, mssql_database):
     study.setup_from_string(invalid_dataset_attribute_dataset_definition)
     with pytest.raises(
         AssertionError,
-        match="'dataset' must be an instance of databuilder.query_language.Dataset()",
+        match="'dataset' must be an instance of databuilder.ehrql.Dataset()",
     ):
         study.dump_dataset_sql()
 

--- a/tests/integration/backends/test_base.py
+++ b/tests/integration/backends/test_base.py
@@ -7,7 +7,7 @@ from databuilder import sqlalchemy_types
 from databuilder.backends.base import BaseBackend, MappedTable, QueryTable
 from databuilder.ehrql import Dataset
 from databuilder.query_engines.base_sql import BaseSQLQueryEngine
-from databuilder.query_language import EventFrame, PatientFrame, Series, table
+from databuilder.tables import EventFrame, PatientFrame, Series, table
 
 # Generate an integer sequence to use as default IDs. Normally you'd rely on the DBMS to
 # provide these, but we need to support DBMSs like Spark which don't have this feature.

--- a/tests/integration/backends/test_base.py
+++ b/tests/integration/backends/test_base.py
@@ -5,8 +5,9 @@ import sqlalchemy
 
 from databuilder import sqlalchemy_types
 from databuilder.backends.base import BaseBackend, MappedTable, QueryTable
+from databuilder.ehrql import Dataset
 from databuilder.query_engines.base_sql import BaseSQLQueryEngine
-from databuilder.query_language import Dataset, EventFrame, PatientFrame, Series, table
+from databuilder.query_language import EventFrame, PatientFrame, Series, table
 
 # Generate an integer sequence to use as default IDs. Normally you'd rely on the DBMS to
 # provide these, but we need to support DBMSs like Spark which don't have this feature.

--- a/tests/integration/query_engines/test_csv.py
+++ b/tests/integration/query_engines/test_csv.py
@@ -2,7 +2,8 @@ import datetime
 
 from databuilder.ehrql import Dataset
 from databuilder.query_engines.csv import CSVQueryEngine
-from databuilder.query_language import EventFrame, PatientFrame, Series, compile, table
+from databuilder.query_language import compile
+from databuilder.tables import EventFrame, PatientFrame, Series, table
 
 
 def test_csv_query_engine(tmp_path):

--- a/tests/integration/query_engines/test_csv.py
+++ b/tests/integration/query_engines/test_csv.py
@@ -1,14 +1,8 @@
 import datetime
 
+from databuilder.ehrql import Dataset
 from databuilder.query_engines.csv import CSVQueryEngine
-from databuilder.query_language import (
-    Dataset,
-    EventFrame,
-    PatientFrame,
-    Series,
-    compile,
-    table,
-)
+from databuilder.query_language import EventFrame, PatientFrame, Series, compile, table
 
 
 def test_csv_query_engine(tmp_path):

--- a/tests/lib/fixtures.py
+++ b/tests/lib/fixtures.py
@@ -1,5 +1,5 @@
 trivial_dataset_definition = """
-from databuilder.query_language import Dataset
+from databuilder.ehrql import Dataset
 from databuilder.tables.beta.tpp import patients
 
 dataset = Dataset()
@@ -11,7 +11,7 @@ dataset.year = year
 invalid_dataset_definition = "this is nonsense"
 
 no_dataset_attribute_dataset_definition = """
-from databuilder.query_language import Dataset
+from databuilder.ehrql import Dataset
 from databuilder.tables.beta.tpp import patients
 
 my_dataset = Dataset()
@@ -20,7 +20,7 @@ my_dataset.set_population(year >= 1900)
 """
 
 invalid_dataset_attribute_dataset_definition = """
-from databuilder.query_language import Dataset
+from databuilder.ehrql import Dataset
 from databuilder.tables.beta.tpp import patients
 
 dataset = patients

--- a/tests/spec/case_expressions/test_case.py
+++ b/tests/spec/case_expressions/test_case.py
@@ -1,4 +1,4 @@
-from databuilder.query_language import case, when
+from databuilder.ehrql import case, when
 
 from ..tables import p
 

--- a/tests/spec/conftest.py
+++ b/tests/spec/conftest.py
@@ -2,7 +2,7 @@ import datetime
 
 import pytest
 
-from databuilder.query_language import Dataset
+from databuilder.ehrql import Dataset
 
 from . import tables
 

--- a/tests/spec/population/test_population.py
+++ b/tests/spec/population/test_population.py
@@ -1,4 +1,4 @@
-from databuilder.query_language import case, when
+from databuilder.ehrql import case, when
 
 from ..tables import e, p
 

--- a/tests/spec/tables.py
+++ b/tests/spec/tables.py
@@ -4,7 +4,7 @@ import sqlalchemy.orm
 
 from databuilder.codes import SNOMEDCTCode
 from databuilder.orm_factory import orm_class_from_ql_table
-from databuilder.query_language import EventFrame, PatientFrame, Series, table
+from databuilder.tables import EventFrame, PatientFrame, Series, table
 
 
 @table

--- a/tests/unit/backends/test_base.py
+++ b/tests/unit/backends/test_base.py
@@ -11,7 +11,7 @@ from databuilder.backends.base import (
     ValidationError,
 )
 from databuilder.query_engines.base_sql import BaseSQLQueryEngine
-from databuilder.query_language import PatientFrame, Series, table
+from databuilder.tables import PatientFrame, Series, table
 
 
 class TestBackend(BaseBackend):

--- a/tests/unit/test_tables.py
+++ b/tests/unit/test_tables.py
@@ -1,0 +1,17 @@
+from databuilder import tables
+from databuilder.contracts import constraints
+from databuilder.module_utils import is_proper_subclass
+
+
+def test_all_required_classes_are_exported():
+    # If we add a new Constraint we don't want to forget to make it available via
+    # `databuilder.tables`
+    all_constraints = [
+        cls
+        for cls in vars(constraints).values()
+        if is_proper_subclass(cls, constraints.BaseConstraint)
+    ]
+    for cls in all_constraints:
+        name = cls.__name__
+        assert name in tables.__all__
+        assert getattr(tables, name) is cls

--- a/tests/unit/test_validate_dummy_data.py
+++ b/tests/unit/test_validate_dummy_data.py
@@ -5,7 +5,8 @@ from pathlib import Path
 import pytest
 
 from databuilder.column_specs import ColumnSpec
-from databuilder.query_language import Dataset, PatientFrame, Series, table
+from databuilder.ehrql import Dataset
+from databuilder.query_language import PatientFrame, Series, table
 from databuilder.validate_dummy_data import (
     ValidationError,
     validate_csv_against_spec,

--- a/tests/unit/test_validate_dummy_data.py
+++ b/tests/unit/test_validate_dummy_data.py
@@ -6,7 +6,7 @@ import pytest
 
 from databuilder.column_specs import ColumnSpec
 from databuilder.ehrql import Dataset
-from databuilder.query_language import PatientFrame, Series, table
+from databuilder.tables import PatientFrame, Series, table
 from databuilder.validate_dummy_data import (
     ValidationError,
     validate_csv_against_spec,


### PR DESCRIPTION
This adds a `databuilder.ehrql` module which provides a "clean" namespace containing just those things users need in order to write dataset definitions.

Similarly, we add imports to `databuilder.tables` to provide the things necessary for defining tables and their constraints. This is less important as it's "provider-facing" rather than user-facing, but still worthwhile I think.

Codelist handling is still a bit of an open question (see #31) but whatever the final API I expect it to be available through `databuilder.ehrql`.

Closes #527