### PR TITLE
Ensure consistent `sys.path` behaviour

### DIFF
--- a/databuilder/main.py
+++ b/databuilder/main.py
@@ -205,9 +205,10 @@ def load_module(definition_path):
     # The name we give the module is arbitrary
     spec = importlib.util.spec_from_file_location("dataset", definition_path)
     module = importlib.util.module_from_spec(spec)
-    # Temporarily add the directory containing the definition to the path so that the
-    # definition can import library modules from that directory
-    with add_to_sys_path(str(definition_path.parent)):
+    # Temporarily add the directory containing the definition to the start of `sys.path`
+    # (just as `python path/to/script.py` would) so that the definition can import
+    # library modules from that directory
+    with add_to_sys_path(str(definition_path.parent.absolute())):
         spec.loader.exec_module(module)
     return module
 
@@ -215,7 +216,7 @@ def load_module(definition_path):
 @contextmanager
 def add_to_sys_path(directory):
     original = sys.path.copy()
-    sys.path.append(directory)
+    sys.path.insert(0, directory)
     try:
         yield
     finally:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-# -B: don't write bytecode files
-/opt/venv/bin/python3.9 -B -m databuilder "$@"

--- a/pyproject.minimal.toml
+++ b/pyproject.minimal.toml
@@ -1,0 +1,15 @@
+# This contains just the minimal configuration needed to be able to install the
+# script entrypoints. We use this in the Dockerfile to be able to set up a
+# virtualenv with all the right scripts pointing to the right entrypoints
+# without creating a dependency on the whole project state so we avoid having
+# to rebuild the virtualenv every time any file changes.
+#
+# A test at `tests/unit/test_pyproject_minimal.py` makes sure that this file
+# doesn't get out of sync with the original.
+
+[project]
+name = "opensafely-databuilder"
+version = "2+local"
+
+[project.scripts]
+databuilder = "databuilder.__main__:entrypoint"

--- a/tests/unit/test_pyproject_minimal.py
+++ b/tests/unit/test_pyproject_minimal.py
@@ -1,0 +1,14 @@
+import toml
+
+
+def test_pyproject_minimal_is_subset_of_pyproject():
+    with open("pyproject.toml") as f:
+        pyproject = toml.load(f)
+    with open("pyproject.minimal.toml") as f:
+        minimal = toml.load(f)
+
+    # `pyproject.minimal.toml` doesn't need to contain everything `pyproject.toml`
+    # contains, but whatever it does contain should agree with `pyproject.toml`
+    assert minimal.keys() == {"project"}
+    for key, value in minimal["project"].items():
+        assert value == pyproject["project"][key]


### PR DESCRIPTION
This modifies our `sys.path` behaviour such that all of the following have effectively the same `sys.path` configuration while `dataset_definition.py` is executing:
```
python path/to/dataset_definition.py
```
```
databuilder generate-dataset path/to/dataset_definition.py
```
```
opensafely exec databuilder:v0 generate-dataset path/to/dataset_definition.py
```


Closes #817