### PR TITLE
Dummy data: attempt 1

### DIFF
--- a/databuilder/dummy_data/__init__.py
+++ b/databuilder/dummy_data/__init__.py
@@ -1,0 +1,3 @@
+from databuilder.dummy_data.generator import DummyDataGenerator
+
+__all__ = ["DummyDataGenerator"]

--- a/databuilder/dummy_data/generator.py
+++ b/databuilder/dummy_data/generator.py
@@ -15,6 +15,6 @@ class DummyDataGenerator:
 
     def get_results(self):
         database = InMemoryDatabase()
-        database.setup(self.get_data(), metadata=self.orm_classes[0].metadata)
+        database.setup(self.get_data())
         engine = InMemoryQueryEngine(database)
         return engine.get_results(self.variable_definitions)

--- a/databuilder/dummy_data/generator.py
+++ b/databuilder/dummy_data/generator.py
@@ -1,0 +1,20 @@
+from databuilder.orm_utils import orm_classes_from_qm_tables
+from databuilder.query_engines.in_memory import InMemoryQueryEngine
+from databuilder.query_engines.in_memory_database import InMemoryDatabase
+from databuilder.query_model import get_table_nodes
+
+
+class DummyDataGenerator:
+    def __init__(self, variable_definitions):
+        self.variable_definitions = variable_definitions
+        self.tables = get_table_nodes(*variable_definitions.values())
+        self.orm_classes = orm_classes_from_qm_tables(self.tables)
+
+    def get_data(self):
+        return []
+
+    def get_results(self):
+        database = InMemoryDatabase()
+        database.setup(self.get_data(), metadata=self.orm_classes[0].metadata)
+        engine = InMemoryQueryEngine(database)
+        return engine.get_results(self.variable_definitions)

--- a/databuilder/dummy_data/generator.py
+++ b/databuilder/dummy_data/generator.py
@@ -1,20 +1,142 @@
-from databuilder.orm_utils import orm_classes_from_qm_tables
+import random
+from datetime import date, timedelta
+
+from sqlalchemy.orm import declarative_base
+
+from databuilder.dummy_data.query_info import QueryInfo
+from databuilder.orm_utils import orm_class_from_schema
 from databuilder.query_engines.in_memory import InMemoryQueryEngine
 from databuilder.query_engines.in_memory_database import InMemoryDatabase
-from databuilder.query_model import get_table_nodes
 
 
 class DummyDataGenerator:
+    # TODO: Make these user configurable. We're deliberately not doing this right now
+    # because we want to keep the API surface to zero in the early stages while we
+    # iterate on things.
+    population_size = 5000
+    random_seed = "BwRV3spP"
+
     def __init__(self, variable_definitions):
         self.variable_definitions = variable_definitions
-        self.tables = get_table_nodes(*variable_definitions.values())
-        self.orm_classes = orm_classes_from_qm_tables(self.tables)
+
+        # TODO: I dislike using today's date as part of the data generation because it
+        # makes the results non-deterministic. However until we're able to infer a
+        # suitable time range by inspecting the query, this will have to do.
+        self.today = date.today()
+        self.rnd = random.Random()
+
+        # Create ORM classes for each of the tables used in the dataset definition
+        self.query_info = QueryInfo.from_variable_definitions(self.variable_definitions)
+        Base = declarative_base()
+        self.orm_classes = {
+            table_info.name: orm_class_from_schema(
+                Base,
+                table_info.name,
+                table_info,
+                table_info.has_one_row_per_patient,
+            )
+            for table_info in self.query_info.tables.values()
+        }
 
     def get_data(self):
-        return [orm_class(patient_id=1) for orm_class in self.orm_classes]
+        for patient_id in range(1, self.population_size + 1):
+            yield from self.get_patient_data(patient_id)
 
     def get_results(self):
         database = InMemoryDatabase()
         database.setup(self.get_data())
         engine = InMemoryQueryEngine(database)
         return engine.get_results(self.variable_definitions)
