### PR TITLE
Link to notes on using `pytest` with Data Builder

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -67,6 +67,10 @@ For example:
 just test-spec-no-spark
 ```
 
+There are further notes on using `pytest` in the wiki here:
+https://github.com/opensafely-core/databuilder/wiki/Tips-for-using-pytest
+
+
 #### Generative tests
 
 The generative tests use Hypothesis to generate variable definitions (in the query model) and test data.

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -64,7 +64,7 @@ Since we have many tests that are parameterized across multiple databases and th
 These are much faster and should be used unless you're specifically working on Spark.
 For example:
 ```
-just test-integration-no-spark
+just test-spec-no-spark
 ```
 
 #### Generative tests

--- a/Justfile
+++ b/Justfile
@@ -168,10 +168,6 @@ test-docker *ARGS: devenv
 test-integration *ARGS: devenv
     $BIN/python -m pytest tests/integration {{ ARGS }}
 
-# Run the integration tests only, excluding spark tests which are slow. Optional args are passed to pytest.
-test-integration-no-spark *ARGS: devenv
-    $BIN/python -m pytest tests/integration -k "not spark" {{ ARGS }}
-
 # Run the spec tests only. Optional args are passed to pytest.
 test-spec *ARGS: devenv
     $BIN/python -m pytest tests/spec {{ ARGS }}


### PR DESCRIPTION
It would be quite reasonable to abandon the Wiki entirely and bring its contents into the repo itself. But for now this seemed like the lowest friction way of sharing these notes.
https://github.com/opensafely-core/databuilder/wiki/Tips-for-using-pytest