### PR TITLE
Build databuilder-dev with BuildKit

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -119,7 +119,7 @@ build-databuilder:
     set -euo pipefail
 
     [[ -v CI ]] && echo "::group::Build databuilder (click to view)" || echo "Build databuilder"
-    docker build . -t databuilder-dev
+    DOCKER_BUILDKIT=1 docker build . -t databuilder-dev
     [[ -v CI ]] && echo "::endgroup::" || echo ""
 
 


### PR DESCRIPTION
BuildKit is needed to bind-mount the .git directory, which in turn is needed to build the Python package.