### PR TITLE
Revert "chore: bump mathieudutour/github-tag-action from 4.5 to 6.0"

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,7 +62,7 @@ jobs:
           fetch-depth: 0
       - name: Bump version and push tag
         id: tag
-        uses: mathieudutour/github-tag-action@d745f2e74aaf1ee82e747b181f7a0967978abee0
+        uses: mathieudutour/github-tag-action@981ffb2cc3f2b684b2bfd8ee17bc8d781368ba60
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           default_bump: false


### PR DESCRIPTION
Reverts opensafely-core/databuilder#689

Following this change, we had issues with tagging (#709).