### PR TITLE
fix: Fix traceback trimming

### DIFF
--- a/databuilder/main.py
+++ b/databuilder/main.py
@@ -242,7 +242,7 @@ def load_module(module_path):
         spec.loader.exec_module(module)
         return module
     except Exception as exc:
-        traceback = get_trimmed_traceback(exc, str(module_path))
+        traceback = get_trimmed_traceback(exc, module.__file__)
         raise CommandError(f"Failed to import '{module_path}':\n\n{traceback}")
     finally:
         sys.path = original_sys_path

--- a/databuilder/main.py
+++ b/databuilder/main.py
@@ -242,7 +242,7 @@ def load_module(module_path):
         spec.loader.exec_module(module)
         return module
     except Exception as exc:
-        traceback = get_trimmed_traceback(exc)
+        traceback = get_trimmed_traceback(exc, str(module_path))
         raise CommandError(f"Failed to import '{module_path}':\n\n{traceback}")
     finally:
         sys.path = original_sys_path

--- a/databuilder/utils/traceback_utils.py
+++ b/databuilder/utils/traceback_utils.py
@@ -16,7 +16,9 @@ def get_trimmed_traceback(exc, filename):
     first_user_frame = next(
         tb for tb in walk_traceback(exc.__traceback__) if get_filename(tb) == filename
     )
