### PR TITLE
Add `test-all-no-spark` command

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -60,11 +60,11 @@ For example:
 just test tests/integration/backends/test_tpp.py
 ```
 
-Since we have many tests that are parameterized across multiple databases and the Spark database tests are very slow, test commands which run such parameterized tests have a variant that skips the Spark tests.
-These are much faster and should be used unless you're specifically working on Spark.
-For example:
+Since the Spark tests are currently very slow we have variants of these test commands which exclude them (by adding a `-k 'not spark` pytest argument).
+Unless you are specifically working on Spark you should be using these variants.
+In particular you can run the full CI tests, including the coverage and documentation checks, but without the Spark tests using:
 ```
-just test-spec-no-spark
+just test-all-no-spark
 ```
 
 There are further notes on using `pytest` in the wiki here:

--- a/Justfile
+++ b/Justfile
@@ -201,7 +201,6 @@ test-generative *ARGS: devenv
         --cov-report=html \
         --cov-report=term-missing:skip-covered \
         --hypothesis-seed=1234 \
-        tests \
         {{ ARGS }}
     $BIN/python -m pytest --doctest-modules databuilder
     [[ -v CI ]]  && echo "::endgroup::" || echo ""

--- a/Justfile
+++ b/Justfile
@@ -205,6 +205,9 @@ test-generative *ARGS: devenv
     $BIN/python -m pytest --doctest-modules databuilder
     [[ -v CI ]]  && echo "::endgroup::" || echo ""
 
+# Run the CI tests (including coverage checks) but without the slow Spark tests
+test-all-no-spark *ARGS: (test-all '-k "not spark"' ARGS)
+
 # run scripts/dbx
 dbx *ARGS:
     @$BIN/python scripts/dbx {{ ARGS }}

--- a/Justfile
+++ b/Justfile
@@ -189,7 +189,8 @@ test-generative *ARGS: devenv
     $BIN/python -m pytest tests/generative {{ ARGS }}
 
 # Run by CI. Run all tests, checking code coverage. Optional args are passed to pytest.
-test-all *ARGS: devenv generate-docs
+# (The `@` prefix means that the script is echoed first for debugging purposes.)
+@test-all *ARGS: devenv generate-docs
     #!/usr/bin/env bash
     set -euo pipefail
 

--- a/databuilder/query_engines/base_sql.py
+++ b/databuilder/query_engines/base_sql.py
@@ -533,7 +533,9 @@ class BaseSQLQueryEngine(BaseQueryEngine):
         results_query = self.get_query(variable_definitions)
         setup_queries, cleanup_queries = get_setup_and_cleanup_queries(results_query)
         with self.engine.connect() as connection:
-            for n, setup_query in enumerate(setup_queries, start=1):
+            for n, setup_query in enumerate(
+                setup_queries, start=1
+            ):  # pragma: cover-spark-only
                 log.info(f"Running setup query {n:03} / {len(setup_queries):03}")
                 connection.execute(setup_query)
 

--- a/databuilder/query_engines/spark.py
+++ b/databuilder/query_engines/spark.py
@@ -7,7 +7,7 @@ from databuilder.query_engines.spark_dialect import CreateTemporaryViewAs, Spark
 from databuilder.utils.sqlalchemy_query_utils import GeneratedTable
 
 
-class SparkQueryEngine(BaseSQLQueryEngine):
+class SparkQueryEngine(BaseSQLQueryEngine):  # pragma: cover-spark-only
     sqlalchemy_dialect = SparkDialect
 
     def date_difference_in_days(self, end, start):

--- a/databuilder/query_engines/spark_dialect.py
+++ b/databuilder/query_engines/spark_dialect.py
@@ -18,7 +18,7 @@ from sqlalchemy.sql.compiler import DDLCompiler, IdentifierPreparer
 from sqlalchemy.sql.expression import ClauseElement, Executable, cast
 
 
-class CreateTemporaryViewAs(Executable, ClauseElement):
+class CreateTemporaryViewAs(Executable, ClauseElement):  # pragma: cover-spark-only
     inherit_cache = True
 
     def __init__(self, table, query):
@@ -30,14 +30,14 @@ class CreateTemporaryViewAs(Executable, ClauseElement):
 
 
 @compiles(CreateTemporaryViewAs)
-def visit_create_temporary_view_as(element, compiler, **kw):
+def visit_create_temporary_view_as(element, compiler, **kw):  # pragma: cover-spark-only
     return "CREATE TEMPORARY VIEW {} AS {}".format(
         compiler.process(element.table, asfrom=True, **kw),
         compiler.process(element.query, **kw),
     )
 
 
-class SparkDate(sqlalchemy.types.TypeDecorator):
+class SparkDate(sqlalchemy.types.TypeDecorator):  # pragma: cover-spark-only
     cache_ok = True
     impl = sqlalchemy.types.Date
     text_type = sqlalchemy.types.Text()
@@ -76,7 +76,7 @@ class SparkDate(sqlalchemy.types.TypeDecorator):
         return literal_processor(value_str)
 
 
