### PR TITLE
Support ISO date strings in place of dates

### DIFF
--- a/databuilder/query_language.py
+++ b/databuilder/query_language.py
@@ -273,26 +273,38 @@ class DateFunctions(ComparableFunctions):
         return self.add_days(other.__neg__())
 
     def is_before(self, other):
-        other = parse_date_if_str(other)
-        return self < other
+        return self.__lt__(other)
 
     def is_on_or_before(self, other):
-        other = parse_date_if_str(other)
-        return self <= other
+        return self.__le__(other)
 
     def is_after(self, other):
-        other = parse_date_if_str(other)
-        return self > other
+        return self.__gt__(other)
 
     def is_on_or_after(self, other):
-        other = parse_date_if_str(other)
-        return self >= other
+        return self.__ge__(other)
 
     def to_first_of_year(self):
         return _apply(qm.Function.ToFirstOfYear, self)
 
     def to_first_of_month(self):
         return _apply(qm.Function.ToFirstOfMonth, self)
+
+    def __lt__(self, other):
+        other = parse_date_if_str(other)
+        return _apply(qm.Function.LT, self, other)
+
+    def __le__(self, other):
+        other = parse_date_if_str(other)
+        return _apply(qm.Function.LE, self, other)
+
+    def __ge__(self, other):
+        other = parse_date_if_str(other)
+        return _apply(qm.Function.GE, self, other)
+
+    def __gt__(self, other):
+        other = parse_date_if_str(other)
+        return _apply(qm.Function.GT, self, other)
 
 
 class DateAggregations(ComparableAggregations):

--- a/databuilder/query_language.py
+++ b/databuilder/query_language.py
@@ -306,6 +306,10 @@ class DateFunctions(ComparableFunctions):
         other = parse_date_if_str(other)
         return _apply(qm.Function.GT, self, other)
 
+    def __eq__(self, other):
+        other = parse_date_if_str(other)
+        return _apply(qm.Function.EQ, self, other)
+
 
 class DateAggregations(ComparableAggregations):
     "Empty for now"

--- a/tests/spec/date_series_ops/test_date_comparisons.py
+++ b/tests/spec/date_series_ops/test_date_comparisons.py
@@ -64,3 +64,55 @@ def test_is_on_or_after(spec_test):
             4: None,
         },
     )
+
+
+def test_is_before_with_str_date(spec_test):
+    spec_test(
+        table_data,
+        p.d1 < "2000-01-01",
+        {
+            1: True,
+            2: False,
+            3: False,
+            4: None,
+        },
+    )
+
+
+def test_is_on_or_before_with_str_date(spec_test):
+    spec_test(
+        table_data,
+        p.d1 <= "2000-01-01",
+        {
+            1: True,
+            2: True,
+            3: False,
+            4: None,
+        },
+    )
+
+
+def test_is_after_with_str_date(spec_test):
+    spec_test(
+        table_data,
+        p.d1 > "2000-01-01",
+        {
+            1: False,
+            2: False,
+            3: True,
+            4: None,
+        },
+    )
+
+
+def test_is_on_or_after_with_str_date(spec_test):
+    spec_test(
+        table_data,
+        p.d1 >= "2000-01-01",
+        {
+            1: False,
+            2: True,
+            3: True,
+            4: None,
+        },
+    )

--- a/tests/spec/date_series_ops/test_date_comparisons.py
+++ b/tests/spec/date_series_ops/test_date_comparisons.py
@@ -116,3 +116,16 @@ def test_is_on_or_after_with_str_date(spec_test):
             4: None,
         },
     )
+
+
+def test_is_equal_with_str_date(spec_test):
+    spec_test(
+        table_data,
+        p.d1 == "2000-01-01",
+        {
+            1: False,
+            2: True,
+            3: False,
+            4: None,
+        },
+    )


### PR DESCRIPTION
Addresses #618 

As discussed with @evansd, this adds the ability to use `<=, <, >, =>, ==` with dates. 

In terms of the original ticket, after discussion, the `is_in()` and `between()` methods need a little more thought and we decided they should have their own tickets. I will make and link to this PR. 