+
+    def get_patient_data(self, patient_id):
+        # Seed the random generator using the patient_id so we always generate the same
+        # data for the same patient
+        self.rnd.seed(f"{self.random_seed}:{patient_id}")
+        # Generate some basic demographic facts about the patient which subsequent table
+        # generators can use to ensure a consistent patient history
+        self.generate_patient_facts()
+        # Generate data for each of the tables used in the query
+        for table_info in self.query_info.tables.values():
+            # Support specialised generators for individual tables, otherwise just make
+            # some empty rows
+            get_rows = getattr(self, f"rows_for_{table_info.name}", self.empty_rows)
+            rows = get_rows(table_info)
+            for row in rows:
+                # Fill in any values that haven't already been set by a specialised
+                # generator
+                self.populate_row(table_info, row)
+                row["patient_id"] = patient_id
+            orm_class = self.orm_classes[table_info.name]
+            yield from (orm_class(**row) for row in rows)
+
+    def generate_patient_facts(self):
+        # TODO: We could obviously generate more realistic age distributions than this
+        date_of_birth = self.today - timedelta(days=self.rnd.randrange(0, 120 * 365))
+        age_days = self.rnd.randrange(105 * 365)
+        date_of_death = date_of_birth + timedelta(days=age_days)
+
+        self.date_of_birth = date_of_birth
+        self.date_of_death = date_of_death if date_of_death < self.today else None
+        self.events_start = self.date_of_birth
+        self.events_end = min(self.today, date_of_death)
+
+    def rows_for_patients(self, table_info):
+        row = {
+            "date_of_birth": self.date_of_birth.replace(day=1),
+            "date_of_death": self.date_of_death,
+        }
+        return [row]
+
+    def rows_for_practice_registrations(self, table_info):
+        # TODO: Generate more interesting registration histories; for now, we just
+        # assume that every patient is permanently registered with a single practice
+        # from birth
+        row = {
+            "start_date": self.events_start,
+            "end_date": None,
+        }
+        return [row]
+
+    def empty_rows(self, table_info):
+        # Generate a small handful of events for event-level tables
+        max_rows = 1 if table_info.has_one_row_per_patient else 8
+        row_count = self.rnd.randrange(max_rows + 1)
+        return [{} for _ in range(row_count)]
+
+    def populate_row(self, table_info, row):
+        # Remove any columns created by table generators that aren't used in the query
+        for extra_column in row.keys() - table_info.columns:
+            del row[extra_column]
+        # Populate any columns used in the query which haven't already been set
+        for name, column_info in table_info.columns.items():
+            if name not in row:
+                row[name] = self.get_random_value(column_info)
+
+    def get_random_value(self, column_info):
+        # TODO: This never returns None although for realism it sometimes should
+        if column_info.choices:
+            # TODO: It's obviously not true in general that categories are equiprobable
+            return self.rnd.choice(column_info.choices)
+        elif column_info.type is bool:
+            return self.rnd.choice((True, False))
+        elif column_info.type is int:
+            # TODO: This distributon is obviously ridiculous but will do for now
+            return self.rnd.randrange(100)
+        elif column_info.type is float:
+            # TODO: As is this
+            return self.rnd.random() * 100
+        elif column_info.type is str:
+            # There's not much we can do about non-categorical strings with no
+            # comparison values used in the query (generating a random string is
+            # unlikely to be useful), but I don't expect we'll get many of these
+            return ""
+        elif column_info.type is date:
+            # Use an exponential distribution to preferentially generate recent events
+            # (mean of one year ago). This works OK for the our immediate purposes but
+            # we'll no doubt have to iterate on this.
+            days_ago = int(self.rnd.expovariate(1 / 365))
+            event_date = self.events_end - timedelta(days=days_ago)
+            # Clip to the available time range
+            return max(event_date, self.events_start)
+        else:
+            assert False, f"Unhandled type: {column_info.type}"

--- a/databuilder/dummy_data/generator.py
+++ b/databuilder/dummy_data/generator.py
@@ -11,7 +11,7 @@ class DummyDataGenerator:
         self.orm_classes = orm_classes_from_qm_tables(self.tables)
 
     def get_data(self):
