### PR TITLE
Support categorical variables

### DIFF
--- a/databuilder/backends/base.py
+++ b/databuilder/backends/base.py
@@ -87,7 +87,7 @@ class MappedTable(SQLTable):
         self.db_schema_name = schema
 
     def validate_against_table_schema(self, schema):
-        missing = set(schema) - set(self.column_map)
+        missing = set(schema.column_names) - set(self.column_map)
         if missing:
             raise ValidationError(f"missing columns: {', '.join(missing)}")
 
@@ -100,7 +100,7 @@ class MappedTable(SQLTable):
                 sqlalchemy.Column(
                     self.column_map[name], key=name, type_=type_from_python_type(type_)
                 )
-                for (name, type_) in schema.items()
+                for (name, type_) in schema.column_types
             ],
             schema=self.db_schema_name,
         )
@@ -115,7 +115,7 @@ class QueryTable(SQLTable):
         # This is a very crude form of validation: we just check that the SQL string
         # contains each of the column names as words. But without actually executing the
         # SQL we can't know what it returns
-        columns = ["patient_id", *schema.keys()]
+        columns = ["patient_id", *schema.column_names]
         missing = [
             name
             for name in columns
@@ -130,7 +130,7 @@ class QueryTable(SQLTable):
         columns = [sqlalchemy.Column("patient_id")]
         columns.extend(
             sqlalchemy.Column(name, type_=type_from_python_type(type_))
-            for (name, type_) in schema.items()
+            for (name, type_) in schema.column_types
         )
         query = sqlalchemy.text(self.query).columns(*columns)
         return query.alias(table_name)
@@ -146,7 +146,7 @@ class DefaultBackend:
             sqlalchemy.Column("patient_id"),
             *[
                 sqlalchemy.Column(name, type_=type_from_python_type(type_))
-                for (name, type_) in schema.items()
+                for (name, type_) in schema.column_types
             ],
         )
 

--- a/databuilder/column_specs.py
+++ b/databuilder/column_specs.py
@@ -19,6 +19,8 @@ class ColumnSpec:
     type: type[T]  # noqa: A003
     nullable: bool = True
     categories: Optional[tuple[T]] = None
+    min_value: Optional[T] = None
+    max_value: Optional[T] = None
 
 
 def get_column_specs(variable_definitions):
@@ -35,11 +37,18 @@ def get_column_specs(variable_definitions):
             continue
         type_ = get_series_type(series)
         categories = get_categories(series)
+        min_value, max_value = get_range(series)
         if hasattr(type_, "_primitive_type"):
             type_ = type_._primitive_type()
             if categories:
                 categories = tuple(c._to_primitive_type() for c in categories)
-        column_specs[name] = ColumnSpec(type_, nullable=True, categories=categories)
+        column_specs[name] = ColumnSpec(
+            type_,
+            nullable=True,
+            categories=categories,
+            min_value=min_value,
+            max_value=max_value,
+        )
     return column_specs
 
 
@@ -88,3 +97,9 @@ def get_categories_for_case(series):
         all_categories.extend(categories)
     # De-duplicate categories while maintaining their original order
     return tuple(dict.fromkeys(all_categories).keys())
+
+
+@singledispatch
+def get_range(series):
+    # For most operations we don't even try to determine the numerical range
+    return None, None

--- a/databuilder/column_specs.py
+++ b/databuilder/column_specs.py
@@ -103,3 +103,12 @@ def get_categories_for_case(series):
 def get_range(series):
     # For most operations we don't even try to determine the numerical range
     return None, None
+
+
+@get_range.register(AggregateByPatient.Count)
+def get_range_for_count(series):
+    # Per-patient row counts can never be negative and we think 65,535 is a reasonable
+    # upper bound, meaning they can be stored in a 16-bit unsigned int, thus reducing
+    # memory pressure. For counts anywhere near this high the user should be classifying
+    # them into buckets rather than retrieving the raw numbers in any case.
+    return 0, 2**16 - 1

--- a/databuilder/column_specs.py
+++ b/databuilder/column_specs.py
@@ -1,12 +1,22 @@
 import dataclasses
+from functools import singledispatch
+from typing import Optional, TypeVar
 
-from databuilder.query_model import get_series_type
+from databuilder.query_model import (
+    AggregateByPatient,
+    SelectColumn,
+    get_root_frame,
+    get_series_type,
+)
+
+T = TypeVar("T")
 
 
 @dataclasses.dataclass(frozen=True)
 class ColumnSpec:
-    type: type  # noqa: A003
+    type: type[T]  # noqa: A003
     nullable: bool = True
+    categories: Optional[tuple[T]] = None
 
 
 def get_column_specs(variable_definitions):
@@ -22,7 +32,32 @@ def get_column_specs(variable_definitions):
         if name == "population":
             continue
         type_ = get_series_type(series)
+        categories = get_categories(series)
         if hasattr(type_, "_primitive_type"):
             type_ = type_._primitive_type()
-        column_specs[name] = ColumnSpec(type_, nullable=True)
+            if categories:
+                categories = tuple(c._to_primitive_type() for c in categories)
+        column_specs[name] = ColumnSpec(type_, nullable=True, categories=categories)
     return column_specs
