### PR TITLE
feat: Add TPP appointments table

### DIFF
--- a/databuilder/backends/tpp.py
+++ b/databuilder/backends/tpp.py
@@ -192,3 +192,13 @@ class TPPBackend(BaseBackend):
             ON apcs.APCS_Ident = der.APCS_Ident
         """
     )
+
+    appointments = QueryTable(
+        """
+            SELECT
+                Patient_ID AS patient_id,
+                CAST(BookedDate AS date) AS booked_date,
+                CAST(StartDate AS date) AS start_date
+            FROM Appointment
+        """
+    )

--- a/databuilder/tables/beta/tpp.py
+++ b/databuilder/tables/beta/tpp.py
@@ -16,6 +16,7 @@ __all__ = [
     "occupation_on_covid_vaccine_record",
     "emergency_care_attendances",
     "hospital_admissions",
+    "appointments",
 ]
 
 
@@ -143,3 +144,9 @@ class hospital_admissions(EventFrame):
     all_diagnoses = Series(str)
     patient_classification = Series(str)
     days_in_critical_care = Series(int)
+
+
+@table
+class appointments(EventFrame):
+    booked_date = Series(datetime.date)
+    start_date = Series(datetime.date)

--- a/tests/integration/backends/test_tpp.py
+++ b/tests/integration/backends/test_tpp.py
@@ -10,6 +10,7 @@ from tests.lib.tpp_schema import (
     APCS,
     EC,
     APCS_Der,
+    Appointment,
     CodedEvent,
     CodedEventSnomed,
     EC_Diagnosis,
@@ -424,6 +425,25 @@ def test_hospital_admissions(select_all):
             "patient_classification": "X",
             "days_in_critical_care": 5,
         }
+    ]
+
+
+@register_test_for(tpp.appointments)
+def test_appointments(select_all):
+    results = select_all(
+        Patient(Patient_ID=1),
+        Appointment(
+            Patient_ID=1,
+            BookedDate="2021-01-01T09:00:00",
+            StartDate="2021-01-01T09:00:00",
+        ),
+    )
+    assert results == [
+        {
+            "patient_id": 1,
+            "booked_date": date(2021, 1, 1),
+            "start_date": date(2021, 1, 1),
+        },
     ]
 
 

--- a/tests/lib/tpp_schema.py
+++ b/tests/lib/tpp_schema.py
@@ -136,6 +136,8 @@ class Appointment(Base):
     # The real table has various other datetime columns but we don't currently
     # use them
     SeenDate = Column(DateTime)
+    BookedDate = Column(DateTime)
+    StartDate = Column(DateTime)
     # Status = Column(IntEnum(AppointmentStatus))
 
 


### PR DESCRIPTION
This adds just enough of the TPP appointments table for the [Winter Pressures study][1] and allows us to remove the placeholder table from that study.

[1]: https://github.com/opensafely/winter-pressures