-        return []
+        return [orm_class(patient_id=1) for orm_class in self.orm_classes]
 
     def get_results(self):
         database = InMemoryDatabase()

--- a/databuilder/dummy_data/query_info.py
+++ b/databuilder/dummy_data/query_info.py
@@ -1,0 +1,128 @@
+import dataclasses
+from collections import defaultdict
+from typing import Optional
+
+from databuilder.query_model import (
+    Function,
+    SelectColumn,
+    SelectPatientTable,
+    SelectTable,
+    Value,
+    get_input_nodes,
+    get_root_frame,
+)
+
+
+@dataclasses.dataclass
+class ColumnInfo:
+    """
+    Captures information about a column as used in a particular dataset definition
+    """
+
+    name: str
+    type: type  # NOQA: A003
+    categories: Optional[tuple]
+    values_used: set = dataclasses.field(default_factory=set)
+
+    def __post_init__(self):
+        if hasattr(self.type, "_primitive_type"):
+            self.type = self.type._primitive_type()
+
+    def record_value(self, value):
+        if hasattr(value, "_to_primitive_type"):
+            value = value._to_primitive_type()
+        self.values_used.add(value)
+
+
+@dataclasses.dataclass
+class TableInfo:
+    """
+    Captures information about a table as used in a particular dataset definition
+    """
+
+    name: str
+    has_one_row_per_patient: bool
+    columns: dict[str, ColumnInfo] = dataclasses.field(default_factory=dict)
+
+
+@dataclasses.dataclass
+class QueryInfo:
+    """
+    Captures information about a dataset definition, including the specific tables and
+    columns used and the values expected in those columns
+    """
+
+    tables: dict[str, TableInfo]
+
+    @classmethod
+    def from_variable_definitions(cls, variable_definitions):
+        all_nodes = walk_tree(*variable_definitions.values())
+        by_type = get_nodes_by_type(all_nodes)
+
+        tables = {
+            # Create a TableInfo object …
+            table.name: TableInfo(
+                name=table.name,
+                has_one_row_per_patient=isinstance(table, SelectPatientTable),
+            )
+            # … for every table used in the query (sorted for consistency)
+            for table in sort_by_name(
+                by_type[SelectTable] | by_type[SelectPatientTable]
+            )
+        }
+
+        column_info_by_column: dict[SelectColumn, ColumnInfo] = {}
+
+        # For every column used in the query (sorted for consistency) …
+        for column in sort_by_name(by_type[SelectColumn]):
+            table = get_root_frame(column.source)
+            name = column.name
+            table_info = tables[table.name]
+            column_info = table_info.columns.get(name)
+            if column_info is None:
+                # … insert a ColumnInfo object into the appropriate table
+                column_info = ColumnInfo(
+                    name=name,
+                    type=table.schema.get_column_type(name),
+                    categories=table.schema.get_column_categories(name),
+                )
+                table_info.columns[name] = column_info
+            # Record the ColumnInfo object associated with each SelectColumn node
+            column_info_by_column[column] = column_info
+
+        # Record values used in equality and substring comparisons
+        for node in by_type[Function.EQ] | by_type[Function.StringContains]:
+            # The query model in theory supports "1 == x" style comparisons (i.e.  with
+            # the column on the RHS) but there's no way to generate such constructions
+            # using ehrQL so we only bother handling the "x == 1" orientation here.
+            if not (isinstance(node.lhs, SelectColumn) and isinstance(node.rhs, Value)):
+                continue
+            column_info = column_info_by_column[node.lhs]
+            column_info.record_value(node.rhs.value)
+
+        # Record values used in containment comparisons
+        for node in by_type[Function.In]:
+            if not (isinstance(node.lhs, SelectColumn) and isinstance(node.rhs, Value)):
+                continue
+            column_info = column_info_by_column[node.lhs]
+            for value in node.rhs.value:
+                column_info.record_value(value)
+
+        return cls(tables=tables)
+
+
+def get_nodes_by_type(nodes):
+    by_type = defaultdict(set)
+    for node in nodes:
+        by_type[type(node)].add(node)
+    return by_type
+
+
+def walk_tree(*nodes):
+    for node in nodes:
+        yield node
+        yield from walk_tree(*get_input_nodes(node))
+
+
+def sort_by_name(iterable):
+    return sorted(iterable, key=lambda i: i.name)

