### PR TITLE
Use `opensafely-core/setup-action`

### DIFF
--- a/.github/workflows/databricks.yml
+++ b/.github/workflows/databricks.yml
@@ -15,14 +15,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: "actions/setup-python@v4"
+      - uses: opensafely-core/setup-action@v1
         with:
+          install-just: true
           python-version: "3.9"
-      - name: Install just
-        run: |
-          mkdir -p ~/.local/bin
-          curl -L https://github.com/casey/just/releases/download/1.9.0/just-1.9.0-x86_64-unknown-linux-musl.tar.gz \
-           | tar -xzf - --directory ~/.local/bin just
       - name: Login to databricks
         run: |
             echo -e \

--- a/.github/workflows/generative-tests.yml
+++ b/.github/workflows/generative-tests.yml
@@ -12,12 +12,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: "actions/setup-python@v4"
+      - uses: opensafely-core/setup-action@v1
         with:
+          install-just: true
           python-version: "3.9"
-      - name: Install just
-        run: |
-          mkdir -p ~/.local/bin
-          curl -L https://github.com/casey/just/releases/download/1.9.0/just-1.9.0-x86_64-unknown-linux-musl.tar.gz \
-           | tar -xzf - --directory ~/.local/bin just
       - run: GENTEST_EXAMPLES=40000 GENTEST_COMPREHENSIVE=t GENTEST_DEBUG=t just test-generative

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,14 +13,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: "actions/setup-python@v4"
+      - uses: opensafely-core/setup-action@v1
         with:
+          install-just: true
           python-version: "3.9"
-      - name: Install just
-        run: |
-          mkdir -p ~/.local/bin
-          curl -L https://github.com/casey/just/releases/download/1.9.0/just-1.9.0-x86_64-unknown-linux-musl.tar.gz \
-           | tar -xzf - --directory ~/.local/bin just
       - name: Check formatting, linting and import sorting
         run: just check
 
@@ -29,14 +25,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: "actions/setup-python@v4"
+      - uses: opensafely-core/setup-action@v1
         with:
+          install-just: true
           python-version: "3.9"
-      - name: Install just
-        run: |
-          mkdir -p ~/.local/bin
-          curl -L https://github.com/casey/just/releases/download/1.9.0/just-1.9.0-x86_64-unknown-linux-musl.tar.gz \
-           | tar -xzf - --directory ~/.local/bin just
       - name: Run tests
         env:
           CI: 1
@@ -81,7 +73,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - uses: actions/setup-python@v4
+    - uses: opensafely-core/setup-action@v1
       with:
         python-version: "3.9"
     - name: Install package

--- a/.github/workflows/update-public-docs.yml
+++ b/.github/workflows/update-public-docs.yml
@@ -20,14 +20,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: "actions/setup-python@v4"
+      - uses: opensafely-core/setup-action@v1
         with:
+          install-just: true
           python-version: "3.9"
-      - name: Install just
-        run: |
-          mkdir -p ~/.local/bin
-          curl -L https://github.com/casey/just/releases/download/1.9.0/just-1.9.0-x86_64-unknown-linux-musl.tar.gz \
-           | tar -xzf - --directory ~/.local/bin just
 
       - name: Generate new public docs file
         run: just generate-docs new_public_docs.json


### PR DESCRIPTION
We switched from the problematic `setup-just` action to some inline bash here: 4b4ad9a6fd8e0092ca2c518f6aa7cd8e3196bf58

But copy/pasting this bash around isn't great either, and Lucy has packaged this up in an action here:
https://github.com/opensafely-core/setup-action