### PR TITLE
Correct `just remove-database-containers`

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -158,7 +158,7 @@ Each run of the tests starts the database if it's not already running _and then 
 
 There is a `just` command to remove the database containers:
 ```
-just remove-persistent-database
+just remove-database-containers
 ```
 
 ### Displaying SQL queries


### PR DESCRIPTION
This was changed, and hadn't been updated in the documentation.