### PR TITLE
Remove the explicit `six` dependency

### DIFF
--- a/requirements.dev.in
+++ b/requirements.dev.in
@@ -25,4 +25,3 @@ pytest-freezegun
 pytest-mock
 pytest-subtests
 pyupgrade
-six # undeclared dependency of docker (https://github.com/docker/docker-py/issues/2842)

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -341,7 +341,6 @@ six==1.16.0 \
     --hash=sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254
     # via
     #   -c requirements.prod.txt
-    #   -r requirements.dev.in
     #   databricks-cli
     #   python-dateutil
     #   virtualenv


### PR DESCRIPTION
This does not remove the dependency as we still need it, but does simplify our requirements. 