### PR TITLE
Refactor test setup machinery

### DIFF
--- a/databuilder/backends/base.py
+++ b/databuilder/backends/base.py
@@ -2,7 +2,7 @@ import re
 
 import sqlalchemy
 
-from databuilder.query_language import BaseFrame
+from databuilder.query_language import get_tables_from_namespace
 from databuilder.sqlalchemy_types import type_from_python_type
 
 
@@ -149,13 +149,3 @@ class DefaultBackend:
                 for (name, type_) in schema.column_types
             ],
         )
-
-
-def get_tables_from_namespace(namespace):
-    """
-    Get all query model SelectTable/SelectPatientTable objects referenced by any Frames
-    contained in `namespace`
-    """
-    for attr, value in vars(namespace).items():
-        if isinstance(value, BaseFrame):
-            yield attr, value.qm_node

--- a/databuilder/backends/base.py
+++ b/databuilder/backends/base.py
@@ -41,7 +41,8 @@ class BaseBackend:
 
     @classmethod
     def validate_against_table_namespace(cls, table_namespace):
-        for attr, table in get_tables_from_namespace(table_namespace):
+        for attr, ql_table in get_tables_from_namespace(table_namespace):
+            table = ql_table.qm_node
             if table.name not in cls.tables:
                 raise ValidationError(
                     f"{cls} does not implement table '{table.name}' from "

--- a/databuilder/dummy_data/generator.py
+++ b/databuilder/dummy_data/generator.py
@@ -4,12 +4,11 @@ import time
 from datetime import date, timedelta
 
 import structlog
-from sqlalchemy.orm import declarative_base
 
 from databuilder.dummy_data.query_info import QueryInfo
 from databuilder.query_engines.in_memory import InMemoryQueryEngine
 from databuilder.query_engines.in_memory_database import InMemoryDatabase
-from databuilder.utils.orm_utils import orm_class_from_schema
+from databuilder.utils.orm_utils import orm_classes_from_tables
 
 log = structlog.getLogger()
 
@@ -112,16 +111,10 @@ class DummyPatientGenerator:
 
         self.query_info = QueryInfo.from_variable_definitions(variable_definitions)
         # Create ORM classes for each of the tables used in the dataset definition
-        Base = declarative_base()
-        self.orm_classes = {
-            table_info.name: orm_class_from_schema(
-                Base,
-                table_info.name,
-                table_info,
-                table_info.has_one_row_per_patient,
-            )
+        self.orm_classes = orm_classes_from_tables(
+            table_info.get_table_node()
             for table_info in self.query_info.tables.values()
-        }
+        )
 
     def get_patient_data_for_population_condition(self, patient_id):
         # Generate data for just those tables needed for determining whether the patient

--- a/databuilder/query_engines/csv.py
+++ b/databuilder/query_engines/csv.py
@@ -4,7 +4,7 @@ from databuilder.query_engines.in_memory import InMemoryQueryEngine
 from databuilder.query_engines.in_memory_database import InMemoryDatabase
 from databuilder.query_model.nodes import get_table_nodes
 from databuilder.utils.orm_utils import (
-    orm_classes_from_qm_tables,
+    orm_classes_from_tables,
     read_orm_models_from_csv_directory,
 )
 
@@ -26,10 +26,10 @@ class CSVQueryEngine(InMemoryQueryEngine):
         # Given the variables supplied determine the tables used and create
         # corresponding ORM classes
         table_nodes = get_table_nodes(*variable_definitions.values())
-        orm_classes = orm_classes_from_qm_tables(table_nodes)
+        orm_classes = orm_classes_from_tables(table_nodes)
         # Populate the database using CSV files in the supplied directory
         input_data = read_orm_models_from_csv_directory(
-            Path(self.csv_directory), orm_classes
+            Path(self.csv_directory), orm_classes.values()
         )
         self.dsn.setup(input_data)
 

--- a/databuilder/query_language.py
+++ b/databuilder/query_language.py
@@ -706,12 +706,11 @@ class Series:
 
 def get_tables_from_namespace(namespace):
     """
-    Get all query model SelectTable/SelectPatientTable objects referenced by any Frames
-    contained in `namespace`
+    Yield all ehrQL tables contained in `namespace`
     """
     for attr, value in vars(namespace).items():
         if isinstance(value, BaseFrame):
-            yield attr, value.qm_node
+            yield attr, value
 
 
 # CASE EXPRESSION FUNCTIONS

--- a/databuilder/query_language.py
+++ b/databuilder/query_language.py
@@ -704,6 +704,16 @@ class Series:
         return instance._select_column(self.name)
 
 
+def get_tables_from_namespace(namespace):
+    """
+    Get all query model SelectTable/SelectPatientTable objects referenced by any Frames
+    contained in `namespace`
+    """
+    for attr, value in vars(namespace).items():
+        if isinstance(value, BaseFrame):
+            yield attr, value.qm_node
+
+
 # CASE EXPRESSION FUNCTIONS
 #
 

--- a/databuilder/utils/orm_utils.py
+++ b/databuilder/utils/orm_utils.py
@@ -28,8 +28,8 @@ def null():
 
 def orm_class_from_schema(base_class, table_name, schema, has_one_row_per_patient):
     """
-    Given a SQLAlchemy ORM "declarative base" class, a table name and a schema, return
-    an ORM class with the schema of that table
+    Given a SQLAlchemy ORM "declarative base" class, a table name and a TableSchema,
+    return a ORM class with the appropriate columns
     """
     attributes = {"__tablename__": table_name}
 
@@ -54,7 +54,7 @@ def orm_class_from_schema(base_class, table_name, schema, has_one_row_per_patien
 def orm_class_from_qm_table(base_class, qm_table):
     """
     Given a SQLAlchemy ORM "declarative base" class and a QM table, return an ORM
-    class with the schema of that table
+    class with the appropriate columns
     """
     return orm_class_from_schema(
         base_class, qm_table.name, qm_table.schema, has_one_row_per_patient(qm_table)
@@ -64,7 +64,7 @@ def orm_class_from_qm_table(base_class, qm_table):
 def orm_class_from_ql_table(base_class, table):
     """
     Given a SQLAlchemy ORM "declarative base" class and a QL table, return an ORM
-    class with the schema of that table
+    class with the appropriate columns
     """
     return orm_class_from_qm_table(base_class, table.qm_node)
 
@@ -84,7 +84,7 @@ def orm_classes_from_ql_table_namespace(namespace):
 
 def orm_classes_from_qm_tables(qm_tables):
     """
-    Given a list of Query Model tables, return a list of corresponding ORM instances
+    Given a list of Query Model tables, return a list of corresponding ORM classes
     """
     Base = declarative_base()
     return [orm_class_from_qm_table(Base, table) for table in qm_tables]

--- a/databuilder/utils/orm_utils.py
+++ b/databuilder/utils/orm_utils.py
@@ -2,7 +2,6 @@ import csv
 import datetime
 import functools
 from contextlib import ExitStack
-from types import SimpleNamespace
 
 import sqlalchemy
 from sqlalchemy.orm import declarative_base
@@ -50,45 +49,6 @@ def orm_class_from_schema(base_class, table_name, schema, has_one_row_per_patien
     class_name = table_name.title().replace("_", "")
 
     return type(class_name, (base_class,), attributes)
-
-
-def orm_class_from_qm_table(base_class, qm_table):
-    """
-    Given a SQLAlchemy ORM "declarative base" class and a QM table, return an ORM
-    class with the appropriate columns
-    """
-    return orm_class_from_schema(
-        base_class, qm_table.name, qm_table.schema, has_one_row_per_patient(qm_table)
-    )
-
-
-def orm_class_from_ql_table(base_class, table):
-    """
-    Given a SQLAlchemy ORM "declarative base" class and a QL table, return an ORM
-    class with the appropriate columns
-    """
-    return orm_class_from_qm_table(base_class, table.qm_node)
-
-
-def orm_classes_from_ql_table_namespace(namespace):
-    """
-    Given a namespace containing QL tables, return a namespace where each QL table is
-    mapped to an equivalent ORM class
-    """
-    Base = declarative_base()
-    orm_classes = {"Base": Base}
-    for attr, value in vars(namespace).items():
-        if isinstance(value, BaseFrame):
-            orm_classes[attr] = orm_class_from_ql_table(Base, value)
-    return SimpleNamespace(**orm_classes)
-
-
-def orm_classes_from_qm_tables(qm_tables):
-    """
-    Given a list of Query Model tables, return a list of corresponding ORM classes
-    """
-    Base = declarative_base()
-    return [orm_class_from_qm_table(Base, table) for table in qm_tables]
 
 
 def make_orm_models(*args):

--- a/databuilder/utils/orm_utils.py
+++ b/databuilder/utils/orm_utils.py
@@ -1,5 +1,6 @@
 import csv
 import datetime
+import functools
 from contextlib import ExitStack
 from types import SimpleNamespace
 
@@ -88,6 +89,56 @@ def orm_classes_from_qm_tables(qm_tables):
     """
     Base = declarative_base()
     return [orm_class_from_qm_table(Base, table) for table in qm_tables]
+
+
+def make_orm_models(*args):
+    """
+    Takes one or many dicts like:
+        {
+            patients: [dict(patient_id=1, sex="male")],
+            events: [
+                dict(patient_id=1, code="abc"),
+                dict(patient_id=1, code="xyz"),
+            ]
+        }
+
+    Where the keys are tables (either ehrQL tables or query model tables) and the values
+    are lists of rows. Yields a sequence of ORM model instances.
+    """
+    # Merge the supplied dicts so we can get the full set of tables used upfront
+    combined = {}
+    for table_data in args:
+        for table, rows in table_data.items():
+            combined.setdefault(table, []).extend(rows)
+    orm_classes = orm_classes_from_tables(combined.keys())
+    for table, rows in combined.items():
+        table_name = table.qm_node.name if isinstance(table, BaseFrame) else table.name
+        orm_class = orm_classes[table_name]
+        yield from (orm_class(**row) for row in rows)
+
+
+def orm_classes_from_tables(tables):
+    """
+    Takes an iterable of tables (either ehrQL tables or query model tables) and returns
+    a dict mapping table names to ORM classes
+    """
+    qm_tables = frozenset(
+        table.qm_node if isinstance(table, BaseFrame) else table for table in tables
+    )
+    return _orm_classes_from_qm_tables(qm_tables)
+
+
+# Apply caching so that when large numbers of tests use the same tables we aren't
+# constantly recreating ORM classes
+@functools.cache
+def _orm_classes_from_qm_tables(qm_tables: frozenset):
+    Base = declarative_base()
+    return {
+        table.name: orm_class_from_schema(
+            Base, table.name, table.schema, has_one_row_per_patient(table)
+        )
+        for table in qm_tables
+    }
 
 
 def table_has_one_row_per_patient(table):

--- a/tests/acceptance/comparative_booster_study/test_dataset_definition.py
+++ b/tests/acceptance/comparative_booster_study/test_dataset_definition.py
@@ -33,13 +33,10 @@ def _tpp_orm_metadata():
     return first_orm_class.metadata
 
 
-def test_dataset_definition_against_tpp_backend(request, engine):
-    if engine.query_engine_class is not TPPBackend.query_engine_class:
-        pytest.skip("TPPBackend is only designed for one query engine")
-
+def test_dataset_definition_against_tpp_backend(mssql_engine):
     # In contract to `_tpp_orm_metadata` above, this creates the schema as it actualy
     # exists in the TPP database, and therefore requires the `TPPBackend` to translate
     # it appropriately
-    engine.setup(metadata=tpp_schema.Base.metadata)
-    results = engine.extract(dataset, backend=TPPBackend())
+    mssql_engine.setup(metadata=tpp_schema.Base.metadata)
+    results = mssql_engine.extract(dataset, backend=TPPBackend())
     assert results == []

--- a/tests/acceptance/comparative_booster_study/test_dataset_definition.py
+++ b/tests/acceptance/comparative_booster_study/test_dataset_definition.py
@@ -1,8 +1,9 @@
 import pytest
 
 from databuilder.backends.tpp import TPPBackend
+from databuilder.query_language import get_tables_from_namespace
 from databuilder.tables.beta import tpp
-from databuilder.utils.orm_utils import orm_classes_from_ql_table_namespace
+from databuilder.utils.orm_utils import orm_classes_from_tables
 from tests.lib import tpp_schema
 
 from .dataset_definition import dataset
@@ -17,16 +18,28 @@ def test_dataset_definition(engine):
         pytest.skip("spark tests are too slow")
     if engine.name == "sqlite":
         pytest.xfail("SQLite engine can't handle more than 64 variables")
-    orm_classes = orm_classes_from_ql_table_namespace(tpp)
-    engine.setup(metadata=orm_classes.Base.metadata)
+    engine.setup(metadata=_tpp_orm_metadata())
     results = engine.extract(dataset)
     assert results == []
+
+
+def _tpp_orm_metadata():
+    # Return a SQLAlchemy MetaData object which contains references to all the tables in
+    # the logical TPP schema (i.e. the schema we present in ehrQL)
+    orm_classes = orm_classes_from_tables(
+        table for _, table in get_tables_from_namespace(tpp)
+    )
+    first_orm_class = list(orm_classes.values())[0]
+    return first_orm_class.metadata
 
 
 def test_dataset_definition_against_tpp_backend(request, engine):
     if engine.query_engine_class is not TPPBackend.query_engine_class:
         pytest.skip("TPPBackend is only designed for one query engine")
 
+    # In contract to `_tpp_orm_metadata` above, this creates the schema as it actualy
+    # exists in the TPP database, and therefore requires the `TPPBackend` to translate
+    # it appropriately
     engine.setup(metadata=tpp_schema.Base.metadata)
     results = engine.extract(dataset, backend=TPPBackend())
     assert results == []

--- a/tests/acceptance/comparative_booster_study/test_dataset_definition.py
+++ b/tests/acceptance/comparative_booster_study/test_dataset_definition.py
@@ -1,5 +1,3 @@
-import pytest
-
 from databuilder.backends.tpp import TPPBackend
 from databuilder.query_language import get_tables_from_namespace
 from databuilder.tables.beta import tpp
@@ -9,17 +7,10 @@ from tests.lib import tpp_schema
 from .dataset_definition import dataset
 
 
-def test_dataset_definition(engine):
-    # This test may not look like much but it confirms that the database schema can be
-    # created and that the dataset definition can be evaluated and compiled into valid
-    # SQL which runs without error against that schema, so it's not quite as trivial as
-    # it looks
-    if engine.name == "spark":
-        pytest.skip("spark tests are too slow")
-    if engine.name == "sqlite":
-        pytest.xfail("SQLite engine can't handle more than 64 variables")
-    engine.setup(metadata=_tpp_orm_metadata())
-    results = engine.extract(dataset)
+def test_dataset_definition(in_memory_engine):
+    # Rapid test that the dataset definition can be evaluated without error
+    in_memory_engine.setup(metadata=_tpp_orm_metadata())
+    results = in_memory_engine.extract(dataset)
     assert results == []
 
 
@@ -34,9 +25,9 @@ def _tpp_orm_metadata():
 
 
 def test_dataset_definition_against_tpp_backend(mssql_engine):
-    # In contract to `_tpp_orm_metadata` above, this creates the schema as it actualy
-    # exists in the TPP database, and therefore requires the `TPPBackend` to translate
-    # it appropriately
+    # This test may not look like much but it confirms that the dataset definition can
+    # be evaluated and compiled into valid SQL which runs without error against the TPP
+    # schema via the TPP backend, so it's not quite as trivial as it looks
     mssql_engine.setup(metadata=tpp_schema.Base.metadata)
     results = mssql_engine.extract(dataset, backend=TPPBackend())
     assert results == []

--- a/tests/acceptance/comparative_booster_study/test_variables_lib.py
+++ b/tests/acceptance/comparative_booster_study/test_variables_lib.py
@@ -12,7 +12,9 @@ class events(EventFrame):
     value = Series(int)
 
 
-def test_create_sequential_variables(engine):
+def test_create_sequential_variables(in_memory_engine):
+    engine = in_memory_engine
+
     engine.populate(
         {events: [dict(patient_id=1, date=date(2020, n * 2, 1)) for n in range(1, 5)]},
         {events: [dict(patient_id=2, date=date(2020, n * 3, 1)) for n in range(1, 4)]},
@@ -43,7 +45,9 @@ def test_create_sequential_variables(engine):
     ]
 
 
-def test_create_sequential_variables_with_different_sort_column(engine):
+def test_create_sequential_variables_with_different_sort_column(in_memory_engine):
+    engine = in_memory_engine
+
     engine.populate(
         {
             events: [

--- a/tests/acceptance/comparative_booster_study/test_variables_lib.py
+++ b/tests/acceptance/comparative_booster_study/test_variables_lib.py
@@ -1,37 +1,27 @@
 from datetime import date
-from types import SimpleNamespace
-
-import pytest
-import sqlalchemy.orm
 
 from databuilder.ehrql import Dataset
 from databuilder.query_language import EventFrame, Series, table
-from databuilder.utils.orm_utils import orm_class_from_ql_table
 
 from .variables_lib import create_sequential_variables
 
 
-@pytest.fixture
-def schema():
-    @table
-    class events(EventFrame):
-        date = Series(date)
-        value = Series(int)
-
-    Event = orm_class_from_ql_table(sqlalchemy.orm.declarative_base(), events)
-    return SimpleNamespace(events=events, Event=Event)
+@table
+class events(EventFrame):
+    date = Series(date)
+    value = Series(int)
 
 
-def test_create_sequential_variables(engine, schema):
-    engine.setup(
-        [schema.Event(patient_id=1, date=date(2020, n * 2, 1)) for n in range(1, 5)],
-        [schema.Event(patient_id=2, date=date(2020, n * 3, 1)) for n in range(1, 4)],
+def test_create_sequential_variables(engine):
+    engine.populate(
+        {events: [dict(patient_id=1, date=date(2020, n * 2, 1)) for n in range(1, 5)]},
+        {events: [dict(patient_id=2, date=date(2020, n * 3, 1)) for n in range(1, 4)]},
     )
 
     dataset = Dataset()
-    dataset.set_population(schema.events.exists_for_patient())
+    dataset.set_population(events.exists_for_patient())
 
-    frame = schema.events.take(schema.events.date.is_on_or_after("2020-04-01"))
+    frame = events.take(events.date.is_on_or_after("2020-04-01"))
     create_sequential_variables(
         dataset, "date_{n}", frame, column="date", num_variables=3
     )
@@ -53,22 +43,26 @@ def test_create_sequential_variables(engine, schema):
     ]
 
 
-def test_create_sequential_variables_with_different_sort_column(engine, schema):
-    engine.setup(
-        [
-            schema.Event(patient_id=1, date=date(2020, n * 2, 1), value=n)
-            for n in range(1, 5)
-        ],
-        [
-            schema.Event(patient_id=2, date=date(2020, n * 3, 1), value=n)
-            for n in range(1, 4)
-        ],
+def test_create_sequential_variables_with_different_sort_column(engine):
+    engine.populate(
+        {
+            events: [
+                dict(patient_id=1, date=date(2020, n * 2, 1), value=n)
+                for n in range(1, 5)
+            ]
+        },
+        {
+            events: [
+                dict(patient_id=2, date=date(2020, n * 3, 1), value=n)
+                for n in range(1, 4)
+            ]
+        },
     )
 
     dataset = Dataset()
-    dataset.set_population(schema.events.exists_for_patient())
+    dataset.set_population(events.exists_for_patient())
 
-    frame = schema.events.take(schema.events.date.is_on_or_after("2020-04-01"))
+    frame = events.take(events.date.is_on_or_after("2020-04-01"))
     create_sequential_variables(
         dataset, "value_{n}", frame, column="value", sort_column="date", num_variables=3
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -193,6 +193,11 @@ def engine(request):
     return engine_factory(request, request.param)
 
 
+@pytest.fixture
+def mssql_engine(request):
+    return engine_factory(request, "mssql")
+
+
 @pytest.fixture(scope="session")
 def databuilder_image(show_delayed_warning):
     project_dir = Path(databuilder.__file__).parents[1]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,7 @@ from databuilder.query_engines.mssql import MSSQLQueryEngine
 from databuilder.query_engines.spark import SparkQueryEngine
 from databuilder.query_engines.sqlite import SQLiteQueryEngine
 from databuilder.query_language import compile
+from databuilder.utils.orm_utils import make_orm_models
 
 from .lib.databases import (
     InMemorySQLiteDatabase,
@@ -132,6 +133,9 @@ class QueryEngineFixture:
 
     def teardown(self):
         return self.database.teardown()
+
+    def populate(self, *args):
+        return self.setup(make_orm_models(*args))
 
     def extract(self, dataset, **engine_kwargs):
         variables = compile(dataset)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -198,6 +198,11 @@ def mssql_engine(request):
     return engine_factory(request, "mssql")
 
 
+@pytest.fixture
+def in_memory_engine(request):
+    return engine_factory(request, "in_memory")
+
+
 @pytest.fixture(scope="session")
 def databuilder_image(show_delayed_warning):
     project_dir = Path(databuilder.__file__).parents[1]

--- a/tests/generative/data_setup.py
+++ b/tests/generative/data_setup.py
@@ -1,70 +1,54 @@
-import sqlalchemy.orm
-
 from databuilder.query_model.nodes import (
     AggregateByPatient,
     Function,
     SelectPatientTable,
     SelectTable,
 )
-from databuilder.utils.orm_utils import orm_class_from_schema
+from databuilder.utils.orm_utils import orm_classes_from_tables
 
 
 def setup(schema, num_patient_tables, num_event_tables):
-    base_class = sqlalchemy.orm.declarative_base()
+    patient_tables = [
+        SelectPatientTable(f"p{i}", schema=schema) for i in range(num_patient_tables)
+    ]
+    event_tables = [
+        SelectTable(f"e{i}", schema=schema) for i in range(num_event_tables)
+    ]
+    all_tables = patient_tables + event_tables
 
-    patient_table_names, patient_classes = _build_orm_classes(
-        "p", num_patient_tables, schema, base_class, has_one_row_per_patient=True
-    )
-    event_table_names, event_classes = _build_orm_classes(
-        "e", num_event_tables, schema, base_class, has_one_row_per_patient=False
-    )
+    orm_classes = orm_classes_from_tables(all_tables)
+    _add_classes_to_module_namespace(orm_classes)
 
-    all_patients_query = _build_query(patient_table_names, event_table_names, schema)
+    patient_classes = [orm_classes[table.name] for table in patient_tables]
+    event_classes = [orm_classes[table.name] for table in event_tables]
+
+    all_patients_query = _build_query(all_tables)
+
+    # We arbitrarily choose the first patient class, but all the ORM classes share the
+    # same MetaData
+    metadata = patient_classes[0].metadata
 
     return (
         patient_classes,
         event_classes,
         all_patients_query,
-        base_class.metadata,
+        metadata,
     )
 
 
-def _build_orm_classes(prefix, count, schema, base_class, has_one_row_per_patient):
-    names = [f"{prefix}{i}" for i in range(count)]
-    classes = [
-        _build_orm_class(name, schema, base_class, has_one_row_per_patient)
-        for name in names
-    ]
-    return names, classes
-
-
-def _build_orm_class(name, schema, base_class, has_one_row_per_patient):
-    class_ = orm_class_from_schema(base_class, name, schema, has_one_row_per_patient)
+def _add_classes_to_module_namespace(orm_classes):
     # It's helpful to have the classes available as module properties so that we can
     # copy-paste failing test cases from Hypothesis. These classes naturally believe
     # that they belong to the `orm_utils` module which created them, so we have to
     # re-parent them here. We use only the final component of the module name as that's
     # how we import it in `test_query_model`.
-    class_.__module__ = __name__.rpartition(".")[2]
-    globals()[class_.__name__] = class_
-    return class_
+    for class_ in orm_classes.values():
+        class_.__module__ = __name__.rpartition(".")[2]
+        globals()[class_.__name__] = class_
 
 
-def _build_query(patient_tables, event_tables, schema):
-    clauses = []
-
-    for table in patient_tables:
-        clauses.append(
-            AggregateByPatient.Exists(
-                source=SelectPatientTable(name=table, schema=schema)
-            )
-        )
-
-    for table in event_tables:
-        clauses.append(
-            AggregateByPatient.Exists(source=SelectTable(name=table, schema=schema))
-        )
-
+def _build_query(tables):
+    clauses = [AggregateByPatient.Exists(source=table) for table in tables]
     return _join_with_or(clauses)
 
 

--- a/tests/integration/query_engines/test_mssql.py
+++ b/tests/integration/query_engines/test_mssql.py
@@ -4,7 +4,6 @@ from unittest import mock
 import pytest
 from sqlalchemy.exc import OperationalError, ProgrammingError
 from sqlalchemy.future.engine import Connection
-from sqlalchemy.orm import declarative_base
 from sqlalchemy.sql import Select
 
 from databuilder.query_engines.mssql import MSSQLQueryEngine
@@ -15,7 +14,7 @@ from databuilder.query_model.nodes import (
     SelectPatientTable,
     TableSchema,
 )
-from databuilder.utils.orm_utils import orm_class_from_qm_table
+from databuilder.utils.orm_utils import orm_classes_from_tables
 
 
 def test_get_results_using_temporary_database(mssql_database):
@@ -27,7 +26,7 @@ def test_get_results_using_temporary_database(mssql_database):
         population=AggregateByPatient.Exists(patient_table),
         i=SelectColumn(patient_table, "i"),
     )
-    patients = orm_class_from_qm_table(declarative_base(), patient_table)
+    patients = orm_classes_from_tables([patient_table])["patients"]
     mssql_database.setup(
         patients(patient_id=1, i=10),
         patients(patient_id=2, i=20),

--- a/tests/spec/tables.py
+++ b/tests/spec/tables.py
@@ -1,10 +1,7 @@
 import datetime
 
-import sqlalchemy.orm
-
 from databuilder.codes import SNOMEDCTCode
 from databuilder.tables import EventFrame, PatientFrame, Series, table
-from databuilder.utils.orm_utils import orm_class_from_ql_table
 
 
 @table
@@ -41,7 +38,3 @@ class event_level_table(EventFrame):
 # Define short aliases for terser tests
 p = patient_level_table
 e = event_level_table
-
-Base = sqlalchemy.orm.declarative_base()
-PatientLevelTable = orm_class_from_ql_table(Base, patient_level_table)
-EventLevelTable = orm_class_from_ql_table(Base, event_level_table)

--- a/tests/unit/dummy_data/test_query_info.py
+++ b/tests/unit/dummy_data/test_query_info.py
@@ -5,6 +5,7 @@ from databuilder.codes import CTV3Code
 from databuilder.dummy_data.query_info import ColumnInfo, QueryInfo, TableInfo
 from databuilder.ehrql import Dataset, days
 from databuilder.query_language import compile
+from databuilder.query_model.table_schema import Column, TableSchema
 from databuilder.tables import Constraint, EventFrame, PatientFrame, Series, table
 
 
@@ -35,23 +36,40 @@ def test_query_info_from_variable_definitions():
         tables={
             "events": TableInfo(
                 name="events",
+                schema=TableSchema(
+                    date=Column(datetime.date),
+                    code=Column(CTV3Code),
+                ),
                 has_one_row_per_patient=False,
                 columns={},
             ),
             "patients": TableInfo(
                 name="patients",
+                schema=TableSchema(
+                    date_of_birth=Column(datetime.date),
+                    sex=Column(
+                        str,
+                        constraints=(
+                            Constraint.Categorical(
+                                values=("male", "female", "intersex")
+                            ),
+                        ),
+                    ),
+                ),
                 has_one_row_per_patient=True,
                 columns={
                     "date_of_birth": ColumnInfo(
                         name="date_of_birth",
                         type=datetime.date,
                         categories=None,
+                        has_first_of_month_constraint=False,
                         values_used=set(),
                     ),
                     "sex": ColumnInfo(
                         name="sex",
                         type=str,
                         categories=("male", "female", "intersex"),
+                        has_first_of_month_constraint=False,
                         values_used=set(),
                     ),
                 },


### PR DESCRIPTION
This factors out and generalises some of the test setup code from the spec tests so that it can used elsewhere. In particular, it lays the groundwork for supporting end-user tests.

Along the way we trim down the proliferation of ORM utils functions.