-class SparkDateTime(sqlalchemy.types.TypeDecorator):
+class SparkDateTime(sqlalchemy.types.TypeDecorator):  # pragma: cover-spark-only
     cache_ok = True
     impl = sqlalchemy.types.DateTime
 
@@ -90,7 +90,7 @@ class SparkDateTime(sqlalchemy.types.TypeDecorator):
         return cast(bindvalue, type_=self)
 
 
-class SparkDDLCompiler(DDLCompiler):
+class SparkDDLCompiler(DDLCompiler):  # pragma: cover-spark-only
     def visit_primary_key_constraint(self, constraint, **kw):
         """
         Prevent SQLAlchemy from trying to create PRIMARY KEY constraints, which
@@ -106,7 +106,7 @@ class SparkDDLCompiler(DDLCompiler):
         return ""
 
 
-class SparkTypeCompiler(HiveTypeCompiler):
+class SparkTypeCompiler(HiveTypeCompiler):  # pragma: cover-spark-only
     def visit_DATE(self, type_):
         """
         For some reason pyhive treats DATE as TIMESTAMP, as it does for
@@ -118,7 +118,7 @@ class SparkTypeCompiler(HiveTypeCompiler):
         return "DATE"
 
 
-class SparkIdentifierPreparer(IdentifierPreparer):
+class SparkIdentifierPreparer(IdentifierPreparer):  # pragma: cover-spark-only
     """
     pyhive quotes all identifiers, whether they're reserved words or not. This
     makes some already tricky to read SQL even harder to read, so we just use
@@ -132,7 +132,7 @@ class SparkIdentifierPreparer(IdentifierPreparer):
         super().__init__(dialect, initial_quote="`", escape_quote="`")
 
 
-class SparkDialect(HiveHTTPDialect):
+class SparkDialect(HiveHTTPDialect):  # pragma: cover-spark-only
     """Customisation of the base pyhive Sqlalchemy dialect.
 
     Some customisations are generic Spark SQL fixes that we want to handle
@@ -272,7 +272,7 @@ class SparkDialect(HiveHTTPDialect):
         return result
 
 
-class ConnectionWrapper:
+class ConnectionWrapper:  # pragma: cover-spark-only
     """
     When running in "future" mode SQLAlchemy connections will no longer execute
     raw SQL strings. Instead these must be explictly wrapped up as "text" query

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,9 @@ Source = "https://github.com/opensafely-core/databuilder"
 
 [tool.coverage.run]
 branch = true
+plugins = [
+    "coverage_conditional_plugin",
+]
 
 [tool.coverage.report]
 fail_under = 100
@@ -58,6 +61,10 @@ exclude_lines = [
 omit = [
     "databuilder/docs/__main__.py",
 ]
+
+[tool.coverage.coverage_conditional_plugin.rules]
+# We disable Spark coverage if we spot "not spark" in the pytest arguments
+cover-spark-only = "'not spark' in sys.argv"
 
 [tool.coverage.html]
 

--- a/requirements.dev.in
+++ b/requirements.dev.in
@@ -5,6 +5,7 @@
 # pip-compile --generate-hashes --output-file=requirements.dev.txt requirements.dev.in
 
 black
+coverage-conditional-plugin
 databricks-cli
 docker
 flake8

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -96,7 +96,13 @@ coverage[toml]==6.4.1 \
     --hash=sha256:fd180ed867e289964404051a958f7cccabdeed423f91a899829264bb7974d3d3 \
     --hash=sha256:fdb6f7bd51c2d1714cea40718f6149ad9be6a2ee7d93b19e9f00934c0f2a74d9 \
     --hash=sha256:ffa9297c3a453fba4717d06df579af42ab9a28022444cae7fa605af4df612d54
-    # via pytest-cov
+    # via
+    #   coverage-conditional-plugin
+    #   pytest-cov
+coverage-conditional-plugin==0.8.0 \
+    --hash=sha256:421079fbf9676c48397dd14254746e5e2656280b87ef83835701dd233053b9cd \
+    --hash=sha256:e6564944a32ccc962f8c0000ac618efa5f5ff232cb9bcc677ce98546dfa61e6d
+    # via -r requirements.dev.in
 databricks-cli==0.17.4 \
     --hash=sha256:bbd57bc21c88ac6d1f8f0b250db986e500490c4d3cb69664229384632eaeed81 \
     --hash=sha256:bc0c4dd082f033cb6d7978cacaca5261698efe3a4c70f52f98762c38db925ce0
@@ -154,6 +160,10 @@ idna==3.3 \
     --hash=sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff \
     --hash=sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d
     # via requests
+importlib-metadata==6.0.0 \
+    --hash=sha256:7efb448ec9a5e313a57655d35aa54cd3e01b7e1fbcf72dce1bf06119420f5bad \
+    --hash=sha256:e354bedeb60efa6affdcc8ae121b73544a7aa74156d047311948f6d711cd378d
+    # via coverage-conditional-plugin
 iniconfig==1.1.1 \
     --hash=sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3 \
     --hash=sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32
@@ -191,6 +201,7 @@ packaging==21.3 \
     --hash=sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522
     # via
     #   build
+    #   coverage-conditional-plugin
     #   docker
     #   pytest
 pathspec==0.9.0 \
@@ -374,6 +385,10 @@ wheel==0.37.1 \
     --hash=sha256:4bdcd7d840138086126cd09254dc6195fb4fc6f01c050a1d7236f2630db1d22a \
     --hash=sha256:e9a504e793efbca1b8e0e9cb979a249cf4a0a7b5b8c9e8b65a5e39d49529c1c4
     # via pip-tools
+zipp==3.11.0 \
+    --hash=sha256:83a28fcb75844b5c0cdaf5aa4003c2d728c77e05f5aeabe8e95e56727005fbaa \
+    --hash=sha256:a7a22e05929290a67401440b39690ae6563279bced5f314609d9d03798f56766
+    # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 pip==22.1.2 \

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -87,10 +87,10 @@ def show_delayed_warning(request):
     already taken more than N seconds.
     """
 