+
+
+@singledispatch
+def get_categories(series):
+    # As a default, we assume that operations destroy category information and then
+    # define specific implementations for operations which preserve categories
+    return None
+
+
+@get_categories.register(SelectColumn)
+def get_categories_for_select_column(series):
+    # When selecting a column we can ask the underlying table schema for the
+    # corresponding categories
+    root = get_root_frame(series.source)
+    return root.schema.get_column_categories(series.name)
+
+
+@get_categories.register(AggregateByPatient.Min)
+@get_categories.register(AggregateByPatient.Max)
+def get_categories_for_min_max(series):
+    # The min/max aggregations preserve the categories of their inputs
+    return get_categories(series.source)

--- a/databuilder/file_formats/arrow.py
+++ b/databuilder/file_formats/arrow.py
@@ -126,18 +126,31 @@ def batch_and_transpose(iterable, batch_size):
 
 def validate_dataset_arrow(filename, column_specs):
     target_schema, _ = get_schema_and_convertor(column_specs)
-    file_schema = read_schema_from_file(filename)
-    validate_headers(file_schema.names, target_schema.names)
-    if not file_schema.equals(target_schema):
+    # Arrow enforces that all record batches have a consistent schema and that any
+    # categorical columns use the same dictionary, so we only need to get the first
+    # batch in order to validate
+    batch = get_first_record_batch_from_file(filename)
+    validate_headers(batch.schema.names, target_schema.names)
+    if not batch.schema.equals(target_schema):
         # This isn't most user-friendly error message, but it will do for now
         raise ValidationError(
             f"File does not have expected schema\n\n"
-            f"Schema:\n{file_schema.to_string()}\n\n"
+            f"Schema:\n{batch.schema.to_string()}\n\n"
             f"Expected:\n{target_schema.to_string()}"
         )
+    for name, spec in column_specs.items():
+        if spec.categories is None:
+            continue
+        column_categories = batch.column(name).dictionary.to_pylist()
+        if column_categories != list(spec.categories):
+            raise ValidationError(
+                f"Unexpected categories in column '{name}'\n"
+                f"Categories: {', '.join(column_categories)}\n"
+                f"Expected: {', '.join(spec.categories)}\n"
+            )
 
 
-def read_schema_from_file(filename):
+def get_first_record_batch_from_file(filename):
     with pyarrow.OSFile(str(filename), "rb") as f:
         with pyarrow.ipc.open_file(f) as reader:
-            return reader.schema
+            return reader.get_batch(0)

--- a/databuilder/file_formats/csv.py
+++ b/databuilder/file_formats/csv.py
@@ -109,6 +109,9 @@ def create_column_parser(headers, name, spec):
     else:
         assert False, f"Unhandled type: {spec.type}"
 
+    if spec.categories is not None:
+        convertor = validate_categories(convertor, spec.categories)
+
     index = headers.index(name)
 
     def parser(row):
@@ -136,3 +139,16 @@ def parse_bool(value):
         return False
     else:
         raise ValueError("invalid boolean, must be 'T' or 'F'")
+
+
+def validate_categories(convertor, categories):
+    category_set = frozenset(categories)
+    category_str = ", ".join(map(repr, categories))
+
+    def wrapper(value):
+        parsed = convertor(value)
+        if parsed not in category_set:
+            raise ValueError(f"{value!r} not in valid categories: {category_str}")
+        return parsed
+
+    return wrapper

--- a/databuilder/orm_factory.py
+++ b/databuilder/orm_factory.py
@@ -32,7 +32,7 @@ def orm_class_from_schema(base_class, table_name, schema, has_one_row_per_patien
             Integer, primary_key=True, default=next_id
         )
 
-    for col_name, type_ in schema.items():
+    for col_name, type_ in schema.column_types:
         attributes[col_name] = sqlalchemy.Column(
             type_from_python_type(type_), default=null
         )

--- a/databuilder/query_language.py
+++ b/databuilder/query_language.py
@@ -501,12 +501,12 @@ def table(cls):
     table_name = cls.__name__
     # Get all `Series` objects on the class and determine the schema from them
     schema = {
-        series.name: series.type_
+        series.name: qm.Column(series.type_)
         for series in vars(cls).values()
         if isinstance(series, Series)
     }
 
-    qm_node = qm_class(table_name, qm.TableSchema(schema))
+    qm_node = qm_class(table_name, qm.TableSchema(**schema))
     return cls(qm_node)
 
 

--- a/databuilder/query_model.py
+++ b/databuilder/query_model.py
@@ -35,6 +35,7 @@ __all__ = [
     "count_nodes",
     "node_types",
     "get_input_nodes",
+    "get_root_frame",
 ]
 
 
@@ -62,13 +63,14 @@ class Position(Enum):
 @dataclasses.dataclass(frozen=True)
 class Column:
     type_: type
+    categories: Optional[tuple] = None
 
     def __repr__(self):
         # Gives us `self == eval(repr(self))`
         module = self.type_.__module__
         prefix = f"{module}." if module != "builtins" else ""
         type_repr = f"{prefix}{self.type_.__name__}"
-        return f"{self.__class__.__name__}({type_repr})"
+        return f"{self.__class__.__name__}({type_repr}, categories={self.categories!r})"
 
 
 class TableSchema:
@@ -92,6 +94,9 @@ class TableSchema:
 
     def get_column_type(self, name):
         return self.schema[name].type_
+
+    def get_column_categories(self, name):
+        return self.schema[name].categories
 
     @property
     def column_names(self):

--- a/tests/generative/data_strategies.py
+++ b/tests/generative/data_strategies.py
@@ -14,7 +14,7 @@ def record(class_, id_strategy, schema, int_values, bool_values):
     # We don't construct the actual objects here because it's easier to extract stats for the generated data if we
     # pass around simple objects.
     columns = {patient_id_column: id_strategy}
-    for name, type_ in schema.items():
+    for name, type_ in schema.column_types:
         type_strategy = {int: int_values, bool: bool_values}[type_]
         columns[name] = type_strategy
 

--- a/tests/generative/test_query_model.py
+++ b/tests/generative/test_query_model.py
@@ -4,14 +4,14 @@ import hypothesis as hyp
 import hypothesis.strategies as st
 import pytest
 
-from databuilder.query_model import TableSchema
+from databuilder.query_model import Column, TableSchema
 
 from ..conftest import QUERY_ENGINE_NAMES, engine_factory
 from . import data_setup, data_strategies, variable_strategies
 from .conftest import count_nodes, observe_inputs
 
 # To simplify data generation, all tables have the same schema.
-schema = TableSchema(i1=int, i2=int, b1=bool, b2=bool)
+schema = TableSchema(i1=Column(int), i2=Column(int), b1=Column(bool), b2=Column(bool))
 (
     patient_classes,
     event_classes,

--- a/tests/generative/variable_strategies.py
+++ b/tests/generative/variable_strategies.py
@@ -147,7 +147,9 @@ def variable(patient_tables, event_tables, schema, int_values, bool_values):
         st.sampled_from(patient_tables),
         st.just(schema),
     )
-    select_column = qm_builds(SelectColumn, frame, st.sampled_from(list(schema.keys())))
+    select_column = qm_builds(
+        SelectColumn, frame, st.sampled_from(list(schema.column_names))
+    )
 
     filter_ = qm_builds(Filter, many_rows_per_patient_frame, series)
 

--- a/tests/integration/backends/test_tpp.py
+++ b/tests/integration/backends/test_tpp.py
@@ -4,7 +4,7 @@ import pytest
 import sqlalchemy
 
 from databuilder.backends.tpp import TPPBackend
-from databuilder.query_model import TableSchema
+from databuilder.query_model import Column, TableSchema
 from tests.lib.tpp_schema import apcs, patient
 
 
@@ -38,7 +38,7 @@ def test_hospitalization_table_code_conversion(mssql_database, raw, codes):
     )
 
     table = TPPBackend.hospitalizations.get_expression(
-        "hospitalizations", TableSchema(code=str)
+        "hospitalizations", TableSchema(code=Column(str))
     )
     query = sqlalchemy.select(table.c.code)
 
