### PR TITLE
Simplify SQL we generate for `Exists`

### DIFF
--- a/tests/spec/conftest.py
+++ b/tests/spec/conftest.py
@@ -36,8 +36,10 @@ def spec_test(request, engine):
             expected_results = pytest.approx(expected_results, rel=1e-5)
 
         # Extract data, and check it's as expected.
-        results = {r["patient_id"]: r["v"] for r in engine.extract(dataset)}
-        assert results == expected_results
+        results = [(r["patient_id"], r["v"]) for r in engine.extract(dataset)]
+        results_dict = dict(results)
+        assert len(results) == len(results_dict), "Duplicate patient IDs found"
+        assert results_dict == expected_results
 
     # Test that we can generate SQL with literal parmeters for debugging purposes
     def run_test_dump_sql(table_data, series, expected_results, population=None):


### PR DESCRIPTION
Previously, the intermediate table we generated for an `Exists` aggregation had the form:
```sql
SELECT patient_id, True AS value ... GROUP BY patient_id
```

And then we would later ensure it was never NULL valued by referencing it with:
```sql
COALESCE(tmp_table_1.value, False)
```

But this `value` column containing nothing but `True` is unnecessary. We can achieve the same thing with:
```sql
SELECT DISTINCT patient_id ...
```

And then reference it later using:
```sql
tmp_table_1.patient_id IS NOT NULL
```

This reduces the size of the temporary table which is a good thing, although the exact level of performance benefit will depend on the specifics of the database engine being used.