### PR TITLE
Generative test improvements around query model coverage

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -97,6 +97,16 @@ When debugging a failure you'll probably want to reproduce it.
    (You'll need to add some imports to get it to run.) This allows you to get the failure case running in a debugger
    (and also to get the example nicely formatted to help understand it).
 
+Since the variable generation strategies are quite complex, it's hard to convince yourself that they give good coverage of the query space.
+To help with this there is an optional assertion that the generative tests have included every query model operation at least once.
+To enable this assertion set `GENTEST_COMPREHENSIVE=t`, like this:
+
+```
+GENTEST_COMPREHENSIVE=t GENTEST_EXAMPLES=5000 just test-generative
+```
+
+(But note that you need something like 5k examples to have any chance of this passing.)
+
 ### Writing tests
 
 Please think carefully about how to test code that you are adding or changing.

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -80,7 +80,7 @@ To get the benefit of the generative tests you need to run them at larger scale 
 Use something like this:
 
 ```
-EXAMPLES=10000 just test-generative
+GENTEST_EXAMPLES=10000 just test-generative
 ```
 
 This generates 10k examples and takes ten or fifteen minutes to run.
@@ -88,7 +88,7 @@ When developing this, I (Ben) only ever saw one problem that took more than 10k 
 We should schedule longer runs from time to time to make sure that we're not missing anything.
 
 You can get Hypothesis to dump statistics at the end of the run with `--hypothesis-show-statistics`,
-or (more usefully) dump some of our own statistics about the generated data and queries by setting `DEBUG=t`.
+or (more usefully) dump some of our own statistics about the generated data and queries by setting `GENTEST_DEBUG=t`.
 
 When debugging a failure you'll probably want to reproduce it.
 

--- a/Justfile
+++ b/Justfile
@@ -187,7 +187,8 @@ test-unit *ARGS: devenv
 
 # Run the generative tests only. Optional args are passed to pytest.
 #
-# Set DEBUG env var to see stats. Set EXAMPLES to change the number of examples generated.
+# Set GENTEST_DEBUG env var to see stats.
+# Set GENTEST_EXAMPLES to change the number of examples generated.
 test-generative *ARGS: devenv
     $BIN/python -m pytest tests/generative {{ ARGS }}
 

--- a/databuilder/__init__.py
+++ b/databuilder/__init__.py
@@ -1,7 +1,3 @@
 from pathlib import Path
 
-from databuilder.utils.log_utils import init_logging
-
-init_logging()
-
 __version__ = Path(__file__).parent.joinpath("VERSION").read_text().strip()

--- a/databuilder/__main__.py
+++ b/databuilder/__main__.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 from databuilder import __version__
 from databuilder.file_formats import FILE_FORMATS, get_file_extension
+from databuilder.utils.log_utils import init_logging
 
 from .main import (
     CommandError,
@@ -38,6 +39,8 @@ def entrypoint():
 
 def main(args, environ=None):
     environ = environ or {}
+
+    init_logging()
 
     parser = ArgumentParser(
         prog="databuilder", description="Generate datasets in OpenSAFELY"

--- a/databuilder/query_model/transforms.py
+++ b/databuilder/query_model/transforms.py
@@ -27,6 +27,7 @@ from databuilder.query_model.nodes import (
     get_input_nodes,
     get_series_type,
     get_sorts,
+    validate_node,
 )
 from databuilder.utils.collections_utils import DefaultIdentityDict, IdentitySet
 
@@ -128,6 +129,7 @@ def add_columns_to_pick(node, selected_column_names):
     )
     force_setattr(node, "__class__", PickOneRowPerPatientWithColumns)
     force_setattr(node, "selected_columns", selected_columns)
+    validate_node(node)  # check we haven't broken any invariants
 
 
 def add_extra_sorts(node, selected_column_names):
@@ -141,7 +143,7 @@ def add_extra_sorts(node, selected_column_names):
             sort_by=make_sortable(SelectColumn(lowest_sort.source, column)),
         )
         force_setattr(lowest_sort, "source", new_sort)
-        force_setattr(lowest_sort.sort_by, "source", new_sort)
+        validate_node(lowest_sort)  # check we haven't broken any invariants
         lowest_sort = new_sort
 
 

--- a/tests/generative/conftest.py
+++ b/tests/generative/conftest.py
@@ -31,7 +31,7 @@ def histogram(samples):  # pragma: no cover
 
 
 def pytest_terminal_summary(terminalreporter, exitstatus, config):  # pragma: no cover
-    if "DEBUG" not in os.environ:
+    if "GENTEST_DEBUG" not in os.environ:
         return
 
     print(f"\n{len(observed_inputs)} unique input combinations")

--- a/tests/generative/test_query_model.py
+++ b/tests/generative/test_query_model.py
@@ -4,7 +4,7 @@ import hypothesis as hyp
 import hypothesis.strategies as st
 import pytest
 
-from databuilder.query_model.nodes import Column, TableSchema
+from databuilder.query_model.nodes import Column, TableSchema, node_types
 
 from ..conftest import QUERY_ENGINE_NAMES, engine_factory
 from . import data_setup, data_strategies, variable_strategies
@@ -63,12 +63,9 @@ def test_query_model(query_engines, variable, data):
 
 
 def tune_inputs(variable):
-    # Hypothesis maximizes the metric, which makes the number of nodes in the variable
-    # tend towards the target. The target chosen here seems to give a reasonable spread
-    # of query model graphs
-    target_size = 40
-    metric = -abs(target_size - count_nodes(variable))
-    hyp.target(metric)
+    # Encourage Hypothesis to maximize the number and type of nodes
+    hyp.target(count_nodes(variable), label="number of nodes")
+    hyp.target(len(node_types(variable)), label="number of node types")
 
 
 def run_test(query_engines, data, variable):

--- a/tests/generative/test_query_model.py
+++ b/tests/generative/test_query_model.py
@@ -57,14 +57,18 @@ def query_engines(request):
 @hyp.given(variable=variable_strategy, data=data_strategy)
 @hyp.settings(**settings)
 def test_query_model(query_engines, variable, data):
-    hyp.target(tune_qm_graph_size(variable))
+    tune_inputs(variable)
     observe_inputs(variable, data)
     run_test(query_engines, data, variable)
 
 
-def tune_qm_graph_size(variable):
-    target_size = 40  # seems to give a reasonable spread of query model graphs
-    return -abs(target_size - count_nodes(variable))
+def tune_inputs(variable):
+    # Hypothesis maximizes the metric, which makes the number of nodes in the variable
+    # tend towards the target. The target chosen here seems to give a reasonable spread
+    # of query model graphs
+    target_size = 40
+    metric = -abs(target_size - count_nodes(variable))
+    hyp.target(metric)
 
 
 def run_test(query_engines, data, variable):

--- a/tests/generative/test_query_model.py
+++ b/tests/generative/test_query_model.py
@@ -4,18 +4,9 @@ import hypothesis as hyp
 import hypothesis.strategies as st
 import pytest
 
-from databuilder.query_model.nodes import (
-    AggregateByPatient,
-    Case,
-    Column,
-    Function,
-    TableSchema,
-    count_nodes,
-    node_types,
-)
+from databuilder.query_model.nodes import Column, TableSchema, count_nodes, node_types
 
 from ..conftest import QUERY_ENGINE_NAMES, engine_factory
-from ..lib.query_model_utils import get_all_operations
 from . import data_setup, data_strategies, variable_strategies
 
 # To simplify data generation, all tables have the same schema.
@@ -104,38 +95,8 @@ def recorder():  # pragma: no cover
     if not os.getenv("GENTEST_COMPREHENSIVE"):
         return
 
-    all_operations = set(get_all_operations())
-    known_missing = {
-        AggregateByPatient.CombineAsSet,
-        Case,
-        Function.In,
-        Function.StringContains,
-        Function.CastToFloat,
-        Function.CastToInt,
-        Function.DateAddYears,
-        Function.DateAddMonths,
-        Function.DateAddDays,
-        Function.YearFromDate,
-        Function.MonthFromDate,
-        Function.DayFromDate,
-        Function.DateDifferenceInYears,
-        Function.DateDifferenceInMonths,
-        Function.DateDifferenceInDays,
-        Function.ToFirstOfYear,
-        Function.ToFirstOfMonth,
-    }
-
     operations_seen = {o for v in observed_inputs.variables for o in node_types(v)}
-
-    unexpected_missing = all_operations - known_missing - operations_seen
-    assert (
-        not unexpected_missing
-    ), f"unseen operations: {[o.__name__ for o in unexpected_missing]}"
-
-    unexpected_present = known_missing & operations_seen
-    assert (
-        not unexpected_present
-    ), f"unexpectedly seen operations: {[o.__name__ for o in unexpected_present]}"
+    variable_strategies.assert_includes_all_operations(operations_seen)
 
 
 @hyp.given(variable=variable_strategy, data=data_strategy)

--- a/tests/generative/test_query_model.py
+++ b/tests/generative/test_query_model.py
@@ -35,7 +35,7 @@ data_strategy = data_strategies.data(
     patient_classes, event_classes, schema, int_values, bool_values
 )
 settings = dict(
-    max_examples=(int(os.environ.get("EXAMPLES", 100))),
+    max_examples=(int(os.environ.get("GENTEST_EXAMPLES", 100))),
     deadline=None,
     suppress_health_check=[hyp.HealthCheck.filter_too_much, hyp.HealthCheck.too_slow],
 )

--- a/tests/generative/test_query_model.py
+++ b/tests/generative/test_query_model.py
@@ -10,13 +10,14 @@ from databuilder.query_model.nodes import (
     Column,
     Function,
     TableSchema,
+    count_nodes,
     node_types,
 )
 
 from ..conftest import QUERY_ENGINE_NAMES, engine_factory
 from ..lib.query_model_utils import get_all_operations
 from . import data_setup, data_strategies, variable_strategies
-from .conftest import count_nodes, observe_inputs
+from .conftest import observe_inputs
 
 # To simplify data generation, all tables have the same schema.
 schema = TableSchema(i1=Column(int), i2=Column(int), b1=Column(bool), b2=Column(bool))

--- a/tests/generative/variable_strategies.py
+++ b/tests/generative/variable_strategies.py
@@ -182,8 +182,6 @@ def variable(patient_tables, event_tables, schema, int_values, bool_values):
     add = qm_builds(Function.Add, series, series)
     subtract = qm_builds(Function.Subtract, series, series)
 
-    # TODO Unsupported operations: everything that acts on dates or collections
-
     # Variables must be single values which have been reduced to the patient level. We also need to ensure that they
     # contains nodes which actually access the database so that the query engine can calculate a patient universe.
     return one_row_per_patient_series.filter(uses_the_database)

--- a/tests/lib/query_model_utils.py
+++ b/tests/lib/query_model_utils.py
@@ -1,0 +1,28 @@
+import dataclasses
+
+from databuilder.query_model import nodes as query_model
+
+
+def get_all_operations():
+    "Return every operation defined in the query model"
+    return [cls for cls in iterate_query_model_namespace() if is_operation(cls)]
+
+
+def is_operation(cls):
+    "Return whether an arbitrary value is a query model operation class"
+    # We need to check this first or the `issubclass` check can fail
+    if not isinstance(cls, type):
+        return False
+    # We need to check it's a proper subclass as the Node base class isn't itself a
+    # dataclass so the `fields()` call will fail
+    if not issubclass(cls, query_model.Node) or cls is query_model.Node:
+        return False
+    # If it takes arguments it's an operation, otherwise it's an abstract type
+    return len(dataclasses.fields(cls)) > 0
+
+
+def iterate_query_model_namespace():
+    "Yield every public thing in the query_model module"
+    yield from [getattr(query_model, name) for name in query_model.__all__]
+    yield from vars(query_model.Function).values()
+    yield from vars(query_model.AggregateByPatient).values()

--- a/tests/unit/query_model/test_nodes.py
+++ b/tests/unit/query_model/test_nodes.py
@@ -393,7 +393,8 @@ def test_any_type_acts_as_an_escape_hatch():
     assert SomeInternalOperation(value=mixed_set)
 
 
-def test_comparions_between_value_nodes_are_strict():
+def test_comparisons_between_value_nodes_are_strict():
     assert Value(10) == Value(10)
     assert Value(10) != Value(10.0)
     assert Value(1) != Value(True)
+    assert Value(10) != 10

--- a/tests/unit/query_model/test_population_validation.py
+++ b/tests/unit/query_model/test_population_validation.py
@@ -1,8 +1,5 @@
-import dataclasses
-
 import pytest
 
-from databuilder.query_model import nodes as query_model
 from databuilder.query_model.nodes import (
     AggregateByPatient,
     Case,
@@ -20,6 +17,7 @@ from databuilder.query_model.population_validation import (
     evaluate,
     validate_population_definition,
 )
+from tests.lib.query_model_utils import get_all_operations
 
 
 def test_rejects_non_series():
@@ -220,33 +218,6 @@ def test_evaluate(expected, query):
 # Test that the `evaluate()` single dispatch function is exhaustively defined so we
 # can't forget to update it if we add a new query model operation.
 #
-
-
-def get_all_operations():
-    "Return every operation defined in the query model"
-    return [cls for cls in iterate_query_model_namespace() if is_operation(cls)]
-
-
-def is_operation(cls):
-    "Return whether an arbitrary value is a query model operation class"
-    # We need to check this first or the `issubclass` check can fail
-    if not isinstance(cls, type):
-        return False
-    # We need to check it's a proper subclass as the Node base class isn't itself a
-    # dataclass so the `fields()` call will fail
-    if not issubclass(cls, query_model.Node) or cls is query_model.Node:
-        return False
-    # If it takes arguments it's an operation, otherwise it's an abstract type
-    return len(dataclasses.fields(cls)) > 0
-
-
-def iterate_query_model_namespace():
-    "Yield every public thing in the query_model module"
-    yield from [getattr(query_model, name) for name in query_model.__all__]
-    yield from vars(query_model.Function).values()
-    yield from vars(query_model.AggregateByPatient).values()
-
-
 @pytest.mark.parametrize(
     "operation", [op for op in get_all_operations() if issubclass(op, Series)]
 )


### PR DESCRIPTION
Fixes #765.

There is a check in here to ensure that all query model operations are covered by the generative tests. This check is not enabled by default because you need to generate about 5k test cases to be sure of hitting all the operations and that takes more than ten minutes, so it's not suitable for CI. For now we need to run this by hand from time to time. We have #766 to automate long-running generative tests and I have added a note there to turn this check on.

One of the commits mentions issues being created. They are: #836, #837, #838 and #839. I've marked them all as good first issues, intending that they are good issues for someone who wants to start getting their heads around the generative tests specifically, rather than Data Builder more generally.

I haven't documented the flag to enable detailed logging from the query engine (`LOG_ENGINES`) because it didn't seem obvious that people would want to do it often enough to warrant space in the docs (unlike `LOG_SQL`), but I'm happy to have my mind changed about this.