--- a/databuilder/dummy_data/query_info.py
+++ b/databuilder/dummy_data/query_info.py
@@ -67,6 +67,8 @@ class QueryInfo:
     """
 
     tables: dict[str, TableInfo]
+    population_table_names: list[str]
+    other_table_names: list[str]
 
     @classmethod
     def from_variable_definitions(cls, variable_definitions):
@@ -128,7 +130,21 @@ class QueryInfo:
             for value in node.rhs.value:
                 column_info.record_value(value)
 
-        return cls(tables=tables)
+        # Record which tables are used in determining population membership and which
+        # are not
+        population_table_names = {
+            node.name
+            for node in walk_tree(variable_definitions["population"])
+            if isinstance(node, (SelectTable, SelectPatientTable))
+        }
+
+        other_table_names = tables.keys() - population_table_names
+
+        return cls(
+            tables=tables,
+            population_table_names=sorted(population_table_names),
+            other_table_names=sorted(other_table_names),
+        )
 
 
 def get_nodes_by_type(nodes):

--- a/databuilder/dummy_data/query_info.py
+++ b/databuilder/dummy_data/query_info.py
@@ -1,5 +1,6 @@
 import dataclasses
 from collections import defaultdict
+from functools import cached_property
 from typing import Optional
 
 from databuilder.query_model import (
@@ -33,6 +34,13 @@ class ColumnInfo:
             value = value._to_primitive_type()
         self.values_used.add(value)
 
+    @cached_property
+    def choices(self):
+        if self.categories is not None:
+            return self.categories
+        else:
+            return sorted(self.values_used)
+
 
 @dataclasses.dataclass
 class TableInfo:
@@ -43,6 +51,12 @@ class TableInfo:
     name: str
     has_one_row_per_patient: bool
     columns: dict[str, ColumnInfo] = dataclasses.field(default_factory=dict)
+
+    # Act enough like a `query_model.TableSchema` that we can use this class with the
+    # `orm_utils` factory functions
+    @property
+    def column_types(self):
+        return [(name, column.type) for name, column in self.columns.items()]
 
 
 @dataclasses.dataclass

--- a/databuilder/dummy_data/query_info.py
+++ b/databuilder/dummy_data/query_info.py
@@ -96,14 +96,20 @@ class QueryInfo:
             # the column on the RHS) but there's no way to generate such constructions
             # using ehrQL so we only bother handling the "x == 1" orientation here.
             if not (isinstance(node.lhs, SelectColumn) and isinstance(node.rhs, Value)):
-                continue
+                # NOTE: This `continue` is actually covered but due to a bug only fixed in
+                # Python 3.10 coverage can't follow it. See:
+                # https://github.com/nedbat/coveragepy/issues/198
+                continue  # pragma: no cover
             column_info = column_info_by_column[node.lhs]
             column_info.record_value(node.rhs.value)
 
         # Record values used in containment comparisons
         for node in by_type[Function.In]:
             if not (isinstance(node.lhs, SelectColumn) and isinstance(node.rhs, Value)):
-                continue
+                # NOTE: This `continue` is actually covered but due to a bug only fixed in
+                # Python 3.10 coverage can't follow it. See:
+                # https://github.com/nedbat/coveragepy/issues/198
+                continue  # pragma: no cover
             column_info = column_info_by_column[node.lhs]
             for value in node.rhs.value:
                 column_info.record_value(value)

--- a/databuilder/main.py
+++ b/databuilder/main.py
@@ -65,16 +65,19 @@ def generate_dummy_dataset(definition_file, dataset_file, dummy_tables_path=None
     else:
         results = DummyDataGenerator(variable_definitions).get_results()
 
+    log.info("Building dataset and writing results")
     results = eager_iterator(results)
     write_dataset(dataset_file, results, column_specs)
 
 
 def create_dummy_tables(definition_file, dummy_tables_path):
+    log.info(f"Creating dummy data tables for {str(definition_file)}")
     dataset_definition = load_definition(definition_file)
     variable_definitions = compile(dataset_definition)
     generator = DummyDataGenerator(variable_definitions)
     dummy_tables = generator.get_data()
     dummy_tables_path.parent.mkdir(parents=True, exist_ok=True)
+    log.info(f"Writing CSV files to {dummy_tables_path}")
     write_orm_models_to_csv_directory(dummy_tables_path, dummy_tables)
 
 

--- a/databuilder/main.py
+++ b/databuilder/main.py
@@ -72,13 +72,10 @@ def generate_dummy_dataset(definition_file, dataset_file, dummy_tables_path=None
 def create_dummy_tables(definition_file, dummy_tables_path):
     dataset_definition = load_definition(definition_file)
     variable_definitions = compile(dataset_definition)
-    dummy_tables_path.parent.mkdir(parents=True, exist_ok=True)
     generator = DummyDataGenerator(variable_definitions)
-    write_orm_models_to_csv_directory(
-        dummy_tables_path,
-        generator.orm_classes,
-        generator.get_data(),
-    )
+    dummy_tables = generator.get_data()
+    dummy_tables_path.parent.mkdir(parents=True, exist_ok=True)
+    write_orm_models_to_csv_directory(dummy_tables_path, dummy_tables)
 
 
 def pass_dummy_data(definition_file, dataset_file, dummy_data_file):

--- a/databuilder/orm_utils.py
+++ b/databuilder/orm_utils.py
@@ -143,17 +143,21 @@ def _has_type(field, type_):
     return False
 
 
-def write_orm_models_to_csv_directory(directory, orm_classes, models):
+def write_orm_models_to_csv_directory(directory, models):
     directory.mkdir(exist_ok=True)
     writers = {}
     with ExitStack() as stack:
-        for orm_class in orm_classes:
-            fileobj = stack.enter_context(
-                open(directory / f"{orm_class.__tablename__}.csv", "w", newline="")
-            )
-            writers[orm_class] = orm_csv_writer(fileobj, orm_class)
         for model in models:
-            write_row = writers[model.__class__]
+            orm_class = model.__class__
+
+            write_row = writers.get(orm_class)
+            if write_row is None:
+                fileobj = stack.enter_context(
+                    open(directory / f"{orm_class.__tablename__}.csv", "w", newline="")
+                )
+                write_row = orm_csv_writer(fileobj, orm_class)
+                writers[orm_class] = write_row
+
             write_row(model)
 
 

--- a/databuilder/query_engines/in_memory.py
+++ b/databuilder/query_engines/in_memory.py
@@ -24,6 +24,8 @@ class InMemoryQueryEngine(BaseQueryEngine):
     """
 
     def get_results(self, variable_definitions):
