### PR TITLE
fix: Generate correctly formatted MSOA codes

### DIFF
--- a/databuilder/dummy_data/generator.py
+++ b/databuilder/dummy_data/generator.py
@@ -218,6 +218,9 @@ class DummyPatientGenerator:
             # TODO: As is this
             return self.rnd.random() * 100
         elif column_info.type is str:
+            # Generate appropriately formatted Middle Layer Super Output Area codes
+            if column_info.name == "msoa_code":
+                return f"E02{self.rnd.randrange(0, 8000):06d}"
             # A random ASCII string is unlikely to be very useful here, but it at least
             # makes it a bit clearer what the issue is (that we don't know enough about
             # the column to generate anything more helpful) rather than the blank string

--- a/databuilder/dummy_data/generator.py
+++ b/databuilder/dummy_data/generator.py
@@ -1,4 +1,5 @@
 import random
+import string
 import time
 from datetime import date, timedelta
 
@@ -11,6 +12,9 @@ from databuilder.query_engines.in_memory_database import InMemoryDatabase
 from databuilder.utils.orm_utils import orm_class_from_schema
 
 log = structlog.getLogger()
+
+
+CHARS = string.ascii_letters + string.digits + ".-+_"
 
 
 class DummyDataGenerator:
@@ -214,10 +218,13 @@ class DummyPatientGenerator:
             # TODO: As is this
             return self.rnd.random() * 100
         elif column_info.type is str:
-            # There's not much we can do about non-categorical strings with no
-            # comparison values used in the query (generating a random string is
-            # unlikely to be useful), but I don't expect we'll get many of these
-            return ""
+            # A random ASCII string is unlikely to be very useful here, but it at least
+            # makes it a bit clearer what the issue is (that we don't know enough about
+            # the column to generate anything more helpful) rather than the blank string
+            # we always used to return
+            return "".join(
+                self.rnd.choice(CHARS) for _ in range(self.rnd.randrange(16))
+            )
         elif column_info.type is date:
             # Use an exponential distribution to preferentially generate recent events
             # (mean of one year ago). This works OK for the our immediate purposes but

--- a/databuilder/dummy_data/query_info.py
+++ b/databuilder/dummy_data/query_info.py
@@ -23,7 +23,7 @@ class ColumnInfo:
 
     name: str
     type: type  # NOQA: A003
-    categories: Optional[tuple]
+    categories: Optional[tuple] = None
     has_first_of_month_constraint: bool = False
     values_used: set = dataclasses.field(default_factory=set)
 

--- a/tests/unit/dummy_data/test_generator.py
+++ b/tests/unit/dummy_data/test_generator.py
@@ -125,6 +125,13 @@ def test_get_random_value_on_first_of_month(dummy_patient_generator):
     assert value.day == 1
 
 
+def test_get_random_str(dummy_patient_generator):
+    column_info = ColumnInfo(name="test", type=str)
+    values = [dummy_patient_generator.get_random_value(column_info) for _ in range(10)]
+    lengths = {len(s) for s in values}
+    assert len(lengths) > 1, "strings are all the same length"
+
+
 @pytest.fixture(scope="module")
 def dummy_patient_generator():
     dataset = Dataset()

--- a/tests/unit/dummy_data/test_generator.py
+++ b/tests/unit/dummy_data/test_generator.py
@@ -1,4 +1,5 @@
 import datetime
+import re
 from unittest import mock
 
 import pytest
@@ -130,6 +131,12 @@ def test_get_random_str(dummy_patient_generator):
     values = [dummy_patient_generator.get_random_value(column_info) for _ in range(10)]
     lengths = {len(s) for s in values}
     assert len(lengths) > 1, "strings are all the same length"
+
+
+def test_get_random_msoa_code(dummy_patient_generator):
+    column_info = ColumnInfo(name="msoa_code", type=str)
+    value = dummy_patient_generator.get_random_value(column_info)
+    assert re.match(r"E020[0-9]{5}", value)
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
This teaches the dummy data generator that string columns called `msoa_code` should always have a particular format.

We also change the default behaviour for string columns about which we know nothing other than that they're a string. Instead of returning an empty string we return some ASCII gibberish, which at least makes it clear that we are generating _something_ even if we don't know enough about the column to be more helpful. 

Closes #841