-    last_user_frame = next(
+    # By construction, this iterator can never be exhausted so we need to tell Coverage
+    # not to moan at us about it
+    last_user_frame = next(  # pragma: no branch
         tb for tb in walk_traceback(first_user_frame) if is_final_user_frame(tb)
     )
     # Truncate the traceback chain at the last user frame by NULLing the reference.

--- a/databuilder/utils/traceback_utils.py
+++ b/databuilder/utils/traceback_utils.py
@@ -2,33 +2,47 @@ import traceback
 from pathlib import Path
 
 # Note that if this file is moved, this will need to be updated.
-package_root = Path(__file__).resolve().parents[1]
+PACKAGE_ROOT = Path(__file__).resolve().parents[1]
+# We want the trailing slash here so we can use this with `str.startswith()`
+PACKAGE_ROOT_STR = str(PACKAGE_ROOT / "")
 
 
-# The presence of any of these strings in a traceback line indicates that the line
-# almost certainly came from our library code, which we don't want to show to users.
-strings_to_trim = [
-    # Indicates that the line comes from the databuilder package.
-    str(package_root),
-    # Indicates that the line comes from the code that imports a dataset definition from
-    # a user-supplied path.
-    "frozen importlib._bootstrap",
-    # Indicates that the line comes from instantiating a dataclass class (because when a
-    # dataclass class is defined, a string execed).
-    'File "<string>", line 5, in __init__',
-]
-
-
-def get_trimmed_traceback(exc):
+def get_trimmed_traceback(exc, filename):
     """Return only the relevant traceback lines from the supplied exception
 
     We only want to show lines from a user's own code, and not lines from our library
     code.
     """
-    tb_fragments = traceback.format_exception(type(exc), exc, exc.__traceback__)
-    tb_fragments = [
-        fragment
-        for fragment in tb_fragments
-        if not any(s in fragment for s in strings_to_trim)
-    ]
-    return "".join(tb_fragments).strip()
+    first_user_frame = next(
+        tb for tb in walk_traceback(exc.__traceback__) if get_filename(tb) == filename
+    )
+    last_user_frame = next(
+        tb for tb in walk_traceback(first_user_frame) if is_final_user_frame(tb)
+    )
+    # Truncate the traceback chain at the last user frame by NULLing the reference.
+    # We're allowed to do this as `tb_next` is documented as writable, see:
+    # https://docs.python.org/3/reference/datamodel.html#traceback-objects
+    last_user_frame.tb_next = None
+    return "".join(
+        traceback.format_exception(type(exc), value=exc, tb=first_user_frame)
+    )
+
+
+def walk_traceback(tb):
+    while tb is not None:
+        yield tb
+        tb = tb.tb_next
+
+
+def get_filename(tb):
+    # Your "Law of Demeter" has no power here
+    return tb.tb_frame.f_code.co_filename
+
+
+def is_final_user_frame(tb):
+    # Is this the last frame of user code before we either get to the end of the
+    # traceback or find ourselves inside Data Builder code?
+    if tb.tb_next is None:
+        return True
+    else:
+        return get_filename(tb.tb_next).startswith(PACKAGE_ROOT_STR)

--- a/tests/fixtures/bad_dataset_definitions/bad_import.py
+++ b/tests/fixtures/bad_dataset_definitions/bad_import.py
@@ -1,0 +1,2 @@
+# noqa: INP001
+from databuilder.tables.beta.smoketest import no_such_table  # noqa: F401

--- a/tests/fixtures/bad_dataset_definitions/bad_types.py
+++ b/tests/fixtures/bad_dataset_definitions/bad_types.py
@@ -1,0 +1,4 @@
+# noqa: INP001
+from databuilder.tables.beta.tpp import patients
+
+patients.date_of_birth == patients.sex

--- a/tests/integration/utils/test_traceback_utils.py
+++ b/tests/integration/utils/test_traceback_utils.py
@@ -33,3 +33,10 @@ def test_references_to_failed_imports_from_databuilder_are_not_stripped_out():
     # We tried to import a name from `smoketest` which doesn't exist, though the module
     # itself does. Therefore this module should be visible in the traceback.
     assert re.search(re.escape(smoketest.__file__), str(excinfo.value))
+
+
+def test_traceback_filtering_handles_relative_paths():
+    relative_filename = (FIXTURES / "bad_import.py").relative_to(Path.cwd())
+    message = r'Traceback \(most recent call last\):\n  File ".*bad_import\.py"'
+    with pytest.raises(CommandError, match=message):
+        load_module(relative_filename)

--- a/tests/integration/utils/test_traceback_utils.py
+++ b/tests/integration/utils/test_traceback_utils.py
@@ -1,0 +1,35 @@
+import re
+from pathlib import Path
+
+import pytest
+
+import databuilder
+from databuilder.main import CommandError, load_module
+from databuilder.tables.beta import smoketest
+
+FIXTURES = Path(__file__).parents[2] / "fixtures" / "bad_dataset_definitions"
+
+
+def test_traceback_starts_with_user_code():
+    filename = FIXTURES / "bad_import.py"
+    message = f'Traceback (most recent call last):\n  File "{filename}"'
+    with pytest.raises(CommandError, match=re.escape(message)):
+        load_module(filename)
+
+
+def test_traceback_ends_with_user_code():
+    filename = FIXTURES / "bad_types.py"
+    with pytest.raises(CommandError) as excinfo:
+        load_module(filename)
+    # We shouldn't have any references to databuilder code in the traceback
+    databuilder_root = str(Path(databuilder.__file__).parent)
+    assert not re.search(re.escape(databuilder_root), str(excinfo.value))
+
+
+def test_references_to_failed_imports_from_databuilder_are_not_stripped_out():
+    filename = FIXTURES / "bad_import.py"
+    with pytest.raises(CommandError) as excinfo:
+        load_module(filename)
+    # We tried to import a name from `smoketest` which doesn't exist, though the module
+    # itself does. Therefore this module should be visible in the traceback.
+    assert re.search(re.escape(smoketest.__file__), str(excinfo.value))

--- a/tests/unit/utils/test_traceback_utils.py
+++ b/tests/unit/utils/test_traceback_utils.py
@@ -1,0 +1,28 @@
+import pytest
+
+from databuilder.utils.traceback_utils import get_trimmed_traceback, walk_traceback
+
+# NOTE
+#
+# These tests exist purely to exercise some edge cases of the module and keep coverage
+# happy. The actual behaviour of the module is covered in:
+# tests/integeration/utils/test_traceback_utils.py
+
+
+def test_walk_to_end_of_traceback():
+    exc = exception_with_traceback()
+    tb_list = list(walk_traceback(exc.__traceback__))
+    assert len(tb_list) == 1
+
+
+def test_get_trimmed_traceback_with_incorrect_filename():
+    exc = exception_with_traceback()
+    with pytest.raises(StopIteration):
+        get_trimmed_traceback(exc, "no_such_file")
+
+
+def exception_with_traceback():
+    try:
+        raise ValueError()
+    except ValueError as exc:
+        return exc


### PR DESCRIPTION
The previous, string-based approach, was liable to false positives where we would remove frames that actually ought to be kept.

Closes #805