+        self.cache = {}
+
         name_to_col = {
             "patient_id": PatientColumn(
                 {patient: patient for patient in self.all_patients},
@@ -61,8 +63,12 @@ class InMemoryQueryEngine(BaseQueryEngine):
         return self.database.all_patients
 
     def visit(self, node):
-        visitor = getattr(self, f"visit_{type(node).__name__}")
-        return visitor(node)
+        value = self.cache.get(node)
+        if value is None:
+            visitor = getattr(self, f"visit_{type(node).__name__}")
+            value = visitor(node)
+            self.cache[node] = value
+        return value
 
     def visit_Code(self, node):
         assert False

--- a/tests/acceptance/test_embedded_study.py
+++ b/tests/acceptance/test_embedded_study.py
@@ -123,4 +123,4 @@ def test_create_dummy_tables(study, tmp_path):
     study.setup_from_string(trivial_dataset_definition)
     study.create_dummy_tables(dummy_tables_path)
     header_line = (dummy_tables_path / "patients.csv").read_text().splitlines()[0]
-    assert header_line == "patient_id,date_of_birth,sex,date_of_death"
+    assert header_line == "patient_id,date_of_birth"

--- a/tests/unit/dummy_data/test_generator.py
+++ b/tests/unit/dummy_data/test_generator.py
@@ -55,6 +55,7 @@ def test_dummy_data_generator():
     variable_definitions = compile(dataset)
     generator = DummyDataGenerator(variable_definitions)
     generator.population_size = 7
+    generator.batch_size = 4
     results = list(generator.get_results())
 
     # Check they look right

--- a/tests/unit/dummy_data/test_generator.py
+++ b/tests/unit/dummy_data/test_generator.py
@@ -3,7 +3,7 @@ from unittest import mock
 
 import pytest
 
-from databuilder.dummy_data.generator import DummyDataGenerator
+from databuilder.dummy_data.generator import DummyDataGenerator, DummyPatientGenerator
 from databuilder.dummy_data.query_info import ColumnInfo
 from databuilder.ehrql import Dataset
 from databuilder.query_language import compile
@@ -111,17 +111,17 @@ def test_dummy_data_generator_timeout_with_no_results(patched_time):
 
 
 @pytest.mark.parametrize("type_", [bool, int, float, str, datetime.date])
-def test_get_random_value(generator, type_):
+def test_dummy_patient_generator_get_random_value(dummy_patient_generator, type_):
     column_info = ColumnInfo(name="test", categories=None, type=type_)
-    value = generator.get_random_value(column_info)
+    value = dummy_patient_generator.get_random_value(column_info)
     assert isinstance(value, type_)
 
 
 @pytest.fixture(scope="module")
-def generator():
+def dummy_patient_generator():
     dataset = Dataset()
     dataset.set_population(patients.exists_for_patient())
     variable_definitions = compile(dataset)
-    generator = DummyDataGenerator(variable_definitions)
+    generator = DummyPatientGenerator(variable_definitions, random_seed="abc")
     generator.generate_patient_facts()
     return generator

--- a/tests/unit/dummy_data/test_generator.py
+++ b/tests/unit/dummy_data/test_generator.py
@@ -1,0 +1,88 @@
+import datetime
+
+import pytest
+
+from databuilder.dummy_data.generator import DummyDataGenerator
+from databuilder.dummy_data.query_info import ColumnInfo
+from databuilder.ehrql import Dataset
+from databuilder.query_language import compile
+from databuilder.tables import (
+    CategoricalConstraint,
+    EventFrame,
+    PatientFrame,
+    Series,
+    table,
+)
+
+
+@table
+class patients(PatientFrame):
+    date_of_birth = Series(datetime.date)
+    date_of_death = Series(datetime.date)
+    sex = Series(str, constraints=[CategoricalConstraint("male", "female", "intersex")])
+
+
+@table
+class practice_registrations(EventFrame):
+    start_date = Series(datetime.date)
+    end_date = Series(datetime.date)
+    practice_id = Series(int)
+
+
+@table
+class events(EventFrame):
+    date = Series(datetime.date)
+    code = Series(str)
+
+
+def test_dummy_data_generator():
+    # Define a basic dataset
+    dataset = Dataset()
+    dataset.set_population(practice_registrations.exists_for_patient())
+    dataset.date_of_birth = patients.date_of_birth
+    dataset.date_of_death = patients.date_of_death
+    dataset.sex = patients.sex
+
+    last_event = (
+        events.take(events.code.is_in(["abc", "def"]))
+        .sort_by(events.date)
+        .last_for_patient()
+    )
+    dataset.code = last_event.code
+    dataset.date = last_event.date
+
+    # Generate some results
+    variable_definitions = compile(dataset)
+    generator = DummyDataGenerator(variable_definitions)
+    generator.population_size = 7
+    results = list(generator.get_results())
+
+    # Check they look right
+    assert len(results) == 7
+
+    for r in results:
+        assert isinstance(r.date_of_birth, datetime.date)
+        assert r.date_of_death is None or r.date_of_death > r.date_of_birth
+        assert r.sex in {"male", "female", "intersex"}
+        # To get full coverage here we need to generate enough data so that we get at
+        # least one patient with a matching event and one without
+        if r.code is not None or r.date is not None:
+            assert r.code in {"abc", "def"}
+            assert isinstance(r.date, datetime.date)
+
+
+@pytest.mark.parametrize("type_", [bool, int, float, str, datetime.date])
+def test_get_random_value(generator, type_):
+    column_info = ColumnInfo(name="test", categories=None, type=type_)
+    value = generator.get_random_value(column_info)
+    assert isinstance(value, type_)
+
+
+@pytest.fixture(scope="module")
+def generator():
+    dataset = Dataset()
+    dataset.set_population(patients.exists_for_patient())
+    variable_definitions = compile(dataset)
+    generator = DummyDataGenerator(variable_definitions)
+    generator.generate_patient_facts()
+    return generator

--- a/tests/unit/dummy_data/test_query_info.py
+++ b/tests/unit/dummy_data/test_query_info.py
@@ -1,0 +1,104 @@
+import datetime
+
+from databuilder.codes import CTV3Code
+from databuilder.dummy_data.query_info import ColumnInfo, QueryInfo, TableInfo
+from databuilder.ehrql import Dataset
+from databuilder.query_language import compile
+from databuilder.tables import (
+    CategoricalConstraint,
+    EventFrame,
+    PatientFrame,
+    Series,
+    table,
+)
+
+
+@table
+class patients(PatientFrame):
+    date_of_birth = Series(datetime.date)
+    sex = Series(str, constraints=[CategoricalConstraint("male", "female", "intersex")])
+
+
+@table
+class events(EventFrame):
+    date = Series(datetime.date)
+    code = Series(CTV3Code)
+
+
+def test_query_info_from_variable_definitions():
+    dataset = Dataset()
+    dataset.set_population(events.exists_for_patient())
+    dataset.date_of_birth = patients.date_of_birth
+    dataset.sex = patients.sex
+    variable_definitions = compile(dataset)
+
+    query_info = QueryInfo.from_variable_definitions(variable_definitions)
+
+    assert query_info == QueryInfo(
+        tables={
+            "events": TableInfo(
+                name="events",
+                has_one_row_per_patient=False,
+                columns={},
+            ),
+            "patients": TableInfo(
+                name="patients",
+                has_one_row_per_patient=True,
+                columns={
+                    "date_of_birth": ColumnInfo(
+                        name="date_of_birth",
+                        type=datetime.date,
+                        categories=None,
+                        values_used=set(),
+                    ),
+                    "sex": ColumnInfo(
+                        name="sex",
+                        type=str,
+                        categories=("male", "female", "intersex"),
+                        values_used=set(),
+                    ),
+                },
+            ),
+        }
+    )
+
+
+def test_query_info_records_values():
+    dataset = Dataset()
+    dataset.set_population(events.exists_for_patient())
+    # Simple equality comparison
+    dataset.q1 = events.take(events.code == CTV3Code("abc")).exists_for_patient()
+    # String contains
+    dataset.q2 = patients.sex.contains("ale")
+    # Set contains
+    dataset.q3 = events.take(
+        events.code.is_in([CTV3Code("def"), CTV3Code("ghi")])
+    ).exists_for_patient()
+    # Equality comparison where the column is not selected directly from the table
+    old = events.take(events.date < "2000-01-01")
+    dataset.q4 = old.sort_by(old.date).first_for_patient().code == CTV3Code("jkl")
+
+    variable_definitions = compile(dataset)
+    query_info = QueryInfo.from_variable_definitions(variable_definitions)
+    sex_column_info = query_info.tables["patients"].columns["sex"]
+    code_column_info = query_info.tables["events"].columns["code"]
+
+    assert sex_column_info.values_used == {"ale"}
+    assert code_column_info.values_used == {"abc", "def", "ghi", "jkl"}
+
+
+def test_query_info_ignores_complex_comparisons():
+    # By "complex" here we just mean anything other than a direct comparison between a
+    # selected column and a static value. We don't attempt to handle these, but we want
+    # to make sure we don't blow up with an error, or misinterpret them.
+    dataset = Dataset()
+    dataset.set_population(events.exists_for_patient())
+    dataset.q1 = patients.date_of_birth.year.is_in([2000, 2010, 2020])
+    dataset.q2 = patients.date_of_birth.add_days(100) == "2021-10-20"
+    dataset.q3 = patients.date_of_birth == "2022-10-05"
+    variable_definitions = compile(dataset)
+
+    query_info = QueryInfo.from_variable_definitions(variable_definitions)
+    column_info = query_info.tables["patients"].columns["date_of_birth"]
+
+    assert column_info.values_used == {datetime.date(2022, 10, 5)}

--- a/tests/unit/dummy_data/test_query_info.py
+++ b/tests/unit/dummy_data/test_query_info.py
@@ -60,7 +60,9 @@ def test_query_info_from_variable_definitions():
                     ),
                 },
             ),
