### PR TITLE
Add exponential backoff and retry to MSSQL engine

### DIFF
--- a/databuilder/query_engines/mssql.py
+++ b/databuilder/query_engines/mssql.py
@@ -1,6 +1,9 @@
+import datetime
+import secrets
+
 import sqlalchemy
 import structlog
-from sqlalchemy.schema import CreateIndex
+from sqlalchemy.schema import CreateIndex, DropTable
 from sqlalchemy.sql.functions import Function as SQLFunction
 
 from databuilder import sqlalchemy_types
@@ -63,10 +66,41 @@ class MSSQLQueryEngine(BaseSQLQueryEngine):
         results_query = super().get_query(variable_definitions)
         # Write results to a temporary table and select them from there. This allows us
         # to use more efficient/robust mechanisms to retrieve the results.
+        table_name, schema = self.get_results_table_name_and_schema(
+            self.config.get("TEMP_DATABASE_NAME")
+        )
         results_table = temporary_table_from_query(
-            "#results", results_query, index_col="patient_id"
+            table_name, results_query, index_col="patient_id", schema=schema
         )
         return sqlalchemy.select(results_table)
+
+    def get_results_table_name_and_schema(self, temp_database_name):
+        # If we have a temporary database we can write results there which enables
+        # us to continue retrieving results after an interrupted connection
+        if temp_database_name:
+            # As the table is not session-scoped it needs a unique name
+            timestamp = datetime.datetime.utcnow()
+            token = secrets.token_hex(6)
+            table_name = f"results_{timestamp:%Y%m%d_%H%M}_{token}"
+            # The `schema` variable below is actually a multi-part identifier of the
+            # form `<database-name>.<schema>`. We don't really care about the schema
+            # here, we just want to use whatever is the default schema for the database.
+            # MSSQL allows you to do this by specifying "." as the schema name. However
+            # I can't find a way of supplying this without SQLAlchemy's quoting
+            # algorithm either mangling it or blowing up. We could work around this by
+            # attaching our own Identifier Preparer to our MSSQL dialect, but that
+            # sounds a lot like hard work. So we use the default value for the default
+            # schema, which is "dbo" (Database Owner), on the assumption that this will
+            # generally work and we can revisit if we have to. Relevant URLs are:
+            # https://docs.sqlalchemy.org/en/14/dialects/mssql.html#multipart-schema-names
+            # https://github.com/sqlalchemy/sqlalchemy/blob/8c07c68c/lib/sqlalchemy/dialects/mssql/base.py#L2799
+            schema = f"{temp_database_name}.dbo"
+        else:
+            # Otherwise we use a session-scoped temporary table which requires a
+            # continuous connnection
+            table_name = "#results"
+            schema = None
+        return table_name, schema
 
     def get_results(self, variable_definitions):
         results_query = self.get_query(variable_definitions)
@@ -102,15 +136,17 @@ class MSSQLQueryEngine(BaseSQLQueryEngine):
                 log=log.info,
             )
 
-            assert not cleanup_queries, "Support these once tests exercise them"
+            for n, cleanup_query in enumerate(cleanup_queries, start=1):
+                log.info(f"Running cleanup query {n:03} / {len(cleanup_queries):03}")
+                connection.execute(cleanup_query)
 
 
-def temporary_table_from_query(table_name, query, index_col=0):
+def temporary_table_from_query(table_name, query, index_col=0, schema=None):
     # Define a table object with the same columns as the query
     columns = [
         sqlalchemy.Column(c.name, c.type, key=c.key) for c in query.selected_columns
     ]
-    table = GeneratedTable(table_name, sqlalchemy.MetaData(), *columns)
+    table = GeneratedTable(table_name, sqlalchemy.MetaData(), *columns, schema=schema)
     table.setup_queries = [
         # Use the MSSQL `SELECT * INTO ...` construct to create and populate this
         # table
@@ -120,7 +156,12 @@ def temporary_table_from_query(table_name, query, index_col=0):
         # SQLAlchemy generate one for us.)
         CreateIndex(sqlalchemy.Index(None, table.c[index_col], mssql_clustered=True)),
     ]
