### PR TITLE
Enable sorting for generative tests

### DIFF
--- a/databuilder/collections_utils.py
+++ b/databuilder/collections_utils.py
@@ -11,7 +11,9 @@ class IdentitySet(MutableSet):
     """
 
     def __init__(self, seq=()):
-        self._set = {Ref(v) for v in seq}
+        self._set = set()
+        for value in seq:
+            self.add(value)
 
     def add(self, value):
         self._set.add(Ref(value))
@@ -28,7 +30,7 @@ class IdentitySet(MutableSet):
     def __iter__(self):
         return (ref.referent for ref in self._set)
 
-    def __repr__(self):
+    def __repr__(self):  # pragma: no cover
         return f"{type(self).__name__}({list(self)})"
 
 
@@ -39,7 +41,11 @@ class IdentityDict(MutableMapping):
     """
 
     def __init__(self, seq=(), **kwargs):
-        self._dict = {Ref(k): v for k, v in seq}
+        self._dict = {}
+        for k, v in seq:
+            self[k] = v
+        for k, v in kwargs.items():
+            self[k] = v
 
     def __setitem__(self, key, value):
         self._dict[Ref(key)] = value
@@ -56,7 +62,7 @@ class IdentityDict(MutableMapping):
     def __iter__(self):
         return (ref.referent for ref in self._dict)
 
-    def __repr__(self):
+    def __repr__(self):  # pragma: no cover
         return f"{type(self).__name__}({list(self.items())})"
 
 

--- a/databuilder/collections_utils.py
+++ b/databuilder/collections_utils.py
@@ -1,0 +1,101 @@
+from abc import ABC
+from collections.abc import Mapping, MutableMapping, MutableSet
+
+
+class IdentitySet(MutableSet):
+    """
+    This set considers objects equal if and only if they are identical, even if they
+    have overridden __eq__() and __hash__().
+
+    Adapted with gratitude from https://stackoverflow.com/a/17039643/400467.
+    """
+
+    def __init__(self, seq=()):
+        self._set = {Ref(v) for v in seq}
+
+    def add(self, value):
+        self._set.add(Ref(value))
+
+    def discard(self, value):
+        self._set.discard(Ref(value))
+
+    def __contains__(self, value):
+        return Ref(value) in self._set
+
+    def __len__(self):
+        return len(self._set)
+
+    def __iter__(self):
+        return (ref.referent for ref in self._set)
+
+    def __repr__(self):
+        return f"{type(self).__name__}({list(self)})"
+
+
+class IdentityDict(MutableMapping):
+    """
+    This map considers keys equal if and only if they are identical, even if they
+    have overridden __eq__() and __hash__().
+    """
+
+    def __init__(self, seq=(), **kwargs):
+        self._dict = {Ref(k): v for k, v in seq}
+
+    def __setitem__(self, key, value):
+        self._dict[Ref(key)] = value
+
+    def __delitem__(self, key):
+        del self._dict[Ref(key)]
+
+    def __getitem__(self, key):
+        return self._dict[Ref(key)]
+
+    def __len__(self):
+        return len(self._dict)
+
+    def __iter__(self):
+        return (ref.referent for ref in self._dict)
+
+    def __repr__(self):
+        return f"{type(self).__name__}({list(self.items())})"
+
+
+class DefaultDict(Mapping, ABC):
+    """
+    Mixin to provide defaultdict-like behaviour for custom Mapping classes.
+
+    Must be the first base class of a derived class. Must be mixed in with
+    another base class that provides Mapping methods.
+    """
+
+    def __init__(self, default_factory=None, **kwargs):
+        super().__init__(**kwargs)
+        self.default_factory = default_factory
+
+    def __getitem__(self, key):
+        try:
+            return super().__getitem__(key)
+        except KeyError:
+            return self.__missing__(key)
+
+    def __missing__(self, key):
+        if self.default_factory is None:
+            raise KeyError(key)
+        value = self.default_factory()
+        self[key] = value
+        return value
+
+
+class DefaultIdentityDict(DefaultDict, IdentityDict):
+    pass
+
+
+class Ref:
+    def __init__(self, referent):
+        self.referent = referent
+
+    def __eq__(self, other):
+        return isinstance(other, type(self)) and self.referent is other.referent
+
+    def __hash__(self):
+        return id(self.referent)

--- a/databuilder/query_engines/base_sql.py
+++ b/databuilder/query_engines/base_sql.py
@@ -546,7 +546,7 @@ def get_table_and_filter_conditions(frame):
 
 def get_sort_conditions(frame):
     """
-    Given a SortedFrame, return a tuple of Series which gives the sort order
+    Given a sorted frame, return a tuple of Series which gives the sort order
     """
     _, _, sorts = get_frame_operations(frame)
     # Sort operations are given to us in order of application which is the reverse of