-        }
+        },
+        population_table_names=["events"],
+        other_table_names=["patients"],
     )
 
 

--- a/tests/unit/dummy_data/test_query_info.py
+++ b/tests/unit/dummy_data/test_query_info.py
@@ -1,4 +1,5 @@
 import datetime
+import sys
 
 from databuilder.codes import CTV3Code
 from databuilder.dummy_data.query_info import ColumnInfo, QueryInfo, TableInfo
@@ -102,3 +103,11 @@ def test_query_info_ignores_complex_comparisons():
     column_info = query_info.tables["patients"].columns["date_of_birth"]
 
     assert column_info.values_used == {datetime.date(2022, 10, 5)}
+
+
+def test_remove_pragmas_for_python_3_10():
+    # https://github.com/nedbat/coveragepy/issues/198#issuecomment-798891606
+    assert sys.version_info < (3, 10), (
+        f"Remove `no cover` pragmas from continue "
+        f"statements in {QueryInfo.__module__}"
+    )

--- a/tests/unit/test_orm_utils.py
+++ b/tests/unit/test_orm_utils.py
@@ -86,7 +86,7 @@ def test_write_orm_models_to_csv_directory(tmp_path):
     ]
 
     csv_dir = tmp_path / "csvs"
-    write_orm_models_to_csv_directory(csv_dir, [Patient, Event], models)
+    write_orm_models_to_csv_directory(csv_dir, models)
 
     patients_csv = (csv_dir / "patients.csv").read_text()
     events_csv = (csv_dir / "events.csv").read_text()