-    # The "#" prefix ensures this is a session-scoped temporary table so there's no
-    # explict cleanup needed
-    assert table_name.startswith("#")
+    # The "#" prefix indicates a session-scoped temporary table which doesn't need
+    # explict cleanup
+    if table_name.startswith("#"):
+        table.is_persistent = False
+        table.cleanup_queries = []
+    else:
+        table.is_persistent = True
+        table.cleanup_queries = [DropTable(table)]
     return table

--- a/databuilder/query_engines/mssql.py
+++ b/databuilder/query_engines/mssql.py
@@ -83,7 +83,7 @@ class MSSQLQueryEngine(BaseSQLQueryEngine):
                 connection.execute(setup_query)
 
             yield from fetch_table_in_batches(
-                connection,
+                connection.execute,
                 results_table,
                 key_column=results_table.c.patient_id,
                 # This value was copied from the previous cohortextractor. I suspect it

--- a/databuilder/sqlalchemy_utils.py
+++ b/databuilder/sqlalchemy_utils.py
@@ -147,13 +147,14 @@ def clause_as_str(clause, dialect):
 
 
 def fetch_table_in_batches(
-    connection, table, key_column, batch_size=32000, log=lambda *_: None
+    execute, table, key_column, batch_size=32000, log=lambda *_: None
 ):
     """
     Returns an iterator over all the rows in a table by querying it in batches
 
     Args:
-        connection: SQLAlchemy Connection object
+        execute: callable which accepts a SQLAlchemy query and returns results (can be
+            just a Connection.execute method)
         table: SQLAlchemy TableClause
         key_column: reference to a unique orderable column on `table`, used for
             paging (note that this will need an index on it to avoid terrible
@@ -174,7 +175,7 @@ def fetch_table_in_batches(
             query = query.where(key_column > min_key)
 
         log(f"Fetching batch {batch_count}")
-        results = connection.execute(query)
+        results = execute(query)
 
         row_count = 0
         for row in results:

--- a/tests/integration/query_engines/test_mssql.py
+++ b/tests/integration/query_engines/test_mssql.py
@@ -1,0 +1,35 @@
+from sqlalchemy.orm import declarative_base
+
+from databuilder.orm_factory import orm_class_from_qm_table
+from databuilder.query_engines.mssql import MSSQLQueryEngine
+from databuilder.query_model import (
+    AggregateByPatient,
+    Column,
+    SelectColumn,
+    SelectPatientTable,
+    TableSchema,
+)
+
+
+def test_get_results_using_temporary_database(mssql_database):
+    temp_database_name = "temp_tables"
+
+    # Define a simple query and load some test data
+    patient_table = SelectPatientTable("patients", TableSchema(i=Column(int)))
+    variable_definitions = dict(
+        population=AggregateByPatient.Exists(patient_table),
+        i=SelectColumn(patient_table, "i"),
+    )
+    patients = orm_class_from_qm_table(declarative_base(), patient_table)
+    mssql_database.setup(
+        patients(patient_id=1, i=10),
+        patients(patient_id=2, i=20),
+    )
+    query_engine = MSSQLQueryEngine(
+        mssql_database.host_url(),
+        config=dict(TEMP_DATABASE_NAME=temp_database_name),
+    )
+
+    results = query_engine.get_results(variable_definitions)
+
+    assert list(results) == [(1, 10), (2, 20)]

--- a/tests/integration/test_sqlalchemy_utils.py
+++ b/tests/integration/test_sqlalchemy_utils.py
@@ -28,7 +28,7 @@ def test_fetch_table_in_batches(engine):
 
     with engine.sqlalchemy_engine().connect() as connection:
         results = fetch_table_in_batches(
-            connection, table, table.c.pk, batch_size=batch_size
+            connection.execute, table, table.c.pk, batch_size=batch_size
         )
         results = list(results)
 

--- a/tests/unit/test_sqlalchemy_utils.py
+++ b/tests/unit/test_sqlalchemy_utils.py
@@ -194,7 +194,7 @@ def test_fetch_table_in_batches(table_size, batch_size, expected_query_count):
     connection = FakeConnection()
 
     results = fetch_table_in_batches(
-        connection, table, table.c.pk, batch_size=batch_size
+        connection.execute, table, table.c.pk, batch_size=batch_size
     )
     assert list(results) == table_data
     assert connection.call_count == expected_query_count

--- a/tests/unit/test_sqlalchemy_utils.py
+++ b/tests/unit/test_sqlalchemy_utils.py
@@ -3,10 +3,12 @@ from unittest import mock
 import pytest
 import sqlalchemy
 from sqlalchemy.dialects.sqlite.pysqlite import SQLiteDialect_pysqlite
+from sqlalchemy.engine import Engine
 from sqlalchemy.exc import OperationalError
 
 from databuilder.sqlalchemy_utils import (
     GeneratedTable,
+    ReconnectableConnection,
     clause_as_str,
     execute_with_retry_factory,
     fetch_table_in_batches,
@@ -228,3 +230,54 @@ def test_execute_with_retry_exhausted(sleep):
         execute_with_retry()
     assert execute.call_count == 4
     assert sleep.mock_calls == [mock.call(t) for t in [10, 20, 40]]
+
+
+def test_reconnectable_connection():
+    engine = mock.Mock(
+        spec=Engine,
+        **{"connect.return_value.execute.side_effect": [ERROR, "OK1", "OK2"]},
+    )
+    with ReconnectableConnection(engine) as conn:
+        # We connect as soon as the context is entered
+        assert engine.connect.call_count == 1
+
+        with pytest.raises(OperationalError):
+            conn.execute_disconnect_on_error()
+
+        # After the error the connection should be detached and closed
+        assert engine.connect.return_value.detach.call_count == 1
+        assert engine.connect.return_value.close.call_count == 1
+
+        result1 = conn.execute_disconnect_on_error()
+        assert result1 == "OK1"
+
+        # The second query should have automatically opened a new connection
+        assert engine.connect.call_count == 2
+
+        result2 = conn.execute_disconnect_on_error()
+        assert result2 == "OK2"
+
+        # But the third query should reuse the same connection as there was no error
+        assert engine.connect.call_count == 2
+
+    # On exiting the context we should call `close()` again
+    assert engine.connect.return_value.close.call_count == 2
+    # But not `detach()` as that should only be done on error
+    assert engine.connect.return_value.detach.call_count == 1
+
+
+def test_reconnectable_connection_explicit_disconnect():
+    engine = mock.Mock(spec=Engine)
+    with ReconnectableConnection(engine) as conn:
+        # Disconnecting calls `detach()` and `close()`
+        conn.disconnect()
+        assert engine.connect.return_value.detach.call_count == 1
+        assert engine.connect.return_value.close.call_count == 1
+
+        # Calling `disconnect()` on a closed connection is a no-op
+        conn.disconnect()
+        assert engine.connect.return_value.detach.call_count == 1
+        assert engine.connect.return_value.close.call_count == 1
+
+    # Exiting the context does not call `close()` either
+    assert engine.connect.return_value.close.call_count == 1


### PR DESCRIPTION
This adds the behaviour we have in cohortextractor whereby certain classes of database error are regarded as transient and are automatically retried after a suitable pause. Furthermore, if we've been able to write our results somewhere persistent then we close the database connection completely before retrying.

The tests feature the distressing presence of `mock.patch`, but given the kind of thing we're trying to test (what happens if this thing throws an error half-way through?) I don't think there's much alternative. And the tests have already exposed that I had forgotten transactions were a thing, so they do have some value.

Closes #532