### PR TITLE
Handle errors in generative tests where test input creates out-of-range dates

### DIFF
--- a/databuilder/utils/date_utils.py
+++ b/databuilder/utils/date_utils.py
@@ -38,8 +38,9 @@ def date_add_days(date, num_days):
     return date + datetime.timedelta(days=num_days)
 
 
-def valid_year(year):
-    return 0 < year <= 9999
+def assert_valid_year(year):
+    if not 0 < year <= 9999:
+        raise ValueError(f"year {year} is out of range")
 
 
 def date_add_months(date, num_months):
@@ -48,36 +49,33 @@ def date_add_months(date, num_months):
     new_zero_indexed_month = zero_indexed_month + num_months
     new_month = 1 + new_zero_indexed_month % 12
     new_year = date.year + new_zero_indexed_month // 12
+    assert_valid_year(new_year)
     try:
         return datetime.date(new_year, new_month, date.day)
     except ValueError:
-        # We should only ever get an error for:
-        # 1) An out-of-range year, if new_year results in a value < 1 or > 9999 OR
-        # 2) A new month which has no corresponding day; in this case we roll forward to the
-        #    first of the next month. For a defence of this logic see:
-        #    tests/spec/date_series/ops/test_date_series_ops.py::test_add_months
+        # We should only ever get an error for a new month which has no corresponding day;
+        # in this case we roll forward to the first of the next month.
+        # For a defence of this logic see:
+        # tests/spec/date_series/ops/test_date_series_ops.py::test_add_months
 
         # As no month has more days than December we'll never need to roll forward from
         # December and so we don't need to worry about wrapping round to the next year
         assert new_month != 12
-        if valid_year(new_year):
-            return datetime.date(new_year, new_month + 1, 1)
-        raise
+        return datetime.date(new_year, new_month + 1, 1)
 
 
 def date_add_years(date, num_years):
     new_year = date.year + num_years
+    assert_valid_year(new_year)
     try:
         return datetime.date(new_year, date.month, date.day)
     except ValueError:
-        # We should only ever get an error for:
-        # 1) An out-of-range year, if new_year results in a value < 1 or > 9999 OR
-        # 2) 29 Feb on non-leap years, which we want to roll forward to 1 Mar.
-        #    For a defence of this logic see:
-        #    tests/spec/date_series/ops/test_date_series_ops.py::test_add_years
-        if date.month == 2 and date.day == 29 and valid_year(new_year):
-            return datetime.date(date.year + num_years, 3, 1)
-        raise
+        # We should only ever get an error for 29 Feb on non-leap years, which we want to roll
+        # forward to 1 Mar.
+        # For a defence of this logic see:
+        # tests/spec/date_series/ops/test_date_series_ops.py::test_add_years
+        assert date.month == 2 and date.day == 29
+        return datetime.date(date.year + num_years, 3, 1)
 
 
 def to_first_of_year(date):

--- a/databuilder/utils/date_utils.py
+++ b/databuilder/utils/date_utils.py
@@ -38,6 +38,10 @@ def date_add_days(date, num_days):
     return date + datetime.timedelta(days=num_days)
 
 
+def valid_year(year):
+    return 0 < year <= 9999
+
+
 def date_add_months(date, num_months):
     # Dear me, calendars really are terrible aren't they?
     zero_indexed_month = date.month - 1
@@ -47,25 +51,33 @@ def date_add_months(date, num_months):
     try:
         return datetime.date(new_year, new_month, date.day)
     except ValueError:
-        # Where the month we end up has no corresponding day we roll forward to the
-        # first of the next month. For a defence of this logic see:
-        # tests/spec/date_series/ops/test_date_series_ops.py::test_add_months
+        # We should only ever get an error for:
+        # 1) An out-of-range year, if new_year results in a value < 1 or > 9999 OR
+        # 2) A new month which has no corresponding day; in this case we roll forward to the
+        #    first of the next month. For a defence of this logic see:
+        #    tests/spec/date_series/ops/test_date_series_ops.py::test_add_months
 
         # As no month has more days than December we'll never need to roll forward from
         # December and so we don't need to worry about wrapping round to the next year
         assert new_month != 12
-        return datetime.date(new_year, new_month + 1, 1)
+        if valid_year(new_year):
+            return datetime.date(new_year, new_month + 1, 1)
+        raise
 
 
 def date_add_years(date, num_years):
+    new_year = date.year + num_years
     try:
-        return datetime.date(date.year + num_years, date.month, date.day)
+        return datetime.date(new_year, date.month, date.day)
     except ValueError:
-        # We should only ever get an error for 29 Feb on non-leap years, which we want
-        # to roll forward to 1 Mar. For a defence of this logic see:
-        # tests/spec/date_series/ops/test_date_series_ops.py::test_add_years
-        assert date.month == 2 and date.day == 29
-        return datetime.date(date.year + num_years, 3, 1)
+        # We should only ever get an error for:
+        # 1) An out-of-range year, if new_year results in a value < 1 or > 9999 OR
+        # 2) 29 Feb on non-leap years, which we want to roll forward to 1 Mar.
+        #    For a defence of this logic see:
+        #    tests/spec/date_series/ops/test_date_series_ops.py::test_add_years
+        if date.month == 2 and date.day == 29 and valid_year(new_year):
+            return datetime.date(date.year + num_years, 3, 1)
+        raise
 
 
 def to_first_of_year(date):

--- a/tests/generative/test_query_model.py
+++ b/tests/generative/test_query_model.py
@@ -167,12 +167,19 @@ def run_test(query_engines, data, variable, recorder):
 
 
 def run_error_test(query_engines, data, variable):
+    """
+    Runs a test with input that is expected to raise an error in some way which is
+    expected to be handled. If an exception is raised and handled within the test
+    function, the result will be an `IGNORE_RESULT` object.  If the bad input is
+    handled within the query engine itself, the result will contain a None value.
+    e.g. attempting to add 8000 years to 2000-01-01 results in a date that is outside
+    of the valid range (max 9999-12-31).  The sqlite engine returns None for this,
+    all other engines raise an Exception that we catch and ignore.
+    """
     instances, variables = setup_test(data, variable)
-    for name, engine in query_engines.items():
-        try:
-            run_with(engine, instances, variables)
-        except Exception as e:  # pragma: no cover
-            assert False, f"{name} engine encountered an error: {e}"
+    for _, engine in query_engines.items():
+        result = run_with(engine, instances, variables)
+        assert result in [IGNORE_RESULT, [{"patient_id": 1, "v": None}]]
 
 
 IGNORED_ERRORS = [


### PR DESCRIPTION
On occasion the generative tests create very large integers, e.g. as the result of a multiplication operations, or from a DateDifferenceInDays, which can result in date operations that attempt to return an out-of-range date (with year <=0 or >9999).

Fixes #916 