### PR DESCRIPTION
This adds a first pass at a dummy data generator. It has some obvious areas for improvement but it produces non-empty output when run against the comparative booster study (500 rows in 18 seconds) which was our original goal.

While the results are pretty nonsensical (a majority patients have emergency admissions for COVID and many end up spending hundreds of days in critical care) certain things drop out nicely. All the sequential dates (vaccination 1, vaccination 2, admission 1, admission 2 etc) are in the right order and you never end up with a second event without having a first. The columns recording dates for "any COVID vaccine" tie correctly up with the columns for the specific vaccine products. No patients have events after they've died. And the "Age in Aug 2021" agrees sensibly with the "Age at baseline date" column.

Pleasingly, we've managed to get these results with very little domain specific knowledge built in to the generator. It knows that a patient has a date of birth and, potentially, death and that these delineate the range of time during which things can happen to them. And for simplicity, I've made each patient be registered with a single practice from birth. But beyond that it doesn't know anything about the tables other than what's in the contracts.

The current design allows us to define custom generators for specific columns in specific tables, and then it automatically fills in any values which aren't covered by those. You'll see there are two very simple generators: one for `patients` and one for `practice_registrations`.

In terms of magic constants needed to get this particular study to work, there are two. The main one is that we generate dates with a heavy recency bias: an exponential distribution with a mean of one year ago. We also only generate a small handful of rows for each patient in each table (between 0 and 7). These are needed because an inclusion criterion for the study is having your fourth vaccine dose within a specific time frame. My first attempts ended with most patients getting their first doses back in the 80s and being on their 40th dose by the start of the pandemic, so very few made it into the study.

It would be quite simple to apply these constraints just to the `vaccinations` table and have other tables generate more events and over a wider date range. But I wanted to see how little we could get away with at this stage. Eventually I suspect we'll need to teach the generator specifically about the COVID vaccines and their sensible date distributions. 

Closes #764