### PR TITLE
Update Dockerfile including install from pyproject.toml

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -100,7 +100,8 @@ jobs:
 
           echo "$MAJOR.$MINOR.$PATCH" > databuilder/VERSION
 
-          docker build . --file Dockerfile \
+          DOCKER_BUILDKIT=1 docker build .docker build . --file Dockerfile \
+            --target databuilder
             --tag ${{ env.image }}:$MAJOR \
             --tag ${{ env.image }}:$MINOR \
             --tag ${{ env.image }}:$PATCH

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,3 +42,4 @@ repos:
     rev: cdefcb096e520a6daa9552b1d4636f5f1e1729cd
     hooks:
     - id: hadolint
+      entry: --entrypoint /bin/hadolint hadolint/hadolint:latest --ignore DL3061 --ignore DL3013 --ignore DL3042

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,96 @@
+# syntax=docker/dockerfile:1.2
+#################################################
+#
+# Initial databuilder layer with just system dependencies installed.
+#
 # hadolint ignore=DL3007
-FROM ghcr.io/opensafely-core/base-docker:latest
+FROM ghcr.io/opensafely-core/base-action:latest as databuilder-dependencies
+
+
+# setup default env vars for all images
+# ACTION_EXEC sets the default executable for the entrypoint in the base-action image
+ENV VIRTUAL_ENV=/opt/venv/ \
+    PYTHONPATH=/app \
+    PATH="/opt/venv/bin:/opt/mssql-tools/bin:$PATH" \
+    ACTION_EXEC=databuilder \
+    PYTHONUNBUFFERED=True \
+    PYTHONDONTWRITEBYTECODE=1
+
+
+RUN mkdir /workspace
+WORKDIR /workspace
+
+# We are going to use an apt cache on the host, so disable the default debian
+# docker clean up that deletes that cache on every apt install
+RUN rm -f /etc/apt/apt.conf.d/docker-clean
+
+# Using apt-helper means we don't need to install curl or gpg
+RUN /usr/lib/apt/apt-helper download-file https://packages.microsoft.com/keys/microsoft.asc /etc/apt/trusted.gpg.d/microsoft.asc && \
+    /usr/lib/apt/apt-helper download-file https://packages.microsoft.com/config/ubuntu/20.04/prod.list /etc/apt/sources.list.d/mssql-release.list
+
+# Install root dependencies, including python3.9
+COPY dependencies.txt /root/dependencies.txt
+# use space efficient utility from base image
+RUN --mount=type=cache,target=/var/cache/apt \
+    /usr/bin/env ACCEPT_EULA=Y /root/docker-apt-install.sh /root/dependencies.txt
+
+#################################################
+#
+# Next, use the dependencies image to create an image to build dependencies
+FROM databuilder-dependencies as databuilder-builder
+
+# install build time dependencies
+COPY build-dependencies.txt /root/build-dependencies.txt
+RUN /root/docker-apt-install.sh /root/build-dependencies.txt
+
+
+# install everything in venv for isolation from system python libraries
+# hadolint ignore=DL3013,DL3042
+RUN --mount=type=cache,target=/root/.cache \
+    /usr/bin/python3.9 -m venv /opt/venv && \
+    /opt/venv/bin/python -m pip install -U pip setuptools wheel
+
+COPY requirements.prod.txt /root/requirements.prod.txt
+# hadolint ignore=DL3042
+RUN --mount=type=cache,target=/root/.cache python -m pip install -r /root/requirements.prod.txt
+
+# WARNING clever/ugly python packaging hacks alert
+#
+# We could just do `COPY . /app` and then `pip install /app`. However, this is
+# not ideal for a number of reasons:
+#
+# 1) Any changes to the app files will invalidate this and all subsequent
+#    layers, causing them to need rebuilding. This would mean basically
+#    reinstalling dev dependencies every time.
+#
+# 2) We want to use the pinned versions of dependencies in
+#    requirements.prod.txt rather than the unpinned versions in pyproject.toml.
+#
+# 3) We want for developers be able to mount /app with their code and it Just
+#    Works, without reinstalling anything.
+#
+# So, we do the following:
+#
+# 1) Just copy the pyproject.toml file, and install an empty package from it alone.
+#    This means we only repeat this step if pyproject.toml changes, which is
+#    infrequently.
+#
+# 2) We install it without deps, as they've already been installed.
+#
+# 3) We have set PYTHONPATH=/app, so that code copied or mounted into /app will
+#    be used automatically.
+#
+# Note: we only really need to install it at all to use setuptools entrypoints.
+RUN mkdir /app
+COPY pyproject.toml /app/pyproject.toml
+COPY README.md /app/README.md
+# # hadolint ignore=DL3042
+RUN python3.9 -m pip install --no-deps /app
+
+################################################
+#
+# A base image with the including the prepared venv and metadata.
+FROM databuilder-dependencies as databuilder-base
 
 # Some static metadata for this specific image, as defined by:
 # https://github.com/opencontainers/image-spec/blob/master/annotations.md#pre-defined-annotation-keys
