### PR TITLE
Update Dockerfile to improve caching/layering

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -100,7 +100,8 @@ jobs:
 
           echo "$MAJOR.$MINOR.$PATCH" > databuilder/VERSION
 
-          docker build . --file Dockerfile \
+          DOCKER_BUILDKIT=1 docker build .docker build . --file Dockerfile \
+            --target databuilder
             --tag ${{ env.image }}:$MAJOR \
             --tag ${{ env.image }}:$MINOR \
             --tag ${{ env.image }}:$PATCH

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,3 +42,4 @@ repos:
     rev: cdefcb096e520a6daa9552b1d4636f5f1e1729cd
     hooks:
     - id: hadolint
+      entry: --entrypoint /bin/hadolint hadolint/hadolint:latest --ignore DL3061 --ignore DL3013 --ignore DL3042

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,9 +37,3 @@ repos:
     - id: check-toml
     - id: check-yaml
     - id: detect-private-key
-
-  - repo: https://github.com/stratasan/hadolint-pre-commit
-    rev: cdefcb096e520a6daa9552b1d4636f5f1e1729cd
-    hooks:
-    - id: hadolint
-      entry: --entrypoint /bin/hadolint hadolint/hadolint:latest --ignore DL3061 --ignore DL3013 --ignore DL3042

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,63 @@
+# syntax=docker/dockerfile:1.2
+#################################################
+#
+# Initial databuilder layer with just system dependencies installed.
+#
 # hadolint ignore=DL3007
-FROM ghcr.io/opensafely-core/base-docker:latest
+FROM ghcr.io/opensafely-core/base-action:latest as databuilder-dependencies
+
+
+# setup default env vars for all images
+# ACTION_EXEC sets the default executable for the entrypoint in the base-action image
+ENV VIRTUAL_ENV=/opt/venv/ \
+    PYTHONPATH=/app \
+    PATH="/opt/venv/bin:/opt/mssql-tools/bin:$PATH" \
+    ACTION_EXEC=/app/entrypoint.sh \
+    PYTHONUNBUFFERED=True \
+    PYTHONDONTWRITEBYTECODE=1
+
+
+RUN mkdir /workspace
+WORKDIR /workspace
+
+# We are going to use an apt cache on the host, so disable the default debian
+# docker clean up that deletes that cache on every apt install
+RUN rm -f /etc/apt/apt.conf.d/docker-clean
+
+# Using apt-helper means we don't need to install curl or gpg
+RUN /usr/lib/apt/apt-helper download-file https://packages.microsoft.com/keys/microsoft.asc /etc/apt/trusted.gpg.d/microsoft.asc && \
+    /usr/lib/apt/apt-helper download-file https://packages.microsoft.com/config/ubuntu/20.04/prod.list /etc/apt/sources.list.d/mssql-release.list
+
+# Install root dependencies, including python3.9
+COPY dependencies.txt /root/dependencies.txt
+# use space efficient utility from base image
+RUN --mount=type=cache,target=/var/cache/apt \
+    /usr/bin/env ACCEPT_EULA=Y /root/docker-apt-install.sh /root/dependencies.txt
+
+#################################################
+#
+# Next, use the dependencies image to create an image to build dependencies
+FROM databuilder-dependencies as databuilder-builder
+
+# install build time dependencies
+COPY build-dependencies.txt /root/build-dependencies.txt
+RUN /root/docker-apt-install.sh /root/build-dependencies.txt
+
+
+# install everything in venv for isolation from system python libraries
+# hadolint ignore=DL3013,DL3042
+RUN --mount=type=cache,target=/root/.cache \
+    /usr/bin/python3.9 -m venv /opt/venv && \
+    /opt/venv/bin/python -m pip install -U pip setuptools wheel
+
+COPY requirements.prod.txt /root/requirements.prod.txt
+# hadolint ignore=DL3042
+RUN --mount=type=cache,target=/root/.cache python -m pip install -r /root/requirements.prod.txt
+
+################################################
+#
+# A base image with the including the prepared venv and metadata.
+FROM databuilder-dependencies as databuilder-base
 
 # Some static metadata for this specific image, as defined by:
 # https://github.com/opencontainers/image-spec/blob/master/annotations.md#pre-defined-annotation-keys
@@ -10,23 +68,27 @@ LABEL org.opencontainers.image.title="databuilder" \
       org.opencontainers.image.source="https://github.com/opensafely-core/databuilder" \
       org.opensafely.action="databuilder"
 
