### PR TITLE
Fix `repr` for examples produced by `data_strategy`

### DIFF
--- a/tests/generative/data_setup.py
+++ b/tests/generative/data_setup.py
@@ -41,8 +41,12 @@ def _build_orm_classes(prefix, count, schema, base_class, has_one_row_per_patien
 def _build_orm_class(name, schema, base_class, has_one_row_per_patient):
     class_ = orm_class_from_schema(base_class, name, schema, has_one_row_per_patient)
     # It's helpful to have the classes available as module properties so that we can
-    # copy-paste failing test cases from Hypothesis.
-    globals()[name] = class_
+    # copy-paste failing test cases from Hypothesis. These classes naturally believe
+    # that they belong to the `orm_utils` module which created them, so we have to
+    # re-parent them here. We use only the final component of the module name as that's
+    # how we import it in `test_query_model`.
+    class_.__module__ = __name__.rpartition(".")[2]
+    globals()[class_.__name__] = class_
     return class_
 
 

--- a/tests/generative/test_data_setup.py
+++ b/tests/generative/test_data_setup.py
@@ -1,0 +1,26 @@
+import hypothesis as hyp
+from hypothesis.vendor.pretty import pretty
+
+from . import test_query_model
+
+
+# We just need a single non-empty example to check, and we want to keep the test
+# deterministic
+@hyp.given(example=test_query_model.data_strategy)
+@hyp.settings(max_examples=1, derandomize=True)
+def test_data_strategy_examples_round_trip(example):
+    """
+    Examples produced by `data_strategy` contain references to classes dynamically
+    generated in `data_setup` and we need to do some underhand stuff to make sure they
+    can be copy/pasted back into `@hypothesis.example()` and evalate correctly.
+
+    We've broken this propery once without realising so this test ensures we don't do so
+    again.
+    """
+    hyp.assume(len(example) > 0)
+    # `pretty` is the formatter Hypothesis uses for examples
+    example_repr = pretty(example)
+    # Evaluate it in the context of the `text_query_model` module, which is where
+    # examples will get pasted
+    evaled = eval(example_repr, globals(), vars(test_query_model))
+    assert evaled == example


### PR DESCRIPTION
This was broken when we factored out the class generation code in 08a079f5a01ac67e8f583fb44569afb93e3faf57.

We also add a test for the round-trippable-repr property we want to maintain, as it turns out to be easy to break this without noticing.
