### PR TITLE
fix: Work around SQLAlchemy bug compiling SQL to strings

### DIFF
--- a/databuilder/query_engines/sqlite_dialect.py
+++ b/databuilder/query_engines/sqlite_dialect.py
@@ -5,6 +5,11 @@ class SQLiteDialect(SQLiteDialect_pysqlite):
 
     supports_statement_cache = True
 
+    # Use the `named` parameter placeholder style for consistency with other dialects.
+    # SQLite supports this alongside several others:
+    # https://docs.python.org/3/library/sqlite3.html#sqlite3.paramstyle
+    default_paramstyle = "named"
+
     def do_on_connect(self, connection):
         # Set the per-connection flag which makes LIKE queries case-sensitive
         connection.execute("PRAGMA case_sensitive_like = 1;")


### PR DESCRIPTION
A particular combination of SQLAlchemy features (`bind_expressions`, "expanding" BindParameters, and `literal_binds` compilation) exposes a bug in SQLAlchemy.

SQLAlchemy are quite clear that compiling queries to strings with literal values in (rather than parameter placeholders) isn't a particularly well-supported path, for reasons which are generally sensible:
https://docs.sqlalchemy.org/en/14/faq/sqlexpressions.html#rendering-bound-parameters-inline

However, being able to dump Data Builder queries as syntactically valid, copy-pastable SQL is such a useful feature that it's worth enduring a bit of pain here to make this work. (At least, that's the story I'm telling myself having endured the pain anyway.)

We work around this by compiling the query to a string containing parameter placeholders and then doing the value substitution ourselves.