-# hadolint ignore=DL3008
-RUN \
-  apt-get update --fix-missing && \
-  apt-get install -y --no-install-recommends \
-    python3.9 python3.9-dev python3-pip && \
-    update-alternatives --install /usr/bin/python python /usr/bin/python3.9 1 && \
-    rm -rf /var/lib/apt/lists/*
+COPY --from=databuilder-builder /opt/venv /opt/venv
 
-COPY requirements.prod.txt /app/requirements.txt
-RUN python -m pip install --no-cache-dir --requirement /app/requirements.txt
+RUN mkdir /app
 
-# hadolint ignore=DL3059
-RUN mkdir /workspace
-WORKDIR /workspace
+################################################
+#
+# Build the actual production image from the base
+FROM databuilder-base as databuilder
 
-# -B: don't write bytecode files
-ENTRYPOINT ["python", "-B", "-m", "databuilder"]
-ENV PYTHONPATH="/app"
+# copy app code. This will be automatically picked up by the virtual env as per
+# comment above
+COPY entrypoint.sh /app/entrypoint.sh
 COPY databuilder /app/databuilder
 RUN python -m compileall /app/databuilder
+
+################################################
+#
+# Development image that includes test dependencies and mounts the code in
+FROM databuilder as databuilder-dev
+
+# Install dev dependencies
+COPY requirements.dev.txt /root/requirements.dev.txt
+# hadolint ignore=DL3042
+RUN --mount=type=cache,target=/root/.cache python -m pip install -r /root/requirements.dev.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,6 @@ ENV VIRTUAL_ENV=/opt/venv/ \
     PYTHONUNBUFFERED=True \
     PYTHONDONTWRITEBYTECODE=1
 
-
 RUN mkdir /workspace
 WORKDIR /workspace
 
@@ -82,13 +81,3 @@ FROM databuilder-base as databuilder
 COPY entrypoint.sh /app/entrypoint.sh
 COPY databuilder /app/databuilder
 RUN python -m compileall /app/databuilder
-
-################################################
-#
-# Development image that includes test dependencies and mounts the code in
-FROM databuilder as databuilder-dev
-
-# Install dev dependencies
-COPY requirements.dev.txt /root/requirements.dev.txt
-# hadolint ignore=DL3042
-RUN --mount=type=cache,target=/root/.cache python -m pip install -r /root/requirements.dev.txt

--- a/Justfile
+++ b/Justfile
@@ -119,7 +119,7 @@ build-databuilder:
     set -euo pipefail
 
     [[ -v CI ]] && echo "::group::Build databuilder (click to view)" || echo "Build databuilder"
-    docker build . -t databuilder-dev
+    DOCKER_BUILDKIT=1 docker build . -t databuilder-dev
     [[ -v CI ]] && echo "::endgroup::" || echo ""
 
 

--- a/Justfile
+++ b/Justfile
@@ -97,6 +97,8 @@ check: devenv
         $(find databuilder -name "*.py" -type f) \
         $(find tests -name "*.py" -type f)
     just docstrings
+    docker pull hadolint/hadolint
+    docker run --rm -i hadolint/hadolint < Dockerfile
 
 # ensure our public facing docstrings exist so we can build docs from them
 docstrings: devenv

--- a/build-dependencies.txt
+++ b/build-dependencies.txt
@@ -1,0 +1,3 @@
+# list ubuntu packges needed to build dependencies, one per line
+python3.9-dev
+build-essential

--- a/dependencies.txt
+++ b/dependencies.txt
@@ -1,0 +1,11 @@
+# list ubuntu packages needed in production, one per line
+# run time dependencies
+# ensure fully working base python3 installation
+# see: https://gist.github.com/tiran/2dec9e03c6f901814f6d1e8dad09528e
+python3.9
+python3.9-dev
+python3.9-venv
+python3.9-distutils
+
+# from packages.microsoft.com
+mssql-tools

--- a/dependencies.txt
+++ b/dependencies.txt
@@ -3,7 +3,6 @@
 # ensure fully working base python3 installation
 # see: https://gist.github.com/tiran/2dec9e03c6f901814f6d1e8dad09528e
 python3.9
-python3.9-dev
 python3.9-venv
 python3.9-distutils
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 # -B: don't write bytecode files
-/opt/venv/bin/python3.9 -B -m databuilder
+/opt/venv/bin/python3.9 -B -m databuilder "$@"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# -B: don't write bytecode files
+/opt/venv/bin/python3.9 -B -m databuilder

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 from pathlib import Path
 
@@ -126,6 +127,7 @@ def databuilder_image():
     subprocess.run(
         ["docker", "build", project_dir, "-t", image],
         check=True,
+        env=dict(os.environ, DOCKER_BUILDKIT="1"),
     )
     return f"{image}:latest"
 


### PR DESCRIPTION
Fixes #665 

This is the approach that I've been able to get working for databuilder; see comments in the issue and alternative draft PR #773  for the alternative.

This updates the Dockerfile with similar improvements to those in cohort-extractor, but unlike #773 , it doesn't pip install using the pyproject.toml.  It keeps the entrypoint we had before (`python3.9 -m -B databuilder`) but moves it out into an entrypoint script so it can be set as the `ACTION_EXEC` env and passed as the entrypoint to the base-action.

I didn't notice this being discernable slower to build (and rebuild after code changes) than the version in #773 

Docker tests are now passing, and it also works to run a [local project](https://github.com/opensafely/test-age-distribution) with `opensafely-cli`