### PR TITLE
Speed up gentest by inverting query generation logic

### DIFF
--- a/tests/generative/data_strategies.py
+++ b/tests/generative/data_strategies.py
@@ -1,5 +1,3 @@
-from datetime import date
-
 import hypothesis as hyp
 import hypothesis.strategies as st
 
@@ -12,20 +10,12 @@ max_num_patient_records = max_patient_id  # <= max_patient_id, hasn't been fine-
 max_num_event_records = max_patient_id  # could be anything, hasn't been fine-tuned
 
 
-def record(
-    class_, id_strategy, schema, int_values, bool_values, date_values, float_values
-):
+def record(class_, id_strategy, schema, value_strategies):
     # We don't construct the actual objects here because it's easier to extract stats for the generated data if we
     # pass around simple objects.
     columns = {patient_id_column: id_strategy}
     for name, type_ in schema.column_types:
-        type_strategy = {
-            int: int_values,
-            bool: bool_values,
-            date: date_values,
-            float: float_values,
-        }[type_]
-        columns[name] = type_strategy
+        columns[name] = value_strategies[type_]
 
     return st.builds(dict, type=st.just(class_), **columns)
 
@@ -42,26 +32,16 @@ def concat(draw, *list_strategies):
 patient_ids = st.integers(min_value=1, max_value=max_patient_id)
 
 
-def event_records(class_, schema, int_values, bool_values, date_values, float_values):
+def event_records(class_, schema, value_strategies):
     return st.lists(
-        record(
-            class_,
-            patient_ids,
-            schema,
-            int_values,
-            bool_values,
-            date_values,
-            float_values,
-        ),
+        record(class_, patient_ids, schema, value_strategies),
         min_size=0,
         max_size=max_num_event_records,
     )
 
 
 @st.composite
-def patient_records(
-    draw, class_, schema, int_values, bool_values, date_values, float_values
-):
+def patient_records(draw, class_, schema, value_strategies):
     # This strategy ensures that the patient ids are unique. We need to maintain the state to ensure that uniqueness
     # inside the strategy itself so that we can ensure the tests are idempotent as Hypothesis requires. That means that
     # this strategy must be called once only for a given table in a given test.
