### PR TITLE
Parallelise tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,7 @@ add_ignore = [
 ]
 
 [tool.pytest.ini_options]
-addopts = "--tb=native --strict-markers"
+addopts = "--tb=native --strict-markers --dist=loadgroup"
 testpaths = ["tests"]
 markers = [
     "integration: tests that use a container (mostly databases)",

--- a/requirements.dev.in
+++ b/requirements.dev.in
@@ -20,4 +20,5 @@ pydocstyle[toml]
 pytest
 pytest-cov
 pytest-mock
+pytest-xdist
 pyupgrade

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -115,6 +115,10 @@ exceptiongroup==1.0.0rc8 \
     # via
     #   hypothesis
     #   pytest
+execnet==1.9.0 \
+    --hash=sha256:8f694f3ba9cc92cab508b152dcfe322153975c29bda272e2fd7f3f00f36e47c5 \
+    --hash=sha256:a295f7cc774947aac58dde7fdc85f4aa00c42adf5d8f5468fc630c1acf30a142
+    # via pytest-xdist
 filelock==3.7.1 \
     --hash=sha256:37def7b658813cda163b56fc564cdc75e86d338246458c4c28ae84cabefa2404 \
     --hash=sha256:3a0fd85166ad9dbab54c9aec96737b744106dc5f15c0b09a6744a445299fcf04
@@ -246,6 +250,7 @@ pytest==7.2.0 \
     #   -r requirements.dev.in
     #   pytest-cov
     #   pytest-mock
+    #   pytest-xdist
 pytest-cov==4.0.0 \
     --hash=sha256:2feb1b751d66a8bd934e5edfa2e961d11309dc37b73b0eabe73b5945fee20f6b \
     --hash=sha256:996b79efde6433cdbd0088872dbc5fb3ed7fe1578b68cdbba634f14bb8dd0470
@@ -253,6 +258,10 @@ pytest-cov==4.0.0 \
 pytest-mock==3.10.0 \
     --hash=sha256:f4c973eeae0282963eb293eb173ce91b091a79c1334455acfac9ddee8a1c784b \
     --hash=sha256:fbbdb085ef7c252a326fd8cdcac0aa3b1333d8811f131bdcc701002e1be7ed4f
+    # via -r requirements.dev.in
+pytest-xdist==3.1.0 \
+    --hash=sha256:40fdb8f3544921c5dfcd486ac080ce22870e71d82ced6d2e78fa97c2addd480c \
+    --hash=sha256:70a76f191d8a1d2d6be69fc440cdf85f3e4c03c08b520fd5dc5d338d6cf07d89
     # via -r requirements.dev.in
 pyupgrade==3.3.1 \
     --hash=sha256:3b93641963df022d605c78aeae4b5956a5296ea24701eafaef9c487527b77e60 \

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,7 +30,7 @@ def pytest_collection_modifyitems(session, config, items):  # pragma: no cover
     which database is used by the test.
 
     This lets us use pytest-xdist to distribute tests across three processes leading to
-    a moderate speed-up, via `pytest --dist loadgroup -n 3`.
+    a moderate speed-up, via `pytest -n3`.
 
     The "proper" way to distribute tests with pytest-xdist is by adding the xdist_group
     mark.  However, this is very hard to do dynamically (because of our use of

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,8 +25,9 @@ from .lib.docker import Containers
 from .lib.study import Study
 
 
-def pytest_collection_modifyitems(session, config, items):
-    """Add a group identifier to each test item, based on which database is used by the test.
+def pytest_collection_modifyitems(session, config, items):  # pragma: no cover
+    """If running with pytest-xdist, add a group identifier to each test item, based on
+    which database is used by the test.
 
     This lets us use pytest-xdist to distribute tests across three processes leading to
     a moderate speed-up, via `pytest --dist loadgroup -n 3`.
@@ -37,6 +38,12 @@ def pytest_collection_modifyitems(session, config, items):
     during test collection.  Later, pytest-xdist will use the group identifier to
     distribute tests to workers.
     """
+
+    if "PYTEST_XDIST_WORKER" not in os.environ:
+        # Modifying test item identifiers makes it harder to copy and paste identifiers
+        # from failing outputs, so it only makes sense to do so if we're running tests
+        # with pytest-xdist.
+        return
 
     slow_database_names = ["mssql", "spark"]
 

--- a/tests/unit/test_query_language.py
+++ b/tests/unit/test_query_language.py
@@ -386,8 +386,7 @@ def test_incompatible_duration_operations(lhs, op, rhs):
         assert not result
 
 
-@pytest.mark.parametrize(
-    "fn_name",
+fn_names = sorted(
     (
         {k for k, v in DateFunctions.__dict__.items() if callable(v)}
         | {
@@ -406,6 +405,9 @@ def test_incompatible_duration_operations(lhs, op, rhs):
         "__rsub__",
     },
 )
+
+
+@pytest.mark.parametrize("fn_name", fn_names)
 def test_ehrql_date_string_equivalence(fn_name):
     @table
     class p(PatientFrame):


### PR DESCRIPTION
This PR adds support for running tests in parallel using pytest-xdist, with tests against each slow database (mssql and spark) running in a different process.

The default user experience is unchanged, but you can now add `-n3` (or `-k 'not spark' -n2`) to run tests in parallel.

This leads to a moderate speed-up locally.  For me, non-spark tests can now run as quickly as 33s (down from 47s).  The full test suite can run as quickly as 197s (down from 230s).

I tried to enable it in CI but it didn't work because of a race condition in creating the mssql docker container.  (In any case it is not expected to lead to a significant speed-up, since CI runs also spend ~1m setting up the environment.)

Addresses #862.