### PR TITLE
Restore `implements` line in TPP backend

### DIFF
--- a/databuilder/backends/tpp.py
+++ b/databuilder/backends/tpp.py
@@ -1,3 +1,5 @@
+import databuilder.tables.beta.smoketest
+import databuilder.tables.beta.tpp
 from databuilder.backends.base import BaseBackend, MappedTable, QueryTable
 from databuilder.query_engines.mssql import MSSQLQueryEngine
 
@@ -7,6 +9,7 @@ class TPPBackend(BaseBackend):
 
     query_engine_class = MSSQLQueryEngine
     patient_join_column = "Patient_ID"
+    implements = [databuilder.tables.beta.tpp, databuilder.tables.beta.smoketest]
 
     patients = QueryTable(
         """


### PR DESCRIPTION
This was inadvertently removed in #755