### PR TITLE
Tweak Spark config in order to speed it up

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -78,7 +78,7 @@ def mssql_database(containers, show_delayed_warning):
 def spark_database(containers, show_delayed_warning):
     with show_delayed_warning(3, "Downloading and starting Spark Docker image"):
         database = make_spark_database(containers)
-        wait_for_database(database, timeout=15)
+        wait_for_database(database, timeout=20)
     yield database
 
 

--- a/tests/lib/databases.py
+++ b/tests/lib/databases.py
@@ -210,6 +210,15 @@ def make_spark_container_database(containers):
                 "hive.server2.transport.mode=http",
                 "--hiveconf",
                 f"hive.server2.thrift.http.port={spark_port}",
+                # These settings try to reduce the amount of unnecessary "Big Data" work
+                # which Spark does on our tiny test queries in an attempt to speed them
+                # up. They were suggested by a helpful StackOverflow user and seem to
+                # give about a 20% speed up on the Spark tests:
+                # https://stackoverflow.com/a/74878746
+                "--conf",
+                "spark.sql.shuffle.partitions=1",
+                "--conf",
+                "spark.sql.autoBroadcastJoinThreshold=-1",
             ],
             # As described below, there's a directory permissions issue when
             # trying to run Hive using this container. It's possible to chmod


### PR DESCRIPTION
These settings were suggested by a helpful StackOverflow user:
https://stackoverflow.com/a/74878746

They seem to reduce the time taken to run:

    pytest tests/spec/ -k 'spark and execute'

from 314s (5m14) to 255s (4m15) which is nice, although not game-changing.

Related to #248