--- a/databuilder/query_engines/base_sql.py
+++ b/databuilder/query_engines/base_sql.py
@@ -22,6 +22,8 @@ from databuilder.query_model import (
     Sort,
     Value,
     get_domain,
+    get_sorts,
+    get_table_and_filters,
     has_many_rows_per_patient,
 )
 from databuilder.query_model_transforms import (
@@ -540,7 +542,7 @@ def get_table_and_filter_conditions(frame):
     Given a ManyRowsPerPatientFrame, return a base SelectTable operation and a list of
     filter conditions (or predicates) to be applied
     """
-    root_frame, filters, _ = get_frame_operations(frame)
+    filters, root_frame = get_table_and_filters(frame)
     return root_frame, [f.condition for f in filters]
 
 
@@ -548,29 +550,7 @@ def get_sort_conditions(frame):
     """
     Given a sorted frame, return a tuple of Series which gives the sort order
     """
-    _, _, sorts = get_frame_operations(frame)
     # Sort operations are given to us in order of application which is the reverse of
     # order of priority (i.e. the most recently applied sort gives us the primary sort
     # condition) so we reverse them here
-    return tuple(s.sort_by for s in reversed(sorts))
-
-
-def get_frame_operations(frame):
-    """
-    Given a ManyRowsPerPatientFrame, destructure it into a base SelectTable operation,
-    plus separate lists of Filter and Sort operations
-    """
-    filters = []
-    sorts = []
-    while True:
-        type_ = type(frame)
-        if type_ is Filter:
-            filters.insert(0, frame)
-            frame = frame.source
-        elif type_ is Sort:
-            sorts.insert(0, frame)
-            frame = frame.source
-        elif type_ is SelectTable:
-            return frame, filters, sorts
-        else:
-            assert False, f"Unexpected type: {frame}"
+    return tuple(s.sort_by for s in reversed(get_sorts(frame)))

--- a/databuilder/query_engines/in_memory.py
+++ b/databuilder/query_engines/in_memory.py
@@ -10,6 +10,7 @@ from databuilder.query_engines.in_memory_database import (
     apply_function,
     handle_null,
 )
+from databuilder.query_model_transforms import apply_transforms
 
 T = True
 F = False
@@ -25,6 +26,8 @@ class InMemoryQueryEngine(BaseQueryEngine):
 
     def get_results(self, variable_definitions):
         self.cache = {}
+
+        variable_definitions = apply_transforms(variable_definitions)
 
         name_to_col = {
             "patient_id": PatientColumn(
@@ -106,7 +109,7 @@ class InMemoryQueryEngine(BaseQueryEngine):
         sort_index = self.visit(node.sort_by).sort_index()
         return source.sort(sort_index)
 
-    def visit_PickOneRowPerPatient(self, node):
+    def visit_PickOneRowPerPatientWithColumns(self, node):
         ix = {
             qm.Position.FIRST: 0,
             qm.Position.LAST: -1,

--- a/databuilder/query_model.py
+++ b/databuilder/query_model.py
@@ -7,6 +7,7 @@ from functools import cache, singledispatch
 from types import GenericAlias
 from typing import Any, Optional, TypeVar
 
+from .codes import BaseCode
 from .typing_utils import get_typespec, get_typevars, type_matches
 
 # The below classes and functions are the public API surface of the query model
@@ -49,7 +50,7 @@ __all__ = [
 # type without specifying what that type has to be
 T = TypeVar("T")
 Numeric = TypeVar("Numeric", int, float)
-Comparable = TypeVar("Comparable", int, float, str, date)
+Comparable = TypeVar("Comparable", int, float, str, date, BaseCode)
 
 
 class Position(Enum):

--- a/databuilder/query_model.py
+++ b/databuilder/query_model.py
@@ -774,3 +774,42 @@ def get_root_frame(frame):
 @get_root_frame.register(SelectPatientTable)
 def get_root_frame_for_table(frame):
     return frame
+
+
+def get_table_and_filters(frame):
+    """
+    Given a ManyRowsPerPatientFrame, destructure it and return the underlying table and
+    any filter operations that have been applied, in application order.
+    """
+    root_frame, filters, _ = get_frame_operations(frame)
+    return filters, root_frame
+
+
+def get_sorts(frame):
+    """
+    Given a ManyRowsPerPatientFrame, destructure it and return any sort operations that
+    have been applied, in application order.
+    """
+    _, _, sorts = get_frame_operations(frame)
+    return sorts
+
+
+def get_frame_operations(frame):
+    """
+    Given a ManyRowsPerPatientFrame, destructure it and return the underlying table and
+    any filter and sort operations that have been applied, in application order.
+    """
+    filters = []
+    sorts = []
+    while True:
+        type_ = type(frame)
+        if type_ is Filter:
+            filters.insert(0, frame)
+            frame = frame.source
+        elif type_ is Sort:
+            sorts.insert(0, frame)
+            frame = frame.source
+        elif type_ is SelectTable:
+            return frame, filters, sorts
+        else:
+            assert False, f"Unexpected type: {frame}"

--- a/databuilder/query_model.py
+++ b/databuilder/query_model.py
@@ -78,6 +78,10 @@ class Column:
 class TableSchema:
     "Defines a mapping of column names to column definitions"
 
+    @classmethod
+    def from_primitives(cls, **kwargs):
+        return cls(**{name: Column(type_) for name, type_ in kwargs.items()})
+
     def __init__(self, **kwargs):
         self.schema = kwargs
 

--- a/databuilder/query_model.py
+++ b/databuilder/query_model.py
@@ -165,11 +165,6 @@ class ManyRowsPerPatientSeries(Series):
     ...
 
 
-# A Frame which has had a Sort operation applied to it
-class SortedFrame(ManyRowsPerPatientFrame):
-    ...
-
-
 # A OneRowPerPatientSeries which is the result of aggregating one or more
 # ManyRowsPerPatientSeries
 class AggregatedSeries(OneRowPerPatientSeries):
@@ -219,13 +214,13 @@ class Filter(ManyRowsPerPatientFrame):
     condition: Series[bool]
 
 
-class Sort(SortedFrame):
+class Sort(ManyRowsPerPatientFrame):
     source: ManyRowsPerPatientFrame
     sort_by: Series[Comparable]
 
 
 class PickOneRowPerPatient(OneRowPerPatientFrame):
-    source: SortedFrame
+    source: Sort
     position: Position
 
 

--- a/databuilder/query_model_transforms.py
+++ b/databuilder/query_model_transforms.py
@@ -14,10 +14,9 @@ The transformations applied here are all about efficient execution, and therefor
 want to keep them separate from the core query model classes.
 """
 import copy
-from abc import ABC
-from collections.abc import Mapping, MutableMapping, MutableSet
 from typing import Any
 
+from databuilder.collections_utils import DefaultIdentityDict, IdentitySet
 from databuilder.query_model import (
     Case,
     Function,
@@ -182,105 +181,6 @@ def build_reverse_index(nodes):
         for i in get_input_nodes(n):
             reverse_index[i].add(n)
     return reverse_index
-
-
-class IdentitySet(MutableSet):
-    """
-    This set considers objects equal if and only if they are identical, even if they
-    have overridden __eq__() and __hash__().
-
-    Adapted with gratitude from https://stackoverflow.com/a/17039643/400467.
-    """
-
-    def __init__(self, seq=()):
-        self._set = {Ref(v) for v in seq}
-
-    def add(self, value):
-        self._set.add(Ref(value))
-
-    def discard(self, value):
-        self._set.discard(Ref(value))
-
-    def __contains__(self, value):
-        return Ref(value) in self._set
-
-    def __len__(self):
-        return len(self._set)
-
-    def __iter__(self):
-        return (ref.referent for ref in self._set)
-
-    def __repr__(self):
-        return f"{type(self).__name__}({list(self)})"
-
-
-class IdentityDict(MutableMapping):
-    """
-    This map considers keys equal if and only if they are identical, even if they
-    have overridden __eq__() and __hash__().
-    """
-
-    def __init__(self, seq=(), **kwargs):
-        self._dict = {Ref(k): v for k, v in seq}
-
-    def __setitem__(self, key, value):
-        self._dict[Ref(key)] = value
-
-    def __delitem__(self, key):
-        del self._dict[Ref(key)]
-
-    def __getitem__(self, key):
-        return self._dict[Ref(key)]
-
-    def __len__(self):
-        return len(self._dict)
-
-    def __iter__(self):
-        return (ref.referent for ref in self._dict)
-
-    def __repr__(self):
-        return f"{type(self).__name__}({list(self.items())})"
-
-
-class DefaultDict(Mapping, ABC):
-    """
-    Mixin to provide defaultdict-like behaviour for custom Mapping classes.
-
-    Must be the first base class of a derived class. Must be mixed in with
-    another base class that provides Mapping methods.
-    """
-
-    def __init__(self, default_factory=None, **kwargs):
-        super().__init__(**kwargs)
-        self.default_factory = default_factory
-
-    def __getitem__(self, key):
-        try:
-            return super().__getitem__(key)
-        except KeyError:
-            return self.__missing__(key)
-
-    def __missing__(self, key):
-        if self.default_factory is None:
-            raise KeyError(key)
-        value = self.default_factory()
-        self[key] = value
-        return value
-
-
-class DefaultIdentityDict(DefaultDict, IdentityDict):
-    pass
-
-
-class Ref:
-    def __init__(self, referent):
-        self.referent = referent
-
-    def __eq__(self, other):
-        return isinstance(other, type(self)) and self.referent is other.referent
-
-    def __hash__(self):
-        return id(self.referent)
 
 
 # We can't modify attributes on frozen dataclass instances in the normal way, so we have

--- a/databuilder/query_model_transforms.py
+++ b/databuilder/query_model_transforms.py
@@ -111,11 +111,15 @@ def include_all_selected_columns_in_sorts(nodes):
             if column.name not in existing_sorted_column_names
         ]
 
+        # We introduce an arbitrary canonical order for the added sorts (lexically by column name) so
+        # that the sort order is stable.
+        ordered_sorts_to_add = sorted(sorts_to_add, key=lambda c: c.name)
+
         # The new sorts come below the existing ones in the stack -- meaning that they have lower
         # priority and are only used to disambiguate between rows for which the sort order would
         # otherwise be undefined.
         lowest_sort = sorts[-1]
-        for column in sorts_to_add:
+        for column in ordered_sorts_to_add:
             new_sort = Sort(source=lowest_sort.source, sort_by=column)
             force_setattr(lowest_sort, "source", new_sort)
             lowest_sort = new_sort

--- a/databuilder/query_model_transforms.py
+++ b/databuilder/query_model_transforms.py
@@ -27,6 +27,7 @@ from databuilder.query_model import (
     all_nodes,
     get_input_nodes,
     get_series_type,
+    get_sorts,
 )
 
 
@@ -128,7 +129,7 @@ def add_columns_to_pick(node, selected_column_names):
 
 
 def add_extra_sorts(node, selected_column_names):
-    all_sorts = get_immediate_sorts(node)
+    all_sorts = get_sorts(node.source)
 
     # Don't duplicate existing direct sorts
     direct_sorts = [
@@ -141,7 +142,7 @@ def add_extra_sorts(node, selected_column_names):
     ordered_sorts_to_add = sorted(sorts_to_add)
 
     # Add at the bottom of the stack
-    lowest_sort = all_sorts[-1]
+    lowest_sort = all_sorts[0]
     for column in ordered_sorts_to_add:
         sort_by = make_sortable(SelectColumn(lowest_sort.source, column))
         new_sort = Sort(
@@ -151,19 +152,6 @@ def add_extra_sorts(node, selected_column_names):
         force_setattr(lowest_sort, "source", new_sort)
         force_setattr(lowest_sort.sort_by, "source", new_sort)
         lowest_sort = new_sort
-
-
-def get_immediate_sorts(node):
-    """
-    The source of a PickOneRowPerPatient[WithColumns] is always a Sort, which itself may be
-    stacked on top of further Sort nodes. Return just those Sort nodes, from top to bottom.
-    """
-    sorts = []
-    source = node.source
-    while isinstance(source, Sort):
-        sorts.append(source)
-        source = source.source
-    return sorts
 
 
 def make_sortable(col):

--- a/tests/generative/variable_strategies.py
+++ b/tests/generative/variable_strategies.py
@@ -6,9 +6,12 @@ from databuilder.query_model import (
     AggregateByPatient,
     Filter,
     Function,
+    PickOneRowPerPatient,
+    Position,
     SelectColumn,
     SelectPatientTable,
     SelectTable,
+    Sort,
     ValidationError,
     Value,
     get_input_nodes,
@@ -70,16 +73,14 @@ def variable(patient_tables, event_tables, schema, int_values, bool_values):
     one_row_per_patient_frame = st.deferred(
         lambda: st.one_of(
             select_patient_table,
-            # See `sort`
-            # pick_one_row_per_patient,
+            pick_one_row_per_patient,
         )
     )
 
     many_rows_per_patient_frame = st.deferred(
         lambda: st.one_of(
             select_table,
-            # See `sort`
-            # sorted_frame,
+            sorted_frame,
             filter_,
         )
     )
@@ -132,8 +133,7 @@ def variable(patient_tables, event_tables, schema, int_values, bool_values):
         )
     )
 
-    # See `sort`
-    # sorted_frame = st.deferred(lambda: st.one_of(sort))
+    sorted_frame = st.deferred(lambda: st.one_of(sort))
 
     value = qm_builds(Value, st.one_of(int_values, bool_values))
 
@@ -153,15 +153,13 @@ def variable(patient_tables, event_tables, schema, int_values, bool_values):
 
     filter_ = qm_builds(Filter, many_rows_per_patient_frame, series)
 
-    # TODO: gives inconsistent test results, see https://github.com/opensafely-core/databuilder/issues/461
-    # sort = qm_builds(Sort, many_rows_per_patient_frame, many_rows_per_patient_series)
+    sort = qm_builds(Sort, many_rows_per_patient_frame, many_rows_per_patient_series)
 
-    # See `sort`
-    # pick_one_row_per_patient = qm_builds(
-    #     PickOneRowPerPatient,
-    #     sorted_frame,
-    #     st.sampled_from([Position.FIRST, Position.LAST]),
-    # )
+    pick_one_row_per_patient = qm_builds(
+        PickOneRowPerPatient,
+        sorted_frame,
+        st.sampled_from([Position.FIRST, Position.LAST]),
+    )
 
     exists = qm_builds(AggregateByPatient.Exists, many_rows_per_patient_frame)
     count_ = qm_builds(AggregateByPatient.Count, many_rows_per_patient_frame)

--- a/tests/integration/test_query_model_transforms.py
+++ b/tests/integration/test_query_model_transforms.py
@@ -1,0 +1,53 @@
+import sqlalchemy.orm
+
+from databuilder import orm_utils
+from databuilder.query_model import (
+    AggregateByPatient,
+    PickOneRowPerPatient,
+    Position,
+    SelectColumn,
+    SelectTable,
+    Sort,
+    TableSchema,
+)
+
+schema = TableSchema.from_primitives(i=int, b=bool)
+base = sqlalchemy.orm.declarative_base()
+EventsTable = orm_utils.orm_class_from_schema(base, "events", schema, False)
+
+
+def test_sort_booleans_null_first(engine):
+    # The transforms add sorts for unsorted selected columns. Here we're checking the semantics
+    # of the sort added for boolean columns (which are handled explicitly because some databases
+    # don't allow sorting on booleans.
+    #
+    # The desired sort order is: NULL, False, True.
+    #
+    # Each of these patients has two records with different boolean values so we do pairwise
+    # comparisons. The integer column is there only so we can specify a sort on it in the query
+    # model.
+    engine.setup(
+        [
+            EventsTable(patient_id=0, row_id=0, i=0, b=False),
+            EventsTable(patient_id=0, row_id=1, i=0, b=True),
+            EventsTable(patient_id=1, row_id=2, i=0, b=None),
+            EventsTable(patient_id=1, row_id=3, i=0, b=True),
+            EventsTable(patient_id=2, row_id=4, i=0, b=None),
+            EventsTable(patient_id=2, row_id=5, i=0, b=False),
+        ]
+    )
+
+    # Sort the events by i and pick the b from the last row.
+    events = SelectTable("events", schema)
+    by_i = Sort(events, SelectColumn(events, "i"))
+    variable = SelectColumn(
+        PickOneRowPerPatient(source=by_i, position=Position.LAST),
+        "b",
+    )
+    population = AggregateByPatient.Exists(events)
+
+    assert engine.extract_qm(dict(v=variable, population=population)) == [
+        dict(patient_id=0, v=True),  # True sorts after False
+        dict(patient_id=1, v=True),  # True sorts after NULL
+        dict(patient_id=2, v=False),  # False sorts after NULL
+    ]

--- a/tests/spec/sort_and_pick/test_sort_extends_to_all_columns_when_underspecified.py
+++ b/tests/spec/sort_and_pick/test_sort_extends_to_all_columns_when_underspecified.py
@@ -1,0 +1,24 @@
+from ..tables import e
+
+title = "Sort extends to all columns when underspecified to ensure that sort order is consistent"
+
+table_data = {
+    e: """
+          |  i1 | i2 |  i3
+        --+----------------
+        1 | 100 |  2 | 101
+        1 | 100 |  1 | 102
+        1 | 100 |  1 | 103
+        2 | 100 |  0 | 500
+        2 | 100 |  1 |   1
+        2 | 101 |  0 |   1
+        """,
+}
+
+
+def test_sorting_extends_to_selected_column(spec_test):
+    spec_test(
+        table_data,
+        e.sort_by(e.i1, e.i2).first_for_patient().i3,
+        {1: 102, 2: 500},
+    )

--- a/tests/spec/tables.py
+++ b/tests/spec/tables.py
@@ -26,6 +26,7 @@ class patient_level_table(PatientFrame):
 class event_level_table(EventFrame):
     i1 = Series(int)
     i2 = Series(int)
+    i3 = Series(int)
     b1 = Series(bool)
     b2 = Series(bool)
     c1 = Series(SNOMEDCTCode)

--- a/tests/unit/test_collections_utils_identity_dict.py
+++ b/tests/unit/test_collections_utils_identity_dict.py
@@ -1,0 +1,102 @@
+from pytest import raises
+
+from databuilder.collections_utils import DefaultIdentityDict, IdentityDict
+
+
+def test_empty_means_empty():
+    assert len(IdentityDict()) == 0
+
+
+def test_can_be_initialized_with_contents():
+    d = IdentityDict(a=1)
+    assert len(d) == 1
+    assert "a" in d
+    assert d["a"] == 1
+
+
+def test_setting():
+    d = IdentityDict()
+    d["a"] = 1
+    assert len(d) == 1
+    assert "a" in d
+    assert d["a"] == 1
+
+
+def test_overriding_a_value():
+    d = IdentityDict(a=1)
+    d["a"] = 2
+    assert d["a"] == 2
+
+
+def test_removing():
+    d = IdentityDict(a=1)
+    del d["a"]
+    assert len(d) == 0
+    assert "a" not in d
+
+
+def test_can_iterate_over_contents():
+    d = IdentityDict(a=1, b=2)
+    assert list(d.items()) == [("a", 1), ("b", 2)]
+
+
+def test_construction_distinguishes_between_equal_but_non_identical_objects():
+    k1 = AlwaysEqual()
+    k2 = AlwaysEqual()
+    s = IdentityDict([(k1, 1), (k2, 2)])
+    assert len(s) == 2
+    assert s[k1] == 1
+    assert s[k2] == 2
+
+
+def test_adding_distinguishes_between_equal_but_non_identical_objects():
+    k1 = AlwaysEqual()
+    k2 = AlwaysEqual()
+    s = IdentityDict()
+    s[k1] = 1
+    s[k2] = 2
+    assert len(s) == 2
+    assert s[k1] == 1
+    assert s[k2] == 2
+
+
+def test_deleting_distinguishes_between_equal_but_non_identical_objects():
+    s = IdentityDict([(AlwaysEqual(), 1)])
+    with raises(KeyError):
+        del s[AlwaysEqual()]
+    assert len(s) == 1
+
+
+def test_contains_distinguishes_between_equal_but_non_identical_objects():
+    assert AlwaysEqual() not in IdentityDict([(AlwaysEqual(), 1)])
+
+
+def test_default_identity_dict_provides_default():
+    assert DefaultIdentityDict(default_factory=lambda: "fish")["a"] == "fish"
+
+
+def test_default_identity_dict_persists_retrieved_defaults():
+    d = DefaultIdentityDict(default_factory=lambda: "fish")
+    assert len(d) == 0
+    _ = d["a"]
+    assert len(d) == 1
+
+
+def test_default_identity_dict_admits_setting_values():
+    def f():
+        return None  # pragma: no cover
+
+    assert DefaultIdentityDict(f, a=1)["a"] == 1
+
+
+def test_default_identity_dict_raises_without_factory():
+    with raises(KeyError):
+        _ = DefaultIdentityDict(default_factory=None)["a"]
+
+
+class AlwaysEqual:
+    def __eq__(self, other):
+        return True  # pragma: no cover
+
+    def __hash__(self):
+        return 1  # pragma: no cover

--- a/tests/unit/test_collections_utils_identity_set.py
+++ b/tests/unit/test_collections_utils_identity_set.py
@@ -1,0 +1,70 @@
+from databuilder.collections_utils import IdentitySet
+
+
+def test_empty_means_empty():
+    assert len(IdentitySet()) == 0
+
+
+def test_can_be_initialized_with_contents():
+    s = IdentitySet([1, 2, 3])
+    assert len(s) == 3
+    assert 1 in s
+
+
+def test_adding():
+    s = IdentitySet()
+    s.add(1)
+    assert len(s) == 1
+    assert 1 in s
+
+
+def test_duplicates_are_ignored():
+    s = IdentitySet([1])
+    s.add(1)
+    assert len(s) == 1
+
+
+def test_can_iterate_over_contents():
+    s = IdentitySet([1, 2])
+    assert list(s) == [1, 2]
+
+
+def test_removing():
+    s = IdentitySet([1])
+    s.remove(1)
+    assert len(s) == 0
+    assert 1 not in s
+
+
+def test_discard_is_idempotent():
+    IdentitySet().discard(1)  # no error
+
+
+def test_construction_distinguishes_between_equal_but_non_identical_objects():
+    s = IdentitySet([AlwaysEqual(), AlwaysEqual()])
+    assert len(s) == 2
+
+
+def test_adding_distinguishes_between_equal_but_non_identical_objects():
+    s = IdentitySet()
+    s.add(AlwaysEqual())
+    s.add(AlwaysEqual())
+    assert len(s) == 2
+
+
+def test_discarding_distinguishes_between_equal_but_non_identical_objects():
+    s = IdentitySet([AlwaysEqual()])
+    s.discard(AlwaysEqual())
+    assert len(s) == 1
+
+
+def test_contains_distinguishes_between_equal_but_non_identical_objects():
+    assert AlwaysEqual() not in IdentitySet([AlwaysEqual()])
+
+
+class AlwaysEqual:
+    def __eq__(self, other):
+        return True  # pragma: no cover
+
+    def __hash__(self):
+        return 1  # pragma: no cover

--- a/tests/unit/test_query_model_transforms.py
+++ b/tests/unit/test_query_model_transforms.py
@@ -50,11 +50,11 @@ def test_pick_one_row_per_patient_transform():
         selected_columns=frozenset(
             {
                 SelectColumn(
-                    source=events,
+                    source=sorted_events,
                     name="value",
                 ),
                 SelectColumn(
-                    source=events,
+                    source=sorted_events,
                     name="code",
                 ),
             }
@@ -86,7 +86,7 @@ def test_adds_one_selected_column_to_sorts():
     transformed = apply_transforms(variables)
 
     by_i2 = Sort(events, SelectColumn(events, "i2"))
-    by_i2_then_i1 = Sort(by_i2, SelectColumn(events, "i1"))
+    by_i2_then_i1 = Sort(by_i2, SelectColumn(by_i2, "i1"))
     expected_variables = dict(
         v=SelectColumn(
             PickOneRowPerPatientWithColumns(
@@ -95,7 +95,7 @@ def test_adds_one_selected_column_to_sorts():
                 selected_columns=frozenset(
                     {
                         SelectColumn(
-                            source=events,
+                            source=by_i2_then_i1,
                             name="i2",
                         ),
                     }
@@ -114,7 +114,7 @@ def test_adds_sorts_at_lowest_priority():
         TableSchema(i1=Column(int), i2=Column(int), i3=Column(int)),
     )
     by_i2 = Sort(events, SelectColumn(events, "i2"))
-    by_i2_then_i1 = Sort(by_i2, SelectColumn(events, "i1"))
+    by_i2_then_i1 = Sort(by_i2, SelectColumn(by_i2, "i1"))
     variables = dict(
         v=SelectColumn(
             PickOneRowPerPatient(source=by_i2_then_i1, position=Position.FIRST),
@@ -125,8 +125,8 @@ def test_adds_sorts_at_lowest_priority():
     transformed = apply_transforms(variables)
 
     by_i3 = Sort(events, SelectColumn(events, "i3"))
-    by_i3_then_i2 = Sort(by_i3, SelectColumn(events, "i2"))
-    by_i3_then_i2_then_i1 = Sort(by_i3_then_i2, SelectColumn(events, "i1"))
+    by_i3_then_i2 = Sort(by_i3, SelectColumn(by_i3, "i2"))
+    by_i3_then_i2_then_i1 = Sort(by_i3_then_i2, SelectColumn(by_i3_then_i2, "i1"))
     expected_variables = dict(
         v=SelectColumn(
             PickOneRowPerPatientWithColumns(
@@ -135,7 +135,7 @@ def test_adds_sorts_at_lowest_priority():
                 selected_columns=frozenset(
                     {
                         SelectColumn(
-                            source=events,
+                            source=by_i3_then_i2_then_i1,
                             name="i3",
                         ),
                     }
@@ -171,7 +171,7 @@ def test_doesnt_duplicate_existing_sorts():
                 selected_columns=frozenset(
                     {
                         SelectColumn(
-                            source=events,
+                            source=by_i1,
                             name="i1",
                         ),
                     }
@@ -199,19 +199,19 @@ def test_adds_sorts_in_lexical_order_of_column_names():
     transformed = apply_transforms(variables)
 
     by_iz = Sort(events, SelectColumn(events, "iz"))
-    by_iz_then_ia = Sort(by_iz, SelectColumn(events, "ia"))
-    by_iz_then_ia_then_i1 = Sort(by_iz_then_ia, SelectColumn(events, "i1"))
+    by_iz_then_ia = Sort(by_iz, SelectColumn(by_iz, "ia"))
+    by_iz_then_ia_then_i1 = Sort(by_iz_then_ia, SelectColumn(by_iz_then_ia, "i1"))
     first_with_extra_sorts = PickOneRowPerPatientWithColumns(
         by_iz_then_ia_then_i1,
         Position.FIRST,
         selected_columns=frozenset(
             {
                 SelectColumn(
-                    source=events,
+                    source=by_iz_then_ia_then_i1,
                     name="iz",
                 ),
                 SelectColumn(
-                    source=events,
+                    source=by_iz_then_ia_then_i1,
                     name="ia",
                 ),
             }
@@ -244,7 +244,7 @@ def test_maps_booleans_to_a_sortable_type():
     by_b = Sort(
         events, Case({b: Value(2), Function.Not(b): Value(1)}, default=Value(0))
     )
-    by_b_then_i = Sort(by_b, SelectColumn(events, "i"))
+    by_b_then_i = Sort(by_b, SelectColumn(by_b, "i"))
     expected_variables = dict(
         v=SelectColumn(
             PickOneRowPerPatientWithColumns(
@@ -253,7 +253,7 @@ def test_maps_booleans_to_a_sortable_type():
                 selected_columns=frozenset(
                     {
                         SelectColumn(
-                            source=events,
+                            source=by_b_then_i,
                             name="b",
                         ),
                     }

--- a/tests/unit/test_query_model_transforms.py
+++ b/tests/unit/test_query_model_transforms.py
@@ -22,28 +22,36 @@ def test_pick_one_row_per_patient_transform():
             date=Column(datetime.date), code=Column(str), value=Column(float)
         ),
     )
-    date = SelectColumn(events, "date")
-    by_date = Sort(events, date)
-    first_event = PickOneRowPerPatient(by_date, Position.FIRST)
+    sorted_events = Sort(
+        Sort(
+            Sort(
+                events,
+                SelectColumn(events, "value"),
+            ),
+            SelectColumn(events, "code"),
+        ),
+        SelectColumn(events, "date"),
+    )
+    first_event = PickOneRowPerPatient(sorted_events, Position.FIRST)
     variables = dict(
         first_code=SelectColumn(first_event, "code"),
         first_value=SelectColumn(first_event, "value"),
-        # Create a new distinct colum object with the same value as the first column:
+        # Create a new distinct column object with the same value as the first column:
         # equal but not identical objects expose bugs in the query model transformation
         first_code_again=SelectColumn(first_event, "code"),
     )
 
     first_event_with_columns = PickOneRowPerPatientWithColumns(
-        source=by_date,
+        source=sorted_events,
         position=Position.FIRST,
         selected_columns=frozenset(
             {
                 SelectColumn(
-                    source=by_date,
+                    source=events,
                     name="value",
                 ),
                 SelectColumn(
-                    source=by_date,
+                    source=events,
                     name="code",
                 ),
             }

--- a/tests/unit/test_query_model_transforms.py
+++ b/tests/unit/test_query_model_transforms.py
@@ -78,7 +78,8 @@ def test_adds_one_selected_column_to_sorts():
     by_i1 = Sort(events, SelectColumn(events, "i1"))
     variables = dict(
         v=SelectColumn(
-            PickOneRowPerPatient(source=by_i1, position=Position.FIRST), "i2"
+            PickOneRowPerPatient(source=by_i1, position=Position.FIRST),
+            "i2",
         ),
     )
 
@@ -116,7 +117,8 @@ def test_adds_sorts_at_lowest_priority():
     by_i2_then_i1 = Sort(by_i2, SelectColumn(events, "i1"))
     variables = dict(
         v=SelectColumn(
-            PickOneRowPerPatient(source=by_i2_then_i1, position=Position.FIRST), "i3"
+            PickOneRowPerPatient(source=by_i2_then_i1, position=Position.FIRST),
+            "i3",
         ),
     )
 
@@ -154,7 +156,8 @@ def test_doesnt_duplicate_existing_sorts():
     by_i1 = Sort(events, SelectColumn(events, "i1"))
     variables = dict(
         v=SelectColumn(
-            PickOneRowPerPatient(source=by_i1, position=Position.FIRST), "i1"
+            PickOneRowPerPatient(source=by_i1, position=Position.FIRST),
+            "i1",
         ),
     )
 
@@ -229,7 +232,10 @@ def test_maps_booleans_to_a_sortable_type():
     )
     by_i = Sort(events, SelectColumn(events, "i"))
     variables = dict(
-        v=SelectColumn(PickOneRowPerPatient(source=by_i, position=Position.FIRST), "b"),
+        v=SelectColumn(
+            PickOneRowPerPatient(source=by_i, position=Position.FIRST),
+            "b",
+        ),
     )
 
     transformed = apply_transforms(variables)


### PR DESCRIPTION
The driver for this is to allow us to do more thorough testing (fixes #461). Previously we couldn't test sorting with the generative tests because in some cases the sort order differed between databases (and even between runs for a given database).

To enable that testing this PR adds a small and possibly user-invisible feature that makes the results of all sorts stable even in cases where the sort is under-specified by the dataset definition.

There are two things that I'm not sure about in this implementation and would welcome feedback on.

1. Should the new transformation be separate or should it be rolled into the existing one. My weak preference is to separate them because they exist for different reasons, but their implementation ties them together so there is an argument for treating them as a single transformation.

2. The unit tests for the transformations are pretty unreadable (and even hard to write). Should we introduce some kind of QM builder tooling to make tests like this more readable?