### PR TITLE
fix: Remove boolean operator footgun

### DIFF
--- a/databuilder/query_language.py
+++ b/databuilder/query_language.py
@@ -37,7 +37,7 @@ class Dataset:
             raise AttributeError(
                 "Cannot set column 'population'; use set_population() instead"
             )
-        if getattr(self, name, None):
+        if hasattr(self, name):
             raise AttributeError(f"'{name}' is already set and cannot be reassigned")
         if not qm.has_one_row_per_patient(value.qm_node):
             raise TypeError(
@@ -62,6 +62,14 @@ class BaseSeries:
         # The issue here is not mutability but the fact that we overload `__eq__` for
         # syntatic sugar, which makes these types spectacularly ill-behaved as dict keys
         raise TypeError(f"unhashable type: {self.__class__.__name__!r}")
+
+    def __bool__(self):
+        raise TypeError(
+            "The keywords 'and', 'or', and 'not' cannot be used with ehrQL, please "
+            "use the operators '&', '|' and '~' instead.\n"
+            "(You will also see this error if you try use a chained comparison, "
+            "such as 'a < b < c'.)"
+        )
 
     # These are the basic operations that apply to any series regardless of type or
     # dimension

--- a/tests/unit/test_query_language.py
+++ b/tests/unit/test_query_language.py
@@ -232,3 +232,17 @@ def test_categories_are_passed_through_to_schema():
 
     schema = some_table.qm_node.schema
     assert schema.get_column_categories("some_str") == ("a", "b", "c")
+
+
+def test_boolean_operators_raise_errors():
+    exists = patients.exists_for_patient()
+    has_dob = patients.date_of_birth.is_not_null()
+    error = "The keywords 'and', 'or', and 'not' cannot be used with ehrQL"
+    with pytest.raises(TypeError, match=error):
+        not exists
+    with pytest.raises(TypeError, match=error):
+        exists and has_dob
+    with pytest.raises(TypeError, match=error):
+        exists or has_dob
+    with pytest.raises(TypeError, match=error):
+        date(2000, 1, 1) < patients.date_of_birth < date(2020, 1, 1)


### PR DESCRIPTION
Previously the standard boolean operators could be used without error in ehrQL, but with totally unexpected behaviour e.g. `a and b` would evaluate as `b`. This also applied to the implicit boolean operators involved in chained comparisons (`a < b < c`).

This PR changes the behaviour to throw a loud, and hopefully explanatory, error message.

Closes #770