### PR TITLE
Replace `setup-just` action with inline bash

### DIFF
--- a/.github/workflows/databricks.yml
+++ b/.github/workflows/databricks.yml
@@ -18,7 +18,11 @@ jobs:
       - uses: "actions/setup-python@v4"
         with:
           python-version: "3.9"
-      - uses: extractions/setup-just@v1
+      - name: Install just
+        run: |
+          mkdir -p ~/.local/bin
+          curl -L https://github.com/casey/just/releases/download/1.9.0/just-1.9.0-x86_64-unknown-linux-musl.tar.gz \
+           | tar -xzf - --directory ~/.local/bin just
       - name: Login to databricks
         run: |
             echo -e \

--- a/.github/workflows/generative-tests.yml
+++ b/.github/workflows/generative-tests.yml
@@ -15,5 +15,9 @@ jobs:
       - uses: "actions/setup-python@v4"
         with:
           python-version: "3.9"
-      - uses: extractions/setup-just@v1
+      - name: Install just
+        run: |
+          mkdir -p ~/.local/bin
+          curl -L https://github.com/casey/just/releases/download/1.9.0/just-1.9.0-x86_64-unknown-linux-musl.tar.gz \
+           | tar -xzf - --directory ~/.local/bin just
       - run: GENTEST_EXAMPLES=40000 GENTEST_COMPREHENSIVE=t GENTEST_DEBUG=t just test-generative

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,11 @@ jobs:
       - uses: "actions/setup-python@v4"
         with:
           python-version: "3.9"
-      - uses: extractions/setup-just@v1
+      - name: Install just
+        run: |
+          mkdir -p ~/.local/bin
+          curl -L https://github.com/casey/just/releases/download/1.9.0/just-1.9.0-x86_64-unknown-linux-musl.tar.gz \
+           | tar -xzf - --directory ~/.local/bin just
       - name: Check formatting, linting and import sorting
         run: just check
 
@@ -28,7 +32,11 @@ jobs:
       - uses: "actions/setup-python@v4"
         with:
           python-version: "3.9"
-      - uses: extractions/setup-just@v1
+      - name: Install just
+        run: |
+          mkdir -p ~/.local/bin
+          curl -L https://github.com/casey/just/releases/download/1.9.0/just-1.9.0-x86_64-unknown-linux-musl.tar.gz \
+           | tar -xzf - --directory ~/.local/bin just
       - name: Run tests
         env:
           CI: 1

--- a/.github/workflows/track-no-cover.yml
+++ b/.github/workflows/track-no-cover.yml
@@ -15,7 +15,11 @@ jobs:
       - uses: "actions/setup-python@v4"
         with:
           python-version: "3.9"
-      - uses: extractions/setup-just@v1
+      - name: Install just
+        run: |
+          mkdir -p ~/.local/bin
+          curl -L https://github.com/casey/just/releases/download/1.9.0/just-1.9.0-x86_64-unknown-linux-musl.tar.gz \
+           | tar -xzf - --directory ~/.local/bin just
 
       - name: Did coverage change?
         env:

--- a/.github/workflows/update-public-docs.yml
+++ b/.github/workflows/update-public-docs.yml
@@ -23,7 +23,11 @@ jobs:
       - uses: "actions/setup-python@v4"
         with:
           python-version: "3.9"
-      - uses: extractions/setup-just@v1
+      - name: Install just
+        run: |
+          mkdir -p ~/.local/bin
+          curl -L https://github.com/casey/just/releases/download/1.9.0/just-1.9.0-x86_64-unknown-linux-musl.tar.gz \
+           | tar -xzf - --directory ~/.local/bin just
 
       - name: Generate new public docs file
         run: just generate-docs new_public_docs.json


### PR DESCRIPTION
The `setup-just` action regularly, but unpredictably, fails with an API limit error:

    Error: API rate limit exceeded for 157.55.189.38. (But here's the
    good news: Authenticated requests get a higher rate limit. Check out
    the documentation for more details.)

The documented remedy is to pass the action your GITHUB_TOKEN so it can use it, but I disagree that it should making these kind of API requests in the first place.

There's some discussion of the issue here:
https://bennettoxford.slack.com/archives/C63UXGB8E/p1671543684567039

I think longer term we want our own "install stuff" action as outlined in the thread, but the intermittent failures have got so annoying that I just want to make them go away for now.