### PR TITLE
Add cast operations to the generative tests

### DIFF
--- a/tests/generative/data_strategies.py
+++ b/tests/generative/data_strategies.py
@@ -12,12 +12,19 @@ max_num_patient_records = max_patient_id  # <= max_patient_id, hasn't been fine-
 max_num_event_records = max_patient_id  # could be anything, hasn't been fine-tuned
 
 
-def record(class_, id_strategy, schema, int_values, bool_values, date_values):
+def record(
+    class_, id_strategy, schema, int_values, bool_values, date_values, float_values
+):
     # We don't construct the actual objects here because it's easier to extract stats for the generated data if we
     # pass around simple objects.
     columns = {patient_id_column: id_strategy}
     for name, type_ in schema.column_types:
-        type_strategy = {int: int_values, bool: bool_values, date: date_values}[type_]
+        type_strategy = {
+            int: int_values,
+            bool: bool_values,
+            date: date_values,
+            float: float_values,
+        }[type_]
         columns[name] = type_strategy
 
     return st.builds(dict, type=st.just(class_), **columns)
@@ -35,16 +42,26 @@ def concat(draw, *list_strategies):
 patient_ids = st.integers(min_value=1, max_value=max_patient_id)
 
 
-def event_records(class_, schema, int_values, bool_values, date_values):
+def event_records(class_, schema, int_values, bool_values, date_values, float_values):
     return st.lists(
-        record(class_, patient_ids, schema, int_values, bool_values, date_values),
+        record(
+            class_,
+            patient_ids,
+            schema,
+            int_values,
+            bool_values,
+            date_values,
+            float_values,
+        ),
         min_size=0,
         max_size=max_num_event_records,
     )
 
 
 @st.composite
-def patient_records(draw, class_, schema, int_values, bool_values, date_values):
+def patient_records(
+    draw, class_, schema, int_values, bool_values, date_values, float_values
+):
     # This strategy ensures that the patient ids are unique. We need to maintain the state to ensure that uniqueness
     # inside the strategy itself so that we can ensure the tests are idempotent as Hypothesis requires. That means that
     # this strategy must be called once only for a given table in a given test.
@@ -56,7 +73,15 @@ def patient_records(draw, class_, schema, int_values, bool_values, date_values):
         hyp.assume(id_ not in used_ids)
         used_ids.append(id_)
         return draw(
-            record(class_, st.just(id_), schema, int_values, bool_values, date_values)
+            record(
+                class_,
+                st.just(id_),
+                schema,
+                int_values,
+                bool_values,
+                date_values,
+                float_values,
+            )
         )
 
     return draw(
@@ -64,14 +89,24 @@ def patient_records(draw, class_, schema, int_values, bool_values, date_values):
     )
 
 
-def data(patient_classes, event_classes, schema, int_values, bool_values, date_values):
+def data(
+    patient_classes,
+    event_classes,
+    schema,
+    int_values,
+    bool_values,
+    date_values,
+    float_values,
+):
     return concat(
         *[
-            patient_records(c, schema, int_values, bool_values, date_values)
+            patient_records(
+                c, schema, int_values, bool_values, date_values, float_values
+            )
             for c in patient_classes
         ],
         *[
-            event_records(c, schema, int_values, bool_values, date_values)
+            event_records(c, schema, int_values, bool_values, date_values, float_values)
             for c in event_classes
         ]
     )

--- a/tests/generative/test_query_model.py
+++ b/tests/generative/test_query_model.py
@@ -22,6 +22,8 @@ schema = TableSchema(
     b2=Column(bool),
     d1=Column(datetime.date),
     d2=Column(datetime.date),
+    f1=Column(float),
+    f2=Column(float),
 )
 (
     patient_classes,
@@ -36,6 +38,7 @@ bool_values = st.booleans()
 date_values = st.dates(
     min_value=datetime.date(1900, 1, 1), max_value=datetime.date(2100, 12, 31)
 )
+float_values = st.floats(min_value=0.0, max_value=11.0, width=16, allow_infinity=False)
 
 
 variable_strategy = variable_strategies.variable(
@@ -45,9 +48,16 @@ variable_strategy = variable_strategies.variable(
     int_values,
     bool_values,
     date_values,
+    float_values,
 )
 data_strategy = data_strategies.data(
-    patient_classes, event_classes, schema, int_values, bool_values, date_values
+    patient_classes,
+    event_classes,
+    schema,
+    int_values,
+    bool_values,
+    date_values,
+    float_values,
 )
 settings = dict(
     max_examples=(int(os.environ.get("GENTEST_EXAMPLES", 100))),

--- a/tests/generative/variable_strategies.py
+++ b/tests/generative/variable_strategies.py
@@ -64,7 +64,13 @@ from tests.lib.query_model_utils import get_all_operations
 
 
 def variable(
-    patient_tables, event_tables, schema, int_values, bool_values, date_values
+    patient_tables,
+    event_tables,
+    schema,
+    int_values,
+    bool_values,
+    date_values,
+    float_values,
 ):
     frame = st.deferred(
         lambda: st.one_of(
@@ -184,7 +190,9 @@ def variable(
 
     sorted_frame = st.deferred(lambda: st.one_of(sort))
 
-    value = qm_builds(Value, st.one_of(int_values, bool_values, date_values))
+    value = qm_builds(
+        Value, st.one_of(int_values, bool_values, date_values, float_values)
+    )
     date_value = qm_builds(Value, st.one_of(date_values))
 
     select_table = qm_builds(

--- a/tests/generative/variable_strategies.py
+++ b/tests/generative/variable_strategies.py
@@ -165,6 +165,8 @@ def variable(
             add,
             subtract,
             multiply,
+            cast_to_int,
+            cast_to_float,
             date_add_years,
             date_add_months,
             date_add_days,
@@ -250,6 +252,9 @@ def variable(
     subtract = qm_builds(Function.Subtract, series, series)
     multiply = qm_builds(Function.Multiply, series, series)
 
+    cast_to_int = qm_builds(Function.CastToInt, series)
+    cast_to_float = qm_builds(Function.CastToFloat, series)
+
     date_add_years = qm_builds(Function.DateAddYears, date_series, series)
     date_add_months = qm_builds(Function.DateAddMonths, date_series, series)
     date_add_days = qm_builds(Function.DateAddDays, date_series, series)
@@ -300,8 +305,6 @@ known_missing_operations = {
     Case,
     Function.In,
     Function.StringContains,
-    Function.CastToFloat,
-    Function.CastToInt,
 }
 
 


### PR DESCRIPTION
Closes #838 

This addes CastToInt and CastToFloat to the generative tests; it also required adding float values to the strategies.

When I added the cast operations, tests started failing every so often when they tried to add or subtract a large number of years from a date.  (e.g. 1900-01-01 - 193 years, which is less than the sqlserver min - 1793-01-01).

We limit int values to 0-10, and the new float values that I've added are limited to 0.0-11.0.  Dates are limited to 1900-01-01 - 2100-12-31.  Previously this was enough to limit the inputs to a DateAddX operation to only values that were valid.

However, there is a Multiply node, which I think returns floats.  Those were previously not being passed to DateAddYears in the tests because it requires an int series.  Now that the tests can cast floats to ints, the result of a Multiply operation can be an input into a  DateAddYears. E.g. if the tests happened to multiply 9 * 10, negate it, cast it to an int and try to add it to a date, it'll try to subtract 900 from the date and fall over.

DateAddX operations take a date series and an int series.  I've solved this for now by filtering out any inputs to a date_add_x strategy that were produced by a CastToInt, because these are ones that may have been the result of a Multiply operation earlier in the tree.