-    def show_warning(message):
+    def show_warning(message):  # pragma: no cover
         capturemanager = request.config.pluginmanager.getplugin("capturemanager")
         # No need to display anything if output is not being captured
-        if capturemanager.is_capturing():  # pragma: no branch
+        if capturemanager.is_capturing():
             with capturemanager.global_and_fixture_disabled():
                 print(f"\n => {message} ...")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -149,7 +149,9 @@ def mssql_database(mssql_database_with_session_scope):
 
 
 @pytest.fixture(scope="session")
-def spark_database_with_session_scope(containers, show_delayed_warning):
+def spark_database_with_session_scope(
+    containers, show_delayed_warning
+):  # pragma: cover-spark-only
     with show_delayed_warning(3, "Downloading and starting Spark Docker image"):
         database = make_spark_database(containers)
         wait_for_database(database, timeout=20)
@@ -157,7 +159,7 @@ def spark_database_with_session_scope(containers, show_delayed_warning):
 
 
 @pytest.fixture(scope="function")
-def spark_database(spark_database_with_session_scope):
+def spark_database(spark_database_with_session_scope):  # pragma: cover-spark-only
     database = spark_database_with_session_scope
     yield database
     database.teardown()
@@ -216,7 +218,7 @@ def engine_factory(request, engine_name, with_session_scope=False):
     elif engine_name == "mssql":
         database_fixture_name = "mssql_database"
         query_engine_class = MSSQLQueryEngine
-    elif engine_name == "spark":
+    elif engine_name == "spark":  # pragma: cover-spark-only
         database_fixture_name = "spark_database"
         query_engine_class = SparkQueryEngine
     else:

--- a/tests/lib/databases.py
+++ b/tests/lib/databases.py
@@ -100,7 +100,7 @@ class DbDetails:
         metadata.create_all(engine)
         session.bulk_save_objects(input_data)
 
-        if self.temp_db is not None:
+        if self.temp_db is not None:  # pragma: cover-spark-only
             session.execute(
                 sqlalchemy.text(f"CREATE DATABASE IF NOT EXISTS {self.temp_db}")
             )
@@ -179,14 +179,14 @@ def run_mssql(container_name, containers, password, mssql_port):  # pragma: no c
     )
 
 
-def make_spark_database(containers):
+def make_spark_database(containers):  # pragma: cover-spark-only
     if "DATABRICKS_URL" in os.environ:  # pragma: no cover
         return make_databricks_database()
     else:
         return make_spark_container_database(containers)
 
 
-def make_spark_container_database(containers):
+def make_spark_container_database(containers):  # pragma: cover-spark-only
     container_name = "databuilder-spark"
     # This is the default anyway, but better to be explicit
     spark_port = 10001

--- a/tests/unit/query_engines/test_spark_dialect.py
+++ b/tests/unit/query_engines/test_spark_dialect.py
@@ -4,7 +4,7 @@ from sqlalchemy.sql.visitors import iterate
 from databuilder.query_engines.spark_dialect import CreateTemporaryViewAs
 
 
-def test_create_temporary_view_as():
+def test_create_temporary_view_as():  # pragma: cover-spark-only
     table = sqlalchemy.table("foo", sqlalchemy.Column("bar"))
     query = sqlalchemy.select(table.c.bar).where(table.c.bar > 1)
     target_table = sqlalchemy.table("test")
@@ -16,7 +16,7 @@ def test_create_temporary_view_as():
     )
 
 
-def test_create_temporary_view_as_can_be_iterated():
+def test_create_temporary_view_as_can_be_iterated():  # pragma: cover-spark-only
     # If we don't define the `get_children()` method on `CreateTemporaryViewAs` we won't
     # get an error when attempting to iterate the resulting element structure: it will
     # just act as a leaf node. But as we rely heavily on query introspection we need to


### PR DESCRIPTION
This adds a new command:

    just test-all-no-spark

Which runs the CI tests, including the coverage checks, but with a `-k 'not spark'` selector to skip the very slow Spark tests.

Obviously this means that Spark-related code doesn't get covered, so we introduce a new pragma `cover-spark-only` to mark lines which we only expect to be covered when the Spark tests are run. We use the [conditional-coverage](https://github.com/wemake-services/coverage-conditional-plugin) plugin to toggle the behaviour of this pragma appropriately.