@@ -72,41 +52,15 @@ def patient_records(
         id_ = draw_(patient_ids)
         hyp.assume(id_ not in used_ids)
         used_ids.append(id_)
-        return draw(
-            record(
-                class_,
-                st.just(id_),
-                schema,
-                int_values,
-                bool_values,
-                date_values,
-                float_values,
-            )
-        )
+        return draw(record(class_, st.just(id_), schema, value_strategies))
 
     return draw(
         st.lists(one_patient_record(), min_size=0, max_size=max_num_patient_records)
     )
 
 
-def data(
-    patient_classes,
-    event_classes,
-    schema,
-    int_values,
-    bool_values,
-    date_values,
-    float_values,
-):
+def data(patient_classes, event_classes, schema, value_strategies):
     return concat(
-        *[
-            patient_records(
-                c, schema, int_values, bool_values, date_values, float_values
-            )
-            for c in patient_classes
-        ],
-        *[
-            event_records(c, schema, int_values, bool_values, date_values, float_values)
-            for c in event_classes
-        ]
+        *[patient_records(c, schema, value_strategies) for c in patient_classes],
+        *[event_records(c, schema, value_strategies) for c in event_classes]
     )

--- a/tests/generative/recording.py
+++ b/tests/generative/recording.py
@@ -1,6 +1,5 @@
 import contextlib
 import os
-import pprint
 from collections import defaultdict
 
 import pytest
@@ -93,11 +92,6 @@ def show_variables_summary(recorder):  # pragma: no cover
     print("\nwith this node count distribution")
     for count, num in histogram(counts):
         print(f"{count:3}\t{num}")
-
-    if recorder.variables:
-        print("\nlargest query")
-        by_size = sorted(recorder.variables, key=lambda v: count_nodes(v))
-        pprint.pprint(by_size[-1])
 
     all_node_types = [
         type_.__name__

--- a/tests/generative/recording.py
+++ b/tests/generative/recording.py
@@ -89,6 +89,7 @@ def show_variables_summary(recorder):  # pragma: no cover
     print(f"\n{len(recorder.variables)} unique queries")
 
     counts = [count_nodes(example) for example in recorder.variables]
+    print(f"\nwith a total of {sum(counts)} nodes")
     print("\nwith this node count distribution")
     for count, num in histogram(counts):
         print(f"{count:3}\t{num}")

--- a/tests/generative/test_data_setup.py
+++ b/tests/generative/test_data_setup.py
@@ -12,9 +12,9 @@ def test_data_strategy_examples_round_trip(example):
     """
     Examples produced by `data_strategy` contain references to classes dynamically
     generated in `data_setup` and we need to do some underhand stuff to make sure they
-    can be copy/pasted back into `@hypothesis.example()` and evalate correctly.
+    can be copy/pasted back into `@hypothesis.example()` and evaluate correctly.
 
-    We've broken this propery once without realising so this test ensures we don't do so
+    We've broken this properly once without realising so this test ensures we don't do so
     again.
     """
     hyp.assume(len(example) > 0)

--- a/tests/generative/test_query_model.py
+++ b/tests/generative/test_query_model.py
@@ -15,8 +15,6 @@ from databuilder.query_model.nodes import (
     SelectPatientTable,
     TableSchema,
     Value,
-    count_nodes,
-    node_types,
 )
 
 from ..conftest import QUERY_ENGINE_NAMES, engine_factory
@@ -87,7 +85,6 @@ def query_engines(request):
 @hyp.settings(**settings)
 def test_query_model(query_engines, variable, data, recorder):
     recorder.record_inputs(variable, data)
-    tune_inputs(variable)
     run_test(query_engines, data, variable, recorder)
 
 
@@ -118,12 +115,6 @@ def test_handle_date_errors(query_engines, operation, rhs, recorder):
         rhs=Value(rhs),
     )
     run_error_test(query_engines, data, variable)
-
-
-def tune_inputs(variable):
-    # Encourage Hypothesis to maximize the number and type of nodes
-    hyp.target(count_nodes(variable), label="number of nodes")
-    hyp.target(len(node_types(variable)), label="number of node types")
 
 
 def setup_test(data, variable):

--- a/tests/generative/test_query_model.py
+++ b/tests/generative/test_query_model.py
@@ -43,31 +43,26 @@ schema = TableSchema(
 ) = data_setup.setup(schema, num_patient_tables=2, num_event_tables=2)
 
 # Use the same strategies for values both for query generation and data generation.
-int_values = st.integers(min_value=0, max_value=10)
-bool_values = st.booleans()
-date_values = st.dates(
-    min_value=datetime.date(1900, 1, 1), max_value=datetime.date(2100, 12, 31)
-)
-float_values = st.floats(min_value=0.0, max_value=11.0, width=16, allow_infinity=False)
-
+value_strategies = {
+    int: st.integers(min_value=0, max_value=10),
+    bool: st.booleans(),
+    datetime.date: st.dates(
+        min_value=datetime.date(1900, 1, 1), max_value=datetime.date(2100, 12, 31)
+    ),
+    float: st.floats(min_value=0.0, max_value=11.0, width=16, allow_infinity=False),
+}
 
 variable_strategy = variable_strategies.variable(
     [c.__tablename__ for c in patient_classes],
     [c.__tablename__ for c in event_classes],
     schema,
-    int_values,
-    bool_values,
-    date_values,
-    float_values,
+    value_strategies,
 )
 data_strategy = data_strategies.data(
     patient_classes,
     event_classes,
     schema,
-    int_values,
-    bool_values,
-    date_values,
-    float_values,
+    value_strategies,
 )
 settings = dict(
     max_examples=(int(os.environ.get("GENTEST_EXAMPLES", 100))),

--- a/tests/generative/test_query_model.py
+++ b/tests/generative/test_query_model.py
@@ -67,7 +67,6 @@ data_strategy = data_strategies.data(
 settings = dict(
     max_examples=(int(os.environ.get("GENTEST_EXAMPLES", 100))),
     deadline=None,
-    suppress_health_check=[hyp.HealthCheck.filter_too_much, hyp.HealthCheck.too_slow],
 )
 
 

--- a/tests/generative/test_query_model.py
+++ b/tests/generative/test_query_model.py
@@ -185,7 +185,7 @@ IGNORED_ERRORS = [
         re.compile(".+Case expressions may only be nested to level 10.+"),
     ),
     # OUT-OF-RANGE DATES
-    # The variable strategy will sometimes result in date operations that contruct
+    # The variable strategy will sometimes result in date operations that construct
     # invalid dates (e.g. a large positive or negative integer in a DateAddYears operation
     # may result in a date with a year that is outside of the allowed range)
     # The different query engines report errors from out-of-range dates in different ways:

--- a/tests/generative/variable_strategies.py
+++ b/tests/generative/variable_strategies.py
@@ -1,3 +1,5 @@
+import datetime
+
 import hypothesis.errors
 import hypothesis.strategies as st
 
@@ -63,15 +65,7 @@ from tests.lib.query_model_utils import get_all_operations
 #   `unknown_dimension_date_series`)
 
 
-def variable(
-    patient_tables,
-    event_tables,
-    schema,
-    int_values,
-    bool_values,
-    date_values,
-    float_values,
-):
+def variable(patient_tables, event_tables, schema, value_strategies):
     frame = st.deferred(
         lambda: st.one_of(
             one_row_per_patient_frame,
@@ -193,10 +187,8 @@ def variable(
 
     sorted_frame = st.deferred(lambda: st.one_of(sort))
 
-    value = qm_builds(
-        Value, st.one_of(int_values, bool_values, date_values, float_values)
-    )
-    date_value = qm_builds(Value, st.one_of(date_values))
+    value = qm_builds(Value, st.one_of(value_strategies.values()))
+    date_value = qm_builds(Value, st.one_of(value_strategies[datetime.date]))
 
     select_table = qm_builds(
         SelectTable,

--- a/tests/generative/variable_strategies.py
+++ b/tests/generative/variable_strategies.py
@@ -1,6 +1,5 @@
 import datetime
 
-import hypothesis.errors
 import hypothesis.strategies as st
 
 from databuilder.query_model.nodes import (
@@ -9,305 +8,209 @@ from databuilder.query_model.nodes import (
     Filter,
     Function,
     PickOneRowPerPatient,
-    Position,
     SelectColumn,
     SelectPatientTable,
     SelectTable,
     Sort,
-    ValidationError,
     Value,
-    has_many_rows_per_patient,
-    has_one_row_per_patient,
     node_types,
 )
 from tests.lib.query_model_utils import get_all_operations
 
-# Here follows a set of recursive strategies for constructing valid query model graphs.
+# This module defines a set of recursive Hypothesis strategies for generating query model graphs.
 #
-# There is a set of strategies corresponding to the abstract types in the query model (for example `frame` or
-# `one_row_per_patient_series`), each of which returns one of the direct subtypes of that type (both abstract and
-# concrete). Another set of strategies corresponds to the concrete types in the query model (for example `filter` or
-# `select_column`), each of which constructs the corresponding node and recursively invokes other strategies to
-# provide the constructor arguments (using the strategy corresponding to the types of the arguments).
+# There are a few points where we deliberate order the types that we choose from, with the
+# "simplest" first (by some subjective measure). This is to enable Hypothesis to more effectively
+# explore the query space and to "shrink" examples when it finds errors. These points are commented
+# below.
 #
-# So each concrete node type appears in two places: in its own strategy and in the strategy of its immediate
-# supertype**. And each abstract type appears in its own strategy, in the strategy of its immediate supertype and in
-# the strategies of any concrete nodes which have a constructor argument of that abstract type.
-#
-# When we invoke the strategy of an abstract type, it tugs at a thread that runs down through the type hierarchy
-# (picking a random subclass at each level) until it reaches a concrete type which can be constructed. (And it then
-# does the same for all of the necessary constructor arguments.)
-#
-# The strategies are ordered in this file in the same order that the corresponding classes are defined in
-# `query_model`, to make it easier to see the correspondence and to spot errors.
-#
-# There are, you will be astonished to learn, a few complications.
-#
-# * In order to help Hypothesis shrink the examples, the subclasses of each abstract type are ordered roughly by
-#   "simplicity", using the number of child nodes as a heuristic. It's hard to follow even that, though, because of
-#   the way the concrete types are grouped. And, partly as a consequence, this strategy doesn't shrink very well.
-# * We need to use `st.deferred` in some places to allow (transitively) mutually recursive strategies. We're using it
-#   in _all_ the abstract type strategies in order to allow us to keep the ordering the same as that of the definitions
-#   in `query_model`.
-# * The query model type hierarchy doesn't give us all the information we need, so the approach outlined above will
-#   generate invalid query model graphs (due either to the domains or the types being incorrect). We handle this by
-#   constructing the query model objects using a special-purpose strategy `qm_builds`, which can discard invalid
-#   instances. There is an unexplored optimization avenue here: make the strategies more specific to include type
-#   and/or domain, so that we don't discard so many examples.
-#
-# **Note that most concrete strategies take a series as an argument, and that series is an abstract `series`
-#   which can be of any type. However, strategies that require a date-type series as one or more arguments, such
-#   as date arithmetic operations, take a `date_series` strategy, which ensures that they only receive a
-#   series of the correct type. This limits the number of rejected examples, and therefore reduces the number of
-#   examples that need to be run in order to cover all nodes in the generative tests.
-#   This does mean that any concrete strategy that takes a date series now needs to appear in three places; its own
-#   strategy, and that of its two immediate supertypes (i.e. `unknown_dimension_series` and
-#   `unknown_dimension_date_series`)
+# We use several Hypothesis combinators for defining our strategies. Most (`one_of`, `just`,
+# `sampled_from`) are fairly self-explanatory. A couple are worth clarifying.
+#     * `st.builds()` is used to construct objects, it takes the class and strategies
+#       corresponding to the constructor arguments.
+#     * `@st.composite` allows us to define a strategy by composing other strategies with
+#       arbitrary Python code; it adds a `draw` argument which is part of the machinery that
+#       enables this composition but which doesn't form part of the signature of the resulting
+#       strategy function.
 
 
 def variable(patient_tables, event_tables, schema, value_strategies):
-    frame = st.deferred(
-        lambda: st.one_of(
-            one_row_per_patient_frame,
-            many_rows_per_patient_frame,
-        )
-    )
+    # Every inner-function here returns a Hypothesis strategy for creating the thing it is named
+    # for, not the thing itself.
+    #
+    # Several of these strategy functions ignore one or more of their arguments in order to make
+    # them uniform with other functions that return the same sort of strategy. Such ignored
+    # arguments are named with a leading underscore.
 
-    series = st.deferred(
-        lambda: st.one_of(
-            unknown_dimension_series,
-            definitely_one_row_patient_series,
-            definitely_many_rows_per_patient_series,
-        )
-    )
+    # Series strategies
+    #
+    # Whenever a series is needed, we call series() passing the type of the series and frame that
+    # it should be built on (these are either constrained by the context in which the series is to
+    # be used or chosen arbitrarily by the caller).
+    #
+    # This strategy then chooses an arbitrary concrete series that respects the constraints imposed
+    # by the passed type and frame.
+    @st.composite
+    def series(draw, type_, frame):
+        class DomainConstraint:
+            PATIENT = (True,)
+            NON_PATIENT = (False,)
+            ANY = (True, False)
 
-    date_series = st.deferred(
-        lambda: st.one_of(
-            unknown_dimension_date_series,
-            definitely_one_row_patient_date_series,
-            definitely_many_rows_per_patient_date_series,
-        )
-    )
+        # Order matters: "simpler" first (see header comment)
+        series_constraints = {
+            value: ({int, float, bool, datetime.date}, DomainConstraint.PATIENT),
+            select_column: ({int, float, bool, datetime.date}, DomainConstraint.ANY),
+            eq: ({bool}, DomainConstraint.ANY),
+            add: ({int, float}, DomainConstraint.ANY),
+            count: ({int}, DomainConstraint.PATIENT),
+        }
+        series_types = series_constraints.keys()
 
-    one_row_per_patient_frame = st.deferred(
-        lambda: st.one_of(
-            select_patient_table,
-            pick_one_row_per_patient,
-        )
-    )
+        def constraints_match(series_type):
+            type_constraint, domain_constraint = series_constraints[series_type]
+            return (
+                type_ in type_constraint
+                and is_one_row_per_patient_frame(frame) in domain_constraint
+            )
 
-    many_rows_per_patient_frame = st.deferred(
-        lambda: st.one_of(
-            select_table,
-            sorted_frame,
-            filter_,
-        )
-    )
+        possible_series = [s for s in series_types if constraints_match(s)]
+        assert possible_series, f"No series matches {type_}, {type(frame)}"
 
-    one_row_per_patient_series = st.deferred(
-        lambda: st.one_of(
-            unknown_dimension_series.filter(has_one_row_per_patient),
-            definitely_one_row_patient_series,
-        )
-    )
+        series_strategy = draw(st.sampled_from(possible_series))
+        return draw(series_strategy(type_, frame))
 
-    definitely_one_row_patient_series = st.deferred(
-        lambda: st.one_of(
-            value,
-            exists,
-            count_,
-            min_,
-            max_,
-            sum_,
-        )
-    )
+    def value(type_, _frame):
+        return st.builds(Value, value_strategies[type_])
 
-    definitely_one_row_patient_date_series = st.deferred(
-        lambda: st.one_of(
-            date_value,
-            min_,
-            max_,
-        )
-    )
-
-    many_rows_per_patient_series = st.deferred(
-        lambda: st.one_of(
-            unknown_dimension_series.filter(has_many_rows_per_patient),
-            definitely_many_rows_per_patient_series,
-        )
-    )
-
-    # We don't currently have any examples of this type, but it's included here for consistency
-    # and to make it clear where it fits in.
-    definitely_many_rows_per_patient_series = st.deferred(lambda: st.one_of())
-    definitely_many_rows_per_patient_date_series = st.deferred(lambda: st.one_of())
-
-    unknown_dimension_series = st.deferred(
-        lambda: st.one_of(
-            select_column,
-            not_,
-            is_null,
-            negate,
-            eq,
-            ne,
-            lt,
-            le,
-            gt,
-            ge,
-            and_,
-            or_,
-            add,
-            subtract,
-            multiply,
-            cast_to_int,
-            cast_to_float,
-            date_add_years,
-            date_add_months,
-            date_add_days,
-            year_from_date,
-            month_from_date,
-            day_from_date,
-            date_difference_in_years,
-            date_difference_in_months,
-            date_difference_in_days,
-            case,
-        )
-    )
-
-    unknown_dimension_date_series = st.deferred(
-        lambda: st.one_of(
-            select_date_column,
-            date_add_years,
-            date_add_months,
-            date_add_days,
-            to_first_of_year,
-            to_first_of_month,
-        )
-    )
-
-    sorted_frame = st.deferred(lambda: st.one_of(sort))
-
-    value = qm_builds(Value, st.one_of(value_strategies.values()))
-    date_value = qm_builds(Value, st.one_of(value_strategies[datetime.date]))
-
-    select_table = qm_builds(
-        SelectTable,
-        st.sampled_from(event_tables),
-        st.just(schema),
-    )
-    select_patient_table = qm_builds(
-        SelectPatientTable,
-        st.sampled_from(patient_tables),
-        st.just(schema),
-    )
-    select_column = qm_builds(
-        SelectColumn, frame, st.sampled_from(list(schema.column_names))
-    )
-    select_date_column = qm_builds(
-        SelectColumn,
-        frame,
-        st.sampled_from(
-            [name for name, type_ in schema.column_types if type_.__name__ == "date"]
-        ),
-    )
-
-    filter_ = qm_builds(Filter, many_rows_per_patient_frame, series)
-
-    sort = qm_builds(Sort, many_rows_per_patient_frame, many_rows_per_patient_series)
-
-    pick_one_row_per_patient = qm_builds(
-        PickOneRowPerPatient,
-        sorted_frame,
-        st.sampled_from([Position.FIRST, Position.LAST]),
-    )
-
-    exists = qm_builds(AggregateByPatient.Exists, many_rows_per_patient_frame)
-    count_ = qm_builds(AggregateByPatient.Count, many_rows_per_patient_frame)
-    min_ = qm_builds(AggregateByPatient.Min, series)
-    max_ = qm_builds(AggregateByPatient.Max, series)
-    sum_ = qm_builds(AggregateByPatient.Sum, many_rows_per_patient_series)
-
-    eq = qm_builds(Function.EQ, series, series)
-    ne = qm_builds(Function.NE, series, series)
-    lt = qm_builds(Function.LT, series, series)
-    le = qm_builds(Function.LE, series, series)
-    gt = qm_builds(Function.GT, series, series)
-    ge = qm_builds(Function.GE, series, series)
-
-    and_ = qm_builds(Function.And, series, series)
-    or_ = qm_builds(Function.Or, series, series)
-    not_ = qm_builds(Function.Not, series)
-
-    is_null = qm_builds(Function.IsNull, series)
-
-    negate = qm_builds(Function.Negate, series)
-    add = qm_builds(Function.Add, series, series)
-    subtract = qm_builds(Function.Subtract, series, series)
-    multiply = qm_builds(Function.Multiply, series, series)
-
-    cast_to_int = qm_builds(Function.CastToInt, series)
-    cast_to_float = qm_builds(Function.CastToFloat, series)
-
-    date_add_years = qm_builds(Function.DateAddYears, date_series, series)
-    date_add_months = qm_builds(Function.DateAddMonths, date_series, series)
-    date_add_days = qm_builds(Function.DateAddDays, date_series, series)
-    year_from_date = qm_builds(Function.YearFromDate, date_series)
-    month_from_date = qm_builds(Function.MonthFromDate, date_series)
-    day_from_date = qm_builds(Function.DayFromDate, date_series)
-    date_difference_in_years = qm_builds(
-        Function.DateDifferenceInYears, date_series, date_series
-    )
-    date_difference_in_months = qm_builds(
-        Function.DateDifferenceInMonths, date_series, date_series
-    )
-    date_difference_in_days = qm_builds(
-        Function.DateDifferenceInDays, date_series, date_series
-    )
-    to_first_of_year = qm_builds(Function.ToFirstOfYear, date_series)
-    to_first_of_month = qm_builds(Function.ToFirstOfMonth, date_series)
-
-    case = qm_builds(
-        Case,
-        st.dictionaries(series, series, min_size=1, max_size=3),
-        st.one_of(st.none(), series),
-    )
-
-    assert_complete_coverage()
-
-    # Variables must be single values which have been reduced to the patient level. We also need to ensure that they
-    # contains nodes which actually access the database so that the query engine can calculate a patient universe.
-    return one_row_per_patient_series.filter(uses_the_database)
-
-
-# A specialized version of st.builds() which cleanly rejects invalid Query Model objects.
-# We also record the QM operations for which strategies have been created and then assert that
-# this includes all operations that exist, to act as a reminder to us to add new operations here
-# when they are added to the query model.
-def qm_builds(type_, *arg_strategies):
-    included_operations.add(type_)
+    def select_column(type_, frame):
+        column_names = [n for n, t in schema.column_types if t == type_]
+        return st.builds(SelectColumn, st.just(frame), st.sampled_from(column_names))
 
     @st.composite
-    def strategy(draw, type_, *arg_strategies):
-        args = [draw(s) for s in arg_strategies]
-        try:
-            return type_(*args)
-        except ValidationError:
-            raise hypothesis.errors.UnsatisfiedAssumption
+    def eq(draw, _type, frame):
+        type_ = draw(any_type())
+        lhs = draw(series(type_, draw(one_row_per_patient_frame_or(frame))))
+        rhs = draw(series(type_, draw(one_row_per_patient_frame_or(frame))))
+        return Function.EQ(lhs, rhs)
 
-    return strategy(type_, *arg_strategies)
+    @st.composite
+    def add(draw, type_, frame):
+        return Function.Add(
+            draw(series(type_, draw(one_row_per_patient_frame_or(frame)))),
+            draw(series(type_, draw(one_row_per_patient_frame_or(frame)))),
+        )
+
+    def count(_type, _frame):
+        return st.builds(AggregateByPatient.Count, any_frame())
+
+    def any_type():
+        return st.sampled_from(list(value_strategies.keys()))
+
+    # Frame strategies
+    #
+    # The main concern when choosing a frame is whether it has one or many rows per patient. Some
+    # callers require one or the other, some don't mind; so we provide strategies for each case.
+    # And sometimes callers need _either_ the frame they have in their hand _or_ an arbitrary
+    # patient frame, so we provide a strategy for that too.
+    #
+    # At variance with the general approach here, many-rows-per-patient frames are created by
+    # imperatively building stacks of filters on top of select nodes, rather than relying on
+    # recursion, because it enormously simplifies the logic needed to keep filter conditions
+    # consistent with the source.
+    def any_frame():
+        # Order matters: "simpler" first (see header comment)
+        return st.one_of(one_row_per_patient_frame(), many_rows_per_patient_frame())
+
+    def one_row_per_patient_frame():
+        return select_patient_table()
+
+    @st.composite
+    def many_rows_per_patient_frame(draw):
+        source = draw(select_table())
+        for _ in range(draw(st.integers(min_value=0, max_value=6))):
+            source = draw(filter_(source))
+        return source
+
+    def one_row_per_patient_frame_or(frame):
+        if is_one_row_per_patient_frame(frame):
+            return st.just(frame)
+        # Order matters: "simpler" first (see header comment)
+        return st.one_of(one_row_per_patient_frame(), st.just(frame))
+
+    def select_table():
+        return st.builds(SelectTable, st.sampled_from(event_tables), st.just(schema))
+
+    def select_patient_table():
+        return st.builds(
+            SelectPatientTable, st.sampled_from(patient_tables), st.just(schema)
+        )
+
+    @st.composite
+    def filter_(draw, source):
+        condition = draw(series(bool, draw(ancestor_of(source))))
+        return Filter(source, condition)
+
+    @st.composite
+    def ancestor_of(draw, frame):
+        for _ in range(draw(st.integers(min_value=0, max_value=3))):
+            if hasattr(frame, "source"):
+                frame = frame.source
+            else:
+                break
+        return frame
+
+    # Variable strategy
+    #
+    # Puts everything above together to create a variable.
+    @st.composite
+    def valid_variable(draw):
+        type_ = draw(any_type())
+        frame = draw(one_row_per_patient_frame())
+        return draw(series(type_, frame).filter(uses_the_database))
+
+    return valid_variable()
 
 
-included_operations = set()
-
+# The second set is a temporary list of node types not covered by the new query generation approach.
 known_missing_operations = {
     AggregateByPatient.CombineAsSet,
     Function.In,
     Function.StringContains,
+} | {
+    Case,
+    Sort,
+    PickOneRowPerPatient,
+    AggregateByPatient.Max,
+    AggregateByPatient.Min,
+    AggregateByPatient.Exists,
+    AggregateByPatient.Sum,
+    Function.IsNull,
+    Function.LE,
+    Function.NE,
+    Function.GT,
+    Function.LT,
+    Function.GE,
+    Function.And,
+    Function.Or,
+    Function.Not,
+    Function.Negate,
+    Function.Subtract,
+    Function.Multiply,
+    Function.CastToFloat,
+    Function.CastToInt,
+    Function.YearFromDate,
+    Function.MonthFromDate,
+    Function.DayFromDate,
+    Function.ToFirstOfYear,
+    Function.ToFirstOfMonth,
+    Function.DateAddYears,
+    Function.DateAddMonths,
+    Function.DateAddDays,
+    Function.DateDifferenceInYears,
+    Function.DateDifferenceInMonths,
+    Function.DateDifferenceInDays,
 }
-
-
-def assert_complete_coverage():
-    assert_includes_all_operations(included_operations)
 
 
 def assert_includes_all_operations(operations):  # pragma: no cover
@@ -327,3 +230,7 @@ def assert_includes_all_operations(operations):  # pragma: no cover
 def uses_the_database(v):
     database_uses = [SelectPatientTable, SelectTable]
     return any(t in database_uses for t in node_types(v))
+
+
+def is_one_row_per_patient_frame(frame):
+    return isinstance(frame, SelectPatientTable)


### PR DESCRIPTION
Although running the gentests for a set number of examples is a bit slower (3 min vs 2 min for 1000 examples on my laptop), the size and variety of queries generated (and executed!) is much greater such that unique queries are generated ~3 times faster and nodes generated ~15 times faster.

This removes the check that we have strategies for all node types because there doesn't seem to be a straightforward way of doing that with this approach (we no longer instantiate all node types with `st.builds()`). So we will be reliant on running `GENTEST_COMPREHENSIVE` to check this.
