### PR TITLE
Respect FirstOfMonth constraint in dummy data

### DIFF
--- a/databuilder/dummy_data/generator.py
+++ b/databuilder/dummy_data/generator.py
@@ -165,9 +165,14 @@ class DummyPatientGenerator:
 
     def rows_for_patients(self, table_info):
         row = {
-            "date_of_birth": self.date_of_birth.replace(day=1),
+            "date_of_birth": self.date_of_birth,
             "date_of_death": self.date_of_death,
         }
+        # Apply any FirstOfMonth constraints
+        for key, value in row.items():
+            if key in table_info.columns:
+                if table_info.columns[key].has_first_of_month_constraint:
+                    row[key] = value.replace(day=1)
         return [row]
 
     def rows_for_practice_registrations(self, table_info):
@@ -220,7 +225,11 @@ class DummyPatientGenerator:
             days_ago = int(self.rnd.expovariate(1 / 365))
             event_date = self.events_end - timedelta(days=days_ago)
             # Clip to the available time range
-            return max(event_date, self.events_start)
+            event_date = max(event_date, self.events_start)
+            # Apply any FirstOfMonth constraints
+            if column_info.has_first_of_month_constraint:
+                event_date = event_date.replace(day=1)
+            return event_date
         else:
             assert False, f"Unhandled type: {column_info.type}"
 

--- a/databuilder/dummy_data/query_info.py
+++ b/databuilder/dummy_data/query_info.py
@@ -24,6 +24,7 @@ class ColumnInfo:
     name: str
     type: type  # NOQA: A003
     categories: Optional[tuple]
+    has_first_of_month_constraint: bool = False
     values_used: set = dataclasses.field(default_factory=set)
 
     @classmethod
@@ -38,8 +39,17 @@ class ColumnInfo:
             categories = cat_constraint.values
         else:
             categories = None
+        # Get date constraints
+        has_first_of_month_constraint = bool(
+            column.get_constraint_by_type(Constraint.FirstOfMonth)
+        )
         # Construct
-        return cls(name=name, type=type_, categories=categories)
+        return cls(
+            name=name,
+            type=type_,
+            categories=categories,
+            has_first_of_month_constraint=has_first_of_month_constraint,
+        )
 
     def record_value(self, value):
         if hasattr(value, "_to_primitive_type"):

--- a/databuilder/dummy_data/query_info.py
+++ b/databuilder/dummy_data/query_info.py
@@ -4,6 +4,7 @@ from functools import cached_property
 from typing import Optional
 
 from databuilder.query_model.nodes import (
+    Constraint,
     Function,
     SelectColumn,
     SelectPatientTable,
@@ -25,9 +26,20 @@ class ColumnInfo:
     categories: Optional[tuple]
     values_used: set = dataclasses.field(default_factory=set)
 
-    def __post_init__(self):
-        if hasattr(self.type, "_primitive_type"):
-            self.type = self.type._primitive_type()
+    @classmethod
+    def from_column(cls, name, column):
+        # Get type
+        type_ = column.type_
+        if hasattr(type_, "_primitive_type"):
+            type_ = type_._primitive_type()
+        # Get categories
+        cat_constraint = column.get_constraint_by_type(Constraint.Categorical)
+        if cat_constraint is not None:
+            categories = cat_constraint.values
+        else:
+            categories = None
+        # Construct
+        return cls(name=name, type=type_, categories=categories)
 
     def record_value(self, value):
         if hasattr(value, "_to_primitive_type"):
@@ -97,10 +109,8 @@ class QueryInfo:
             column_info = table_info.columns.get(name)
             if column_info is None:
                 # … insert a ColumnInfo object into the appropriate table
-                column_info = ColumnInfo(
-                    name=name,
-                    type=table.schema.get_column_type(name),
-                    categories=table.schema.get_column_categories(name),
+                column_info = ColumnInfo.from_column(
+                    name, table.schema.get_column(name)
                 )
                 table_info.columns[name] = column_info
             # Record the ColumnInfo object associated with each SelectColumn node

--- a/databuilder/query_model/table_schema.py
+++ b/databuilder/query_model/table_schema.py
@@ -95,6 +95,9 @@ class TableSchema:
         kwargs = [f"{key}={value!r}" for key, value in self.schema.items()]
         return f"{self.__class__.__name__}({', '.join(kwargs)})"
 
+    def get_column(self, name):
+        return self.schema[name]
+
     def get_column_type(self, name):
         return self.schema[name].type_
 

--- a/tests/unit/dummy_data/test_generator.py
+++ b/tests/unit/dummy_data/test_generator.py
@@ -12,7 +12,7 @@ from databuilder.tables import Constraint, EventFrame, PatientFrame, Series, tab
 
 @table
 class patients(PatientFrame):
-    date_of_birth = Series(datetime.date)
+    date_of_birth = Series(datetime.date, constraints=[Constraint.FirstOfMonth()])
     date_of_death = Series(datetime.date)
     sex = Series(
         str, constraints=[Constraint.Categorical(["male", "female", "intersex"])]
@@ -60,6 +60,7 @@ def test_dummy_data_generator():
 
     for r in results:
         assert isinstance(r.date_of_birth, datetime.date)
+        assert r.date_of_birth.day == 1
         assert r.date_of_death is None or r.date_of_death > r.date_of_birth
         assert r.sex in {"male", "female", "intersex"}
         # To get full coverage here we need to generate enough data so that we get at
@@ -111,6 +112,17 @@ def test_dummy_patient_generator_get_random_value(dummy_patient_generator, type_
     column_info = ColumnInfo(name="test", categories=None, type=type_)
     value = dummy_patient_generator.get_random_value(column_info)
     assert isinstance(value, type_)
+
+
+def test_get_random_value_on_first_of_month(dummy_patient_generator):
+    column_info = ColumnInfo(
+        name="test",
+        categories=None,
+        type=datetime.date,
+        has_first_of_month_constraint=True,
+    )
+    value = dummy_patient_generator.get_random_value(column_info)
+    assert value.day == 1
 
 
 @pytest.fixture(scope="module")

--- a/tests/unit/query_model/test_table_schema.py
+++ b/tests/unit/query_model/test_table_schema.py
@@ -43,6 +43,11 @@ def test_from_primitives():
     assert t1 == t2
 
 
+def test_get_column():
+    schema = TableSchema(i=Column(int))
+    assert schema.get_column("i") == Column(int)
+
+
 def test_get_column_type():
     schema = TableSchema(i=Column(int))
     assert schema.get_column_type("i") is int


### PR DESCRIPTION
Previously the dummy data code was hard-coded to only populate the `patients.date_of_birth` column with dates on the first of the month. We now remove this hard-coded behaviour and instead respect `Constraint.FirstOfMonth`, whichever columns this happens to be applied to.

Depends on #877