### PR TITLE
Fix SQLAlchemy 2.0 deprecations

### DIFF
--- a/databuilder/query_engines/base_sql.py
+++ b/databuilder/query_engines/base_sql.py
@@ -251,7 +251,7 @@ class BaseSQLQueryEngine(BaseQueryEngine):
 
     def string_replace(self, value, pattern, replacement):
         return SQLFunction(
-            "REPLACE", value, pattern, replacement, type=sqlalchemy_types.String
+            "REPLACE", value, pattern, replacement, type_=sqlalchemy_types.String
         )
 
     @get_sql.register(Function.YearFromDate)

--- a/databuilder/query_engines/base_sql.py
+++ b/databuilder/query_engines/base_sql.py
@@ -544,14 +544,15 @@ class BaseSQLQueryEngine(BaseQueryEngine):
 
     @cached_property
     def engine(self):
-        engine_url = sqlalchemy.engine.make_url(self.dsn)
-        # Hardcode the specific SQLAlchemy dialect we want to use: this is the
-        # dialect the query engine will have been written for and tested with and we
-        # don't want to allow global config changes to alter this
-        engine_url._get_entrypoint = lambda: self.sqlalchemy_dialect
+        # Insert the specific SQLAlchemy dialect we want to use into the dialect
+        # registry: this is the dialect the query engine will have been written for and
+        # tested with and we don't want to allow global config changes to alter this
+        dialect_name = self.sqlalchemy_dialect.__name__
+        sqlalchemy.dialects.registry.impls[dialect_name] = self.sqlalchemy_dialect
+        engine_url = sqlalchemy.engine.make_url(self.dsn).set(drivername=dialect_name)
         engine = sqlalchemy.create_engine(engine_url, future=True)
         # The above relies on abusing SQLAlchemy internals so it's possible it will
-        # break in future -- we want to know immediately if it does
+        # break in future — we want to know immediately if it does
         assert isinstance(engine.dialect, self.sqlalchemy_dialect)
         return engine
 

--- a/databuilder/query_engines/base_sql.py
+++ b/databuilder/query_engines/base_sql.py
@@ -498,7 +498,7 @@ class BaseSQLQueryEngine(BaseQueryEngine):
         row_number = subquery_columns[-1]
 
         # Select the first row for each patient according to the above row numbering
-        partitioned_query = sqlalchemy.select(output_columns).where(row_number == 1)
+        partitioned_query = sqlalchemy.select(*output_columns).where(row_number == 1)
 
         return self.reify_query(partitioned_query)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,3 +102,8 @@ filterwarnings = [
     "ignore::DeprecationWarning:docker.utils.utils:53",
     "ignore::DeprecationWarning:pyhive.common:248",
 ]
+env = [
+    # Enable deprecation warnings for SQLAlchemy 2.0. See:
+    # https://docs.sqlalchemy.org/en/14/changelog/migration_20.html#migration-to-2-0-step-two-turn-on-removedin20warnings
+    "SQLALCHEMY_WARN_20=1",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,7 @@ filterwarnings = [
     "ignore::DeprecationWarning:docker.utils.utils:52",
     "ignore::DeprecationWarning:docker.utils.utils:53",
     "ignore::DeprecationWarning:pyhive.common:248",
+    "ignore::DeprecationWarning:pyhive.sqlalchemy_hive:20",
 ]
 env = [
     # Enable deprecation warnings for SQLAlchemy 2.0. See:

--- a/requirements.dev.in
+++ b/requirements.dev.in
@@ -19,5 +19,6 @@ pre-commit
 pydocstyle[toml]
 pytest
 pytest-cov
+pytest-env
 pytest-mock
 pyupgrade

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -245,10 +245,15 @@ pytest==7.2.0 \
     # via
     #   -r requirements.dev.in
     #   pytest-cov
+    #   pytest-env
     #   pytest-mock
 pytest-cov==4.0.0 \
     --hash=sha256:2feb1b751d66a8bd934e5edfa2e961d11309dc37b73b0eabe73b5945fee20f6b \
     --hash=sha256:996b79efde6433cdbd0088872dbc5fb3ed7fe1578b68cdbba634f14bb8dd0470
+    # via -r requirements.dev.in
+pytest-env==0.8.1 \
+    --hash=sha256:8c0605ae09a5b7e41c20ebcc44f2c906eea9654095b4b0c342b3814bcc3a8492 \
+    --hash=sha256:d7b2f5273ec6d1e221757998bc2f50d2474ed7d0b9331b92556011fadc4e9abf
     # via -r requirements.dev.in
 pytest-mock==3.10.0 \
     --hash=sha256:f4c973eeae0282963eb293eb173ce91b091a79c1334455acfac9ddee8a1c784b \

--- a/tests/integration/backends/test_tpp.py
+++ b/tests/integration/backends/test_tpp.py
@@ -62,7 +62,7 @@ def select_all(request, mssql_database):
         mssql_database.setup(*input_data)
         with mssql_database.engine().connect() as connection:
             results = connection.execute(select_all_query)
-            return [dict(row) for row in results]
+            return [row._asdict() for row in results]
 
     return _select_all
 

--- a/tests/integration/query_engines/test_dialects.py
+++ b/tests/integration/query_engines/test_dialects.py
@@ -11,12 +11,10 @@ def test_case_statement(engine):
         pytest.skip("SQLAlchemy dialect tests do not apply to the in-memory engine")
 
     case_statement = sqlalchemy.case(
-        [
-            (sqlalchemy.literal(1) == 0, "foo"),
-            (sqlalchemy.literal(1) == 1, "bar"),
-        ]
+        (sqlalchemy.literal(1) == 0, "foo"),
+        (sqlalchemy.literal(1) == 1, "bar"),
     )
     query = sqlalchemy.select(case_statement.label("output"))
     with engine.sqlalchemy_engine().connect() as conn:
         results = list(conn.execute(query))
-    assert results[0]["output"] == "bar"
+    assert results[0].output == "bar"


### PR DESCRIPTION
SQLAlchemy 2.0 has not yet been released, but a release candidate is out and it seems worth being prepared.
https://docs.sqlalchemy.org/en/14/changelog/migration_20.html