@@ -10,23 +101,26 @@ LABEL org.opencontainers.image.title="databuilder" \
       org.opencontainers.image.source="https://github.com/opensafely-core/databuilder" \
       org.opensafely.action="databuilder"
 
-# hadolint ignore=DL3008
-RUN \
-  apt-get update --fix-missing && \
-  apt-get install -y --no-install-recommends \
-    python3.9 python3.9-dev python3-pip && \
-    update-alternatives --install /usr/bin/python python /usr/bin/python3.9 1 && \
-    rm -rf /var/lib/apt/lists/*
+COPY --from=databuilder-builder /opt/venv /opt/venv
 
-COPY requirements.prod.txt /app/requirements.txt
-RUN python -m pip install --no-cache-dir --requirement /app/requirements.txt
+################################################
+#
+# Build the actual production image from the base
+FROM databuilder-base as databuilder
 
-# hadolint ignore=DL3059
-RUN mkdir /workspace
-WORKDIR /workspace
-
-# -B: don't write bytecode files
-ENTRYPOINT ["python", "-B", "-m", "databuilder"]
-ENV PYTHONPATH="/app"
+# copy app code. This will be automatically picked up by the virtual env as per
+# comment above
 COPY databuilder /app/databuilder
-RUN python -m compileall /app/databuilder
+# COPY entrypoint.sh /app/run.sh
+# RUN python -m compileall /app/databuilder
+RUN /opt/venv/bin/databuilder --help
+
+################################################
+#
+# Development image that includes test dependencies and mounts the code in
+FROM databuilder as databuilder-dev
+
+# Install dev dependencies
+COPY requirements.dev.txt /root/requirements.dev.txt
+# hadolint ignore=DL3042
+RUN --mount=type=cache,target=/root/.cache python -m pip install -r /root/requirements.dev.txt

--- a/Justfile
+++ b/Justfile
@@ -119,7 +119,7 @@ build-databuilder:
     set -euo pipefail
 
     [[ -v CI ]] && echo "::group::Build databuilder (click to view)" || echo "Build databuilder"
-    docker build . -t databuilder-dev
+    DOCKER_BUILDKIT=1 docker build . -t databuilder-dev
     [[ -v CI ]] && echo "::endgroup::" || echo ""
 
 

--- a/build-dependencies.txt
+++ b/build-dependencies.txt
@@ -1,0 +1,3 @@
+# list ubuntu packges needed to build dependencies, one per line
+python3.9-dev
+build-essential

--- a/dependencies.txt
+++ b/dependencies.txt
@@ -1,0 +1,11 @@
+# list ubuntu packages needed in production, one per line
+# run time dependencies
+# ensure fully working base python3 installation
+# see: https://gist.github.com/tiran/2dec9e03c6f901814f6d1e8dad09528e
+python3.9
+python3.9-dev
+python3.9-venv
+python3.9-distutils
+
+# from packages.microsoft.com
+mssql-tools

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["flit_core >=3.2,<4"]
-build-backend = "flit_core.buildapi"
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
 
 [project]
 name = "opensafely-databuilder"
@@ -74,9 +74,6 @@ omit = [
 ]
 
 [tool.coverage.html]
-
-[tool.flit.module]
-name = "databuilder"
 
 [tool.interrogate]
 fail-under = 0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 from pathlib import Path
 
@@ -126,6 +127,7 @@ def databuilder_image():
     subprocess.run(
         ["docker", "build", project_dir, "-t", image],
         check=True,
+        env=dict(os.environ, DOCKER_BUILDKIT="1"),
     )
     return f"{image}:latest"
 


### PR DESCRIPTION
This follows the way cohort-extractor's Dockerfile works, including installing from the pyproject.toml and making the executable `databuilder` available.  
BUT - that didn't work with flit, so I had to make changes to the pyproject.toml file, which then means that pip-compile isn't working properly.  So this builds the docker image correctly, afaict, and it's pretty quick about it, and changes to app code don't take long to rebuild, but the pyproject.toml is broken for other things.  At the moment I don't think we're actually building a databuilder package, but I assume we probably will in future.