@@ -60,7 +60,10 @@ def test_patients_contract_table(mssql_database):
     )
 
     table = TPPBackend.patients.get_expression(
-        "patients", TableSchema(date_of_birth=date, date_of_death=date, sex=str)
+        "patients",
+        TableSchema(
+            date_of_birth=Column(date), date_of_death=Column(date), sex=Column(str)
+        ),
     )
     query = sqlalchemy.select(
         table.c.patient_id, table.c.date_of_birth, table.c.date_of_death, table.c.sex

--- a/tests/integration/file_formats/test_arrow.py
+++ b/tests/integration/file_formats/test_arrow.py
@@ -1,0 +1,32 @@
+import pyarrow.feather
+
+from databuilder.column_specs import ColumnSpec
+from databuilder.file_formats import write_dataset
+
+
+def test_write_dataset_arrow(tmp_path):
+    filename = tmp_path / "somedir" / "file.arrow"
+    column_specs = {
+        "patient_id": ColumnSpec(int),
+        "year_of_birth": ColumnSpec(int, min_value=1900, max_value=2100),
+        "sex": ColumnSpec(str, categories=("M", "F", "I")),
+    }
+    results = [
+        (123, 1980, "F"),
+        (456, None, None),
+        (789, 1999, "M"),
+    ]
+    write_dataset(filename, results, column_specs)
+
+    table = pyarrow.feather.read_table(filename)
+    output_columns = table.column_names
+    output_rows = [tuple(d.values()) for d in table.to_pylist()]
+    categories = table.column("sex").chunk(0).dictionary.to_pylist()
+    index_type = table.column("sex").type.index_type
+
+    assert output_columns == list(column_specs.keys())
+    assert output_rows == results
+    assert categories == ["M", "F", "I"]
+    assert index_type == pyarrow.uint8()
+    assert table.column("patient_id").type == pyarrow.int64()
+    assert table.column("year_of_birth").type == pyarrow.uint16()

--- a/tests/integration/file_formats/test_csv.py
+++ b/tests/integration/file_formats/test_csv.py
@@ -1,0 +1,44 @@
+import gzip
+
+import pytest
+
+from databuilder.column_specs import ColumnSpec
+from databuilder.file_formats import write_dataset
+
+
+@pytest.mark.parametrize("basename", [None, "file.csv", "file.csv.gz"])
+def test_write_dataset_csv(tmp_path, capsys, basename):
+    if basename is None:
+        filename = None
+    else:
+        filename = tmp_path / "somedir" / basename
+
+    column_specs = {
+        "patient_id": ColumnSpec(int),
+        "year_of_birth": ColumnSpec(int),
+        "sex": ColumnSpec(str),
+    }
+    results = [
+        (123, 1980, "F"),
+        (456, None, None),
+        (789, 1999, "M"),
+    ]
+
+    write_dataset(filename, results, column_specs)
+
+    if basename is None:
+        output = capsys.readouterr().out
+    elif basename.endswith(".csv.gz"):
+        with gzip.open(filename, "rt") as f:
+            output = f.read()
+    elif basename.endswith(".csv"):
+        output = filename.read_text()
+    else:
+        assert False
+
+    assert output.splitlines() == [
+        "patient_id,year_of_birth,sex",
+        "123,1980,F",
+        "456,,",
+        "789,1999,M",
+    ]

--- a/tests/integration/test_file_formats.py
+++ b/tests/integration/test_file_formats.py
@@ -55,7 +55,7 @@ def test_write_dataset_arrow(tmp_path):
     column_specs = {
         "patient_id": ColumnSpec(int),
         "year_of_birth": ColumnSpec(int),
-        "sex": ColumnSpec(str),
+        "sex": ColumnSpec(str, categories=("M", "F", "I")),
     }
     results = [
         (123, 1980, "F"),
@@ -67,9 +67,11 @@ def test_write_dataset_arrow(tmp_path):
     table = pyarrow.feather.read_table(filename)
     output_columns = table.column_names
     output_rows = [tuple(d.values()) for d in table.to_pylist()]
+    categories = table.column("sex").chunk(0).dictionary.to_pylist()
 
     assert output_columns == list(column_specs.keys())
     assert output_rows == results
+    assert categories == ["M", "F", "I"]
 
 
 @pytest.mark.parametrize("extension", list(FILE_FORMATS.keys()))

--- a/tests/integration/test_file_formats.py
+++ b/tests/integration/test_file_formats.py
@@ -68,10 +68,12 @@ def test_write_dataset_arrow(tmp_path):
     output_columns = table.column_names
     output_rows = [tuple(d.values()) for d in table.to_pylist()]
     categories = table.column("sex").chunk(0).dictionary.to_pylist()
+    index_type = table.column("sex").type.index_type
 
     assert output_columns == list(column_specs.keys())
     assert output_rows == results
     assert categories == ["M", "F", "I"]
+    assert index_type == pyarrow.uint8()
 
 
 @pytest.mark.parametrize("extension", list(FILE_FORMATS.keys()))

--- a/tests/integration/test_file_formats.py
+++ b/tests/integration/test_file_formats.py
@@ -54,7 +54,7 @@ def test_write_dataset_arrow(tmp_path):
     filename = tmp_path / "somedir" / "file.arrow"
     column_specs = {
         "patient_id": ColumnSpec(int),
-        "year_of_birth": ColumnSpec(int),
+        "year_of_birth": ColumnSpec(int, min_value=1900, max_value=2100),
         "sex": ColumnSpec(str, categories=("M", "F", "I")),
     }
     results = [
@@ -74,6 +74,8 @@ def test_write_dataset_arrow(tmp_path):
     assert output_rows == results
     assert categories == ["M", "F", "I"]
     assert index_type == pyarrow.uint8()
+    assert table.column("patient_id").type == pyarrow.int64()
+    assert table.column("year_of_birth").type == pyarrow.uint16()
 
 
 @pytest.mark.parametrize("extension", list(FILE_FORMATS.keys()))

--- a/tests/integration/test_query_model_with_codes.py
+++ b/tests/integration/test_query_model_with_codes.py
@@ -2,6 +2,7 @@ import pytest
 
 from databuilder.codes import CTV3Code, SNOMEDCTCode
 from databuilder.query_model import (
+    Column,
     Function,
     SelectColumn,
     SelectTable,
@@ -10,22 +11,21 @@ from databuilder.query_model import (
     Value,
 )
 
+events = SelectTable("events", schema=TableSchema(code=Column(CTV3Code)))
+
 
 def test_comparisons_between_codes_are_ok():
-    events = SelectTable("events", schema=TableSchema({"code": CTV3Code}))
     code = SelectColumn(events, "code")
     assert Function.EQ(code, Value(CTV3Code("abc")))
 
 
 def test_attempts_to_mix_coding_systems_are_rejected():
-    events = SelectTable("events", schema=TableSchema({"code": CTV3Code}))
     code = SelectColumn(events, "code")
     with pytest.raises(TypeValidationError):
         Function.EQ(code, Value(SNOMEDCTCode("abc")))
 
 
 def test_attempts_to_mix_codes_and_strings_are_rejected():
-    events = SelectTable("events", schema=TableSchema({"code": CTV3Code}))
     code = SelectColumn(events, "code")
     with pytest.raises(TypeValidationError):
         Function.EQ(code, Value("abc"))

--- a/tests/spec/conftest.py
+++ b/tests/spec/conftest.py
@@ -80,19 +80,21 @@ def parse_table(schema, s):
     header, _, *lines = s.strip().splitlines()
     col_names = [token.strip() for token in header.split("|")]
     col_names[0] = "patient_id"
-    schema = dict(patient_id=int, **schema)
-    rows = [parse_row(schema, col_names, line) for line in lines]
+    column_types = dict(
+        patient_id=int, **{name: type_ for name, type_ in schema.column_types}
+    )
+    rows = [parse_row(column_types, col_names, line) for line in lines]
     return rows
 
 
-def parse_row(schema, col_names, line):
+def parse_row(column_types, col_names, line):
     """Parse string containing row data, returning list of values.
 
     See test_conftest.py for examples.
     """
 
     return {
-        col_name: parse_value(schema[col_name], token.strip())
+        col_name: parse_value(column_types[col_name], token.strip())
         for col_name, token in zip(col_names, line.split("|"))
     }
 

--- a/tests/spec/test_conftest.py
+++ b/tests/spec/test_conftest.py
@@ -1,10 +1,12 @@
+from databuilder.query_model import Column, TableSchema
+
 from .conftest import parse_row, parse_table
 
 
 def test_parse_table():
     assert (
         parse_table(
-            {"i1": int, "i2": int},
+            TableSchema(i1=Column(int), i2=Column(int)),
             """
           |  i1 |  i2
         --+-----+-----

--- a/tests/unit/backends/test_base.py
+++ b/tests/unit/backends/test_base.py
@@ -11,6 +11,7 @@ from databuilder.backends.base import (
     ValidationError,
 )
 from databuilder.query_engines.base_sql import BaseSQLQueryEngine
+from databuilder.query_model import Column, TableSchema
 from databuilder.tables import PatientFrame, Series, table
 
 
@@ -51,9 +52,9 @@ def test_backend_registers_tables():
 def test_mapped_table_sql_with_modified_names():
     table = TestBackend().get_table_expression(
         "patients",
-        {
-            "date_of_birth": datetime.date,
-        },
+        TableSchema(
+            date_of_birth=Column(datetime.date),
+        ),
     )
     sql = str(sqlalchemy.select(table.c.patient_id, table.c.date_of_birth))
     assert sql == 'SELECT "Patient"."PatID", "Patient"."DateOfBirth" \nFROM "Patient"'
@@ -62,9 +63,9 @@ def test_mapped_table_sql_with_modified_names():
 def test_mapped_table_sql_with_matching_names():
     table = TestBackend().get_table_expression(
         "events",
-        {
-            "date": datetime.date,
-        },
+        TableSchema(
+            date=Column(datetime.date),
+        ),
     )
     sql = str(sqlalchemy.select(table.c.patient_id, table.c.date))
     assert sql == 'SELECT events."PatientId", events.date \nFROM events'
@@ -73,10 +74,10 @@ def test_mapped_table_sql_with_matching_names():
 def test_query_table_sql():
     table = TestBackend().get_table_expression(
         "practice_registrations",
-        {
-            "date_start": datetime.date,
-            "date_end": datetime.date,
-        },
+        TableSchema(
+            date_start=Column(datetime.date),
+            date_end=Column(datetime.date),
+        ),
     )
     sql = str(sqlalchemy.select(table.c.patient_id, table.c.date_start))
     assert sql == (
@@ -87,7 +88,9 @@ def test_query_table_sql():
 
 
 def test_default_backend_sql():
-    table = DefaultBackend().get_table_expression("some_table", {"i": int, "b": bool})
+    table = DefaultBackend().get_table_expression(
+        "some_table", TableSchema(i=Column(int), b=Column(bool))
+    )
     sql = str(sqlalchemy.select(table.c.patient_id, table.c.i, table.c.b))
     assert sql == (
         "SELECT some_table.patient_id, some_table.i, some_table.b \nFROM some_table"

--- a/tests/unit/file_formats/test_arrow.py
+++ b/tests/unit/file_formats/test_arrow.py
@@ -64,3 +64,8 @@ def test_smallest_int_type_for_range(min_value, max_value, expected_width):
 
     assert [min_value, max_value] == roundtripped
     assert type_.bit_width == expected_width
+
+
+def test_smallest_int_type_for_range_default():
+    assert smallest_int_type_for_range(None, 0) == pyarrow.int64()
+    assert smallest_int_type_for_range(0, None) == pyarrow.int64()

--- a/tests/unit/file_formats/test_arrow.py
+++ b/tests/unit/file_formats/test_arrow.py
@@ -1,16 +1,20 @@
 import pytest
 
 from databuilder.column_specs import ColumnSpec
-from databuilder.file_formats.arrow import batch_and_transpose, schema_from_column_specs
+from databuilder.file_formats.arrow import batch_and_transpose, get_schema_and_convertor
 from databuilder.sqlalchemy_types import TYPE_MAP
 
 
 # Check we can convert every type in TYPE_MAP to a pyarrow type
 @pytest.mark.parametrize("type_", list(TYPE_MAP.keys()))
-def test_schema_from_column_specs(type_):
+def test_get_schema_and_convertor(type_):
     columns_specs = {"some_col": ColumnSpec(type_)}
-    schema = schema_from_column_specs(columns_specs)
+    schema, batch_to_pyarrow = get_schema_and_convertor(columns_specs)
     assert schema.names == ["some_col"]
+
+    batch = [[None]]
+    pyarrow_batch = batch_to_pyarrow(batch)
+    assert pyarrow_batch[0].type == schema.field(0).type
 
 
 def test_batch_and_transponse():

--- a/tests/unit/file_formats/test_csv.py
+++ b/tests/unit/file_formats/test_csv.py
@@ -136,6 +136,19 @@ def test_read_dataset_csv_lines(csv, error):
             "day is out of range for month",
         ),
         ("2021-2-2", ColumnSpec(datetime.date), None, "Invalid isoformat string"),
+        # Categoricals
+        (
+            "foo",
+            ColumnSpec(str, categories=("foo", "bar")),
+            "foo",
+            None,
+        ),
+        (
+            "baz",
+            ColumnSpec(str, categories=("foo", "bar")),
+            None,
+            "'baz' not in valid categories",
+        ),
     ],
 )
 def test_create_column_parser(value, spec, expected, error):

--- a/tests/unit/query_engines/test_sqlite.py
+++ b/tests/unit/query_engines/test_sqlite.py
@@ -2,6 +2,7 @@ import sqlalchemy
 
 from databuilder.query_engines.sqlite import SQLiteQueryEngine
 from databuilder.query_model import (
+    Column,
     Function,
     SelectColumn,
     SelectPatientTable,
@@ -9,7 +10,7 @@ from databuilder.query_model import (
     Value,
 )
 
-BOOLEAN_COLUMN = SelectColumn(SelectPatientTable("t", TableSchema(c=bool)), "c")
+BOOLEAN_COLUMN = SelectColumn(SelectPatientTable("t", TableSchema(c=Column(bool))), "c")
 
 
 class DummyBackend:

--- a/tests/unit/test_column_specs.py
+++ b/tests/unit/test_column_specs.py
@@ -101,3 +101,11 @@ def test_get_categories_for_case_with_mixed_categorical_and_noncategorical_value
 def test_get_range_default_implementation():
     i = SelectColumn(SelectTable("t", schema=TableSchema(i=Column(int))), "i")
     assert get_range(i) == (None, None)
+
+
+def test_get_range_for_count():
+    count = AggregateByPatient.Count(events)
+    min_value, max_value = get_range(count)
+    assert min_value == 0
+    num_bits = len(f"{max_value:b}")
+    assert num_bits == 16

--- a/tests/unit/test_column_specs.py
+++ b/tests/unit/test_column_specs.py
@@ -1,12 +1,13 @@
 import datetime
 
 from databuilder.codes import SNOMEDCTCode
-from databuilder.column_specs import ColumnSpec, get_column_specs
+from databuilder.column_specs import ColumnSpec, get_categories, get_column_specs
 from databuilder.query_model import (
     AggregateByPatient,
     Column,
     SelectColumn,
     SelectPatientTable,
+    SelectTable,
     TableSchema,
 )
 
@@ -15,17 +16,47 @@ def test_get_column_specs():
     patients = SelectPatientTable(
         "patients",
         schema=TableSchema(
-            date_of_birth=Column(datetime.date), code=Column(SNOMEDCTCode)
+            date_of_birth=Column(datetime.date),
+            code=Column(SNOMEDCTCode),
+            category=Column(
+                SNOMEDCTCode,
+                categories=(SNOMEDCTCode("abc"), SNOMEDCTCode("def")),
+            ),
         ),
     )
     variables = dict(
         population=AggregateByPatient.Exists(patients),
         dob=SelectColumn(patients, "date_of_birth"),
         code=SelectColumn(patients, "code"),
+        category=SelectColumn(patients, "category"),
     )
     column_specs = get_column_specs(variables)
     assert column_specs == {
-        "patient_id": ColumnSpec(type=int, nullable=False),
-        "dob": ColumnSpec(type=datetime.date, nullable=True),
-        "code": ColumnSpec(type=str, nullable=True),
+        "patient_id": ColumnSpec(type=int, nullable=False, categories=None),
+        "dob": ColumnSpec(type=datetime.date, nullable=True, categories=None),
+        "code": ColumnSpec(type=str, nullable=True, categories=None),
+        "category": ColumnSpec(type=str, nullable=True, categories=("abc", "def")),
     }
+
+
+events = SelectTable(
+    "events",
+    schema=TableSchema(
+        event_type=Column(str, categories=("a", "b", "c")),
+        event_name=Column(str),
+    ),
+)
+event_type = SelectColumn(events, "event_type")
+
+
+def test_get_categories_default_implementation():
+    assert get_categories(AggregateByPatient.Exists(events)) is None
+
+
+def test_get_categories_for_select_column():
+    assert get_categories(event_type) == ("a", "b", "c")
+
+
+def test_get_categories_for_min_max():
+    assert get_categories(AggregateByPatient.Min(event_type)) == ("a", "b", "c")
+    assert get_categories(AggregateByPatient.Max(event_type)) == ("a", "b", "c")

--- a/tests/unit/test_column_specs.py
+++ b/tests/unit/test_column_specs.py
@@ -4,6 +4,7 @@ from databuilder.codes import SNOMEDCTCode
 from databuilder.column_specs import ColumnSpec, get_column_specs
 from databuilder.query_model import (
     AggregateByPatient,
+    Column,
     SelectColumn,
     SelectPatientTable,
     TableSchema,
@@ -13,7 +14,9 @@ from databuilder.query_model import (
 def test_get_column_specs():
     patients = SelectPatientTable(
         "patients",
-        schema=TableSchema({"date_of_birth": datetime.date, "code": SNOMEDCTCode}),
+        schema=TableSchema(
+            date_of_birth=Column(datetime.date), code=Column(SNOMEDCTCode)
+        ),
     )
     variables = dict(
         population=AggregateByPatient.Exists(patients),

--- a/tests/unit/test_column_specs.py
+++ b/tests/unit/test_column_specs.py
@@ -1,7 +1,12 @@
 import datetime
 
 from databuilder.codes import SNOMEDCTCode
-from databuilder.column_specs import ColumnSpec, get_categories, get_column_specs
+from databuilder.column_specs import (
+    ColumnSpec,
+    get_categories,
+    get_column_specs,
+    get_range,
+)
 from databuilder.query_model import (
     AggregateByPatient,
     Case,
@@ -91,3 +96,8 @@ def test_get_categories_for_case_with_mixed_categorical_and_noncategorical_value
         default=event_name,
     )
     assert get_categories(type_or_name) is None
+
+
+def test_get_range_default_implementation():
+    i = SelectColumn(SelectTable("t", schema=TableSchema(i=Column(int))), "i")
+    assert get_range(i) == (None, None)

--- a/tests/unit/test_population_validation.py
+++ b/tests/unit/test_population_validation.py
@@ -12,6 +12,7 @@ from databuilder.population_validation import (
 from databuilder.query_model import (
     AggregateByPatient,
     Case,
+    Column,
     Function,
     SelectColumn,
     SelectPatientTable,
@@ -30,7 +31,7 @@ def test_rejects_non_series():
 
 def test_rejects_invalid_dimension():
     event_series = SelectColumn(
-        SelectTable("events", schema=TableSchema(value=bool)), "value"
+        SelectTable("events", schema=TableSchema(value=Column(bool))), "value"
     )
     with pytest.raises(ValidationError, match="one-row-per-patient series"):
         validate_population_definition(event_series)
@@ -38,7 +39,7 @@ def test_rejects_invalid_dimension():
 
 def test_rejects_invalid_type():
     int_series = SelectColumn(
-        SelectPatientTable("patients", schema=TableSchema(value=int)), "value"
+        SelectPatientTable("patients", schema=TableSchema(value=Column(int))), "value"
     )
     with pytest.raises(ValidationError, match="boolean type"):
         validate_population_definition(int_series)
@@ -46,7 +47,7 @@ def test_rejects_invalid_type():
 
 def test_accepts_basic_reasonable_population():
     has_registration = AggregateByPatient.Exists(
-        SelectTable("registrations", schema=TableSchema(value=int))
+        SelectTable("registrations", schema=TableSchema(value=Column(int)))
     )
     assert validate_population_definition(has_registration)
 
@@ -54,7 +55,7 @@ def test_accepts_basic_reasonable_population():
 def test_rejects_basic_unreasonable_population():
     not_died = Function.Not(
         AggregateByPatient.Exists(
-            SelectTable("ons_deaths", schema=TableSchema(value=int))
+            SelectTable("ons_deaths", schema=TableSchema(value=Column(int)))
         )
     )
     with pytest.raises(ValidationError, match="must not evaluate as True for NULL"):
@@ -64,8 +65,8 @@ def test_rejects_basic_unreasonable_population():
 # TEST EVALUATE FUNCTION
 #
 
-patients = SelectPatientTable("patients", schema=TableSchema(value=int))
-events = SelectTable("events", schema=TableSchema(value=int))
+patients = SelectPatientTable("patients", schema=TableSchema(value=Column(int)))
+events = SelectTable("events", schema=TableSchema(value=Column(int)))
 patients_value = SelectColumn(patients, "value")
 events_value = SelectColumn(events, "value")
 

--- a/tests/unit/test_query_language.py
+++ b/tests/unit/test_query_language.py
@@ -3,6 +3,7 @@ from datetime import date
 import pytest
 
 from databuilder.query_language import (
+    CategoricalConstraint,
     Dataset,
     DateEventSeries,
     EventFrame,
@@ -222,3 +223,12 @@ def test_must_reference_instance_not_class():
 
     with pytest.raises(SchemaError, match="Missing `@table` decorator"):
         some_table.some_int
+
+
+def test_categories_are_passed_through_to_schema():
+    @table
+    class some_table(PatientFrame):
+        some_str = Series(str, constraints=[CategoricalConstraint("a", "b", "c")])
+
+    schema = some_table.qm_node.schema
+    assert schema.get_column_categories("some_str") == ("a", "b", "c")

--- a/tests/unit/test_query_language.py
+++ b/tests/unit/test_query_language.py
@@ -17,6 +17,7 @@ from databuilder.query_language import (
     table,
 )
 from databuilder.query_model import (
+    Column,
     Function,
     SelectColumn,
     SelectPatientTable,
@@ -26,9 +27,9 @@ from databuilder.query_model import (
     Value,
 )
 
-patients_schema = TableSchema(date_of_birth=date)
+patients_schema = TableSchema(date_of_birth=Column(date))
 patients = PatientFrame(SelectPatientTable("patients", patients_schema))
-events_schema = TableSchema(event_date=date)
+events_schema = TableSchema(event_date=Column(date))
 events = EventFrame(SelectTable("coded_events", events_schema))
 
 
@@ -98,7 +99,7 @@ def test_cannot_assign_frame_to_column():
 # instantiated isn't important.
 qm_table = SelectTable(
     name="table",
-    schema=TableSchema(int_column=int, date_column=date),
+    schema=TableSchema(int_column=Column(int), date_column=Column(date)),
 )
 qm_int_series = SelectColumn(source=qm_table, name="int_column")
 qm_date_series = SelectColumn(source=qm_table, name="date_column")

--- a/tests/unit/test_query_model.py
+++ b/tests/unit/test_query_model.py
@@ -8,6 +8,7 @@ import pytest
 from databuilder.query_model import (
     AggregateByPatient,
     Case,
+    Column,
     DomainMismatchError,
     Filter,
     Frame,
@@ -27,7 +28,22 @@ from databuilder.query_model import (
     has_one_row_per_patient,
 )
 
-EVENTS_SCHEMA = TableSchema(date=datetime.date, code=str, flag=bool)
+EVENTS_SCHEMA = TableSchema(
+    date=Column(datetime.date), code=Column(str), flag=Column(bool)
+)
+
+
+# TEST TABLESCHEMA
+#
+
+
+def test_table_schema_equality():
+    t1 = TableSchema(i=Column(int))
+    t2 = TableSchema(i=Column(int))
+    t3 = TableSchema(j=Column(int))
+    assert t1 == t2
+    assert t1 != t3
+    assert t1 != "a fish"
 
 
 # TEST BASIC QUERY MODEL PROPERTIES
@@ -38,7 +54,7 @@ EVENTS_SCHEMA = TableSchema(date=datetime.date, code=str, flag=bool)
 def queries():
     q = SimpleNamespace()
 
-    patients = SelectPatientTable("patients", TableSchema(sex=str))
+    patients = SelectPatientTable("patients", TableSchema(sex=Column(str)))
     events = SelectTable("events", EVENTS_SCHEMA)
     code = SelectColumn(events, "code")
     date = SelectColumn(events, "date")
@@ -118,7 +134,9 @@ def test_query_reprs_round_trip(queries):
 
 # The simple, happy case: combining series derived directly from the same frame
 def test_combining_series_from_same_frame_is_ok():
-    events = SelectTable("events", TableSchema(value_1=int, value_2=int))
+    events = SelectTable(
+        "events", TableSchema(value_1=Column(int), value_2=Column(int))
+    )
     value_1 = SelectColumn(events, "value_1")
     value_2 = SelectColumn(events, "value_2")
     assert Function.GT(value_1, value_2)

--- a/tests/unit/test_query_model_transforms.py
+++ b/tests/unit/test_query_model_transforms.py
@@ -1,6 +1,7 @@
 import datetime
 
 from databuilder.query_model import (
+    Column,
     PickOneRowPerPatient,
     Position,
     SelectColumn,
@@ -16,7 +17,10 @@ from databuilder.query_model_transforms import (
 
 def test_pick_one_row_per_patient_transform():
     events = SelectTable(
-        "events", schema=TableSchema(date=datetime.date, code=str, value=float)
+        "events",
+        schema=TableSchema(
+            date=Column(datetime.date), code=Column(str), value=Column(float)
+        ),
     )
     date = SelectColumn(events, "date")
     by_date = Sort(events, date)


### PR DESCRIPTION
This PR adds an internal function to ask, of any variable in a dataset definition: is this a categorical variable and if so what are its categories?

There are two source of categorical variable: those drawn from columns whose definition includes a `CategoricalConstraint`; and those created by a `Case` expression whose outputs are a set of fixed values. Both are handled here. Note that other ways of creating a categorical such as using a categorised codelist to map codes to categories, or using `if_null_then()` to create a new default category, are all compiled down to `Case` expressions and so are handled automatically here.

We use this information to encode such variables as categoricals ([`pyarrow.DictionaryArray`](https://arrow.apache.org/docs/python/data.html#dictionary-arrays)) when writing Arrow files, resulting in significant memory usage and performance benefits over storing them as strings.

We also use this introspection feature when validating user-supplied dummy data to ensure that it uses the same categories as the real thing.

As part of this work we add the basic framework necessary for inferring the range of a numeric variable and selecting the most efficient binary type to represent it — though at present we only use this in one specific case.

Closes #631

---

Although the changes here aren't huge I'm aware that the query model, and the range of different `@singledispatch` functions which do things with it, is growing steadily in complexity and possibly getting a bit out of hand. I think at some point we'll want to step back from all this and come up with a slightly different approach to the query model implementation. _However_, I feel very relaxed about this. I'm confident in the seams we've put in place, and in the fundamental structure of the query model. At some suitable point (which is definitely not now) we can tidy up the implementation to make it more manageable for the long-term. But I don't anticipate that having wider implications on the rest of the codebase.