### PR TITLE
Remove use of ONS deaths from dataset definition

### DIFF
--- a/tests/acceptance/comparative_booster_study/dataset_definition.py
+++ b/tests/acceptance/comparative_booster_study/dataset_definition.py
@@ -8,7 +8,6 @@ from .codelists import combine_codelists
 from .variables_lib import (
     address_as_of,
     age_as_of,
-    cause_of_death_matches,
     create_sequential_variables,
     date_deregistered_from_all_supported_practices,
     emergency_care_diagnosis_matches,
@@ -695,25 +694,15 @@ create_sequential_variables(
 )
 
 
-deaths = schema.ons_deaths
-dataset.coviddeath_date = cause_of_death_matches(
-    deaths, codelists.covid_icd10
-).date.maximum_for_patient()
-dataset.death_date = deaths.date.maximum_for_patient()
-
-
 #######################################################################################
 # Population
 #######################################################################################
 
 registered = practice_registration_as_of(baseline_date).exists_for_patient()
 
-has_died = deaths.take(deaths.date.is_on_or_before(baseline_date)).exists_for_patient()
-
 dataset.set_population(
     registered
     & (dataset.age_august2021 >= 18)
-    & ~has_died
     & boosted_date.is_on_or_after(studystart_date)
     & boosted_date.is_on_or_before(studyend_date)
 )

--- a/tests/acceptance/comparative_booster_study/variables_lib.py
+++ b/tests/acceptance/comparative_booster_study/variables_lib.py
@@ -96,14 +96,6 @@ def most_recent_bmi(*, minimum_age_at_measurement, where=True):
     )
 
 
-def cause_of_death_matches(deaths, codelist):
-    conditions = [
-        getattr(deaths, column_name).is_in(codelist)
-        for column_name in [f"cause_of_death_{i:02d}" for i in range(1, 16)]
-    ]
-    return deaths.take(any_of(conditions))
-
-
 def emergency_care_diagnosis_matches(emergency_care_attendances, codelist):
     conditions = [
         getattr(emergency_care_attendances, column_name).is_in(codelist)


### PR DESCRIPTION
Removes ONS deaths from `dataset_definition.py`
Fixes #690 

---

@evansd suggested that some references to ONS deaths can stay for now:

- [tests/acceptance/comparative_booster_study/schema.py](https://github.com/opensafely-core/databuilder/blob/300e09e45825748759f39df2ca34fbc84e21c0c9/tests/acceptance/comparative_booster_study/schema.py#L43-L64)
- [tests/acceptance/comparative_booster_study/tpp_schema.py](https://github.com/opensafely-core/databuilder/blob/300e09e45825748759f39df2ca34fbc84e21c0c9/tests/acceptance/comparative_booster_study/tpp_schema.py#L164-L166)
- [tests/acceptance/comparative_booster_study/tpp_backend.py](https://github.com/opensafely-core/databuilder/blob/300e09e45825748759f39df2ca34fbc84e21c0c9/tests/acceptance/comparative_booster_study/tpp_backend.py#L47-L53)