### PR TITLE
Rename `hospitalization` to `hospitalisation`

### DIFF
--- a/databuilder/backends/graphnet.py
+++ b/databuilder/backends/graphnet.py
@@ -57,7 +57,7 @@ class GraphnetBackend(BaseBackend):
         ),
     )
 
-    hospitalizations_without_system = MappedTable(
+    hospitalisations_without_system = MappedTable(
         schema=SCHEMA,
         source="Hospitalisations",
         columns=dict(

--- a/databuilder/backends/tpp.py
+++ b/databuilder/backends/tpp.py
@@ -124,7 +124,7 @@ class TPPBackend(BaseBackend):
         """
     )
 
-    hospitalizations = QueryTable(
+    hospitalisations = QueryTable(
         f"""
             SELECT Patient_ID as patient_id, Admission_Date as date, {rtrim("fully_split.Value", "X")} as code, 'icd10' as system
             FROM APCS

--- a/databuilder/contracts/wip.py
+++ b/databuilder/contracts/wip.py
@@ -29,7 +29,7 @@ class hospital_admissions(EventFrame):
 
 
 @table
-class hospitalizations(EventFrame):
+class hospitalisations(EventFrame):
     """TODO."""
 
     date = Series(datetime.date)
@@ -38,7 +38,7 @@ class hospitalizations(EventFrame):
 
 
 @table
-class hospitalizations_without_system(EventFrame):
+class hospitalisations_without_system(EventFrame):
     """TODO."""
 
     code = Series(str)

--- a/databuilder/tables/beta/graphnet.py
+++ b/databuilder/tables/beta/graphnet.py
@@ -1,7 +1,7 @@
 from databuilder.contracts.wip import (
     clinical_events,
     covid_test_results,
-    hospitalizations_without_system,
+    hospitalisations_without_system,
     patient_address,
     patients,
     practice_registrations,
@@ -10,7 +10,7 @@ from databuilder.contracts.wip import (
 __all__ = [
     "clinical_events",
     "covid_test_results",
-    "hospitalizations_without_system",
+    "hospitalisations_without_system",
     "patient_address",
     "patients",
     "practice_registrations",

--- a/databuilder/tables/beta/tpp.py
+++ b/databuilder/tables/beta/tpp.py
@@ -2,7 +2,7 @@ from databuilder.contracts.universal import patients
 from databuilder.contracts.wip import (
     clinical_events,
     covid_test_results,
-    hospitalizations,
+    hospitalisations,
     patient_address,
     practice_registrations,
 )
@@ -11,7 +11,7 @@ __all__ = [
     "patients",
     "clinical_events",
     "covid_test_results",
-    "hospitalizations",
+    "hospitalisations",
     "patient_address",
     "practice_registrations",
 ]

--- a/tests/integration/backends/test_tpp.py
+++ b/tests/integration/backends/test_tpp.py
@@ -30,15 +30,15 @@ def run_query(database, query):
         "strips just trailing xs",
     ],
 )
-def test_hospitalization_table_code_conversion(mssql_database, raw, codes):
+def test_hospitalisation_table_code_conversion(mssql_database, raw, codes):
     mssql_database.setup(
         patient(
             related=[apcs(codes=raw)],
         )
     )
 
-    table = TPPBackend.hospitalizations.get_expression(
-        "hospitalizations", TableSchema(code=Column(str))
+    table = TPPBackend.hospitalisations.get_expression(
+        "hospitalisations", TableSchema(code=Column(str))
     )
     query = sqlalchemy.select(table.c.code)
 


### PR DESCRIPTION
Fixes #742.

This is the British English spellling and makes the usage consistent throughout the codebase.

We may want to rename the relevant tables and contracts in future, but what they should be called right now is not immediately clear. See the discussion in #742 for more details.