### PR TITLE
Make sqlite date arithmetic roll over to the 1st of the next month

### DIFF
--- a/databuilder/query_engines/sqlite.py
+++ b/databuilder/query_engines/sqlite.py
@@ -23,7 +23,47 @@ class SQLiteQueryEngine(BaseSQLQueryEngine):
         return self.date_add("days", date, num_days)
 
     def date_add_months(self, date, num_months):
-        return self.date_add("months", date, num_months)
+        new_date = self.date_add("months", date, num_months)
+        # In cases of day-of-month overflow, SQLite *usually* rolls over to the first of
+        # the next month as want it to.
+        # It does this by performing a normalisation when a date arithmetic operation results
+        # in a date with an invalid number of days (e.g. 30 Feb 2000); namely it
+        # rolls over to the next month by incrementing the month and subtracting
+        # the number of days in the month. For all months except February, the invalid day is only
+        # ever at most 1 day off (i.e. the 31st, for a month with only 30 days), and so this
+        # normalisation results in a rollover to the first of the next month. However for February,
+        # the invalid day can be 1 to 3 days off, which means date rollovers can result in the 1st,
+        # 2nd or 3rd March.
+        #
+        # The SQLite docs (https://sqlite.org/lang_datefunc.html) state:
+        # "Note that "±NNN months" works by rendering the original date into the YYYY-MM-DD
+        # format, adding the ±NNN to the MM month value, then normalizing the result. Thus,
+        # for example, the date 2001-03-31 modified by '+1 month' initially yields 2001-04-31,
+        # but April only has 30 days so the date is normalized to 2001-05-01"
+        #
+        # i.e. 2001-03-31 +1 month results in 2001-04-31, but as the number of days is invalid,
+        # SQLite rolls over to the next month by incrementing the month by 1, and subtracting
+        # the number of days in April (30) from the days, resulting in 2001-05-01
+        #
+        # In the case of February, a calculation that results in a date with an invalid number of
+        # days follows the same normalisation method:
+        # 2000-02-30: increment month by 1, subtract 29 (leap year) days -> 2000-03-01
+        # 2001-02-30: increment month by 1, subtract 28 days -> 2000-03-02
+        # 2000-02-31: increment month by 1, subtract 29 (leap year) days -> 2000-03-02
+        # 2001-02-31: increment month by 1, subtract 28 days -> 2000-03-03
+        #
+        # We detect when it's done that and correct for it here, ensuring that when a date rolls over
+        # to the next month, the date returned is always the first of that month. For more detail see:
+        # tests/spec/date_series/ops/test_date_series_ops.py::test_add_months
+        new_date_day = self.get_date_part(new_date, "DAY")
+        correction = sqlalchemy.case(
+            (
+                self.get_date_part(new_date, "DAY") < self.get_date_part(date, "DAY"),
+                1 - new_date_day,
+            ),
+            else_=0,
+        )
+        return self.date_add_days(new_date, correction)
 
     def date_add_years(self, date, num_years):
         return self.date_add("years", date, num_years)

--- a/tests/spec/date_series_ops/test_date_series_ops.py
+++ b/tests/spec/date_series_ops/test_date_series_ops.py
@@ -132,19 +132,24 @@ def test_add_months(spec_test):
     #
     #       The smallest y such that `(y - x).months == N`
     #
-    #  2. It is what SQLite does.
+    #  2. It is what SQLite does *in most cases*.  SQLite rolls over to the first of the next
+    #     month, except in the case of the last days of February, where the rolled-over date
+    #     from 30/31 Feb becomes 02/03 March.
     #
     # Other databases take different approachs so we have to work around their behaviour
-    # in their respective query engines.
+    # in their respective query engines, and in the SQLite engine for the end of February
+    # behaviour.
     table_data = {
         p: """
           |     d1     | i1
-        --+------------+-----
+        ---+------------+-----
         1 | 2003-01-29 |  1
         2 | 2004-01-29 |  1
-        3 | 2003-01-29 | -1
-        4 | 2000-10-31 |  11
-        5 | 2000-10-31 | -11
+        3 | 2003-01-31 |  1
+        4 | 2004-01-31 |  1
+        5 | 2004-03-31 | -1
+        6 | 2000-10-31 |  11
+        7 | 2000-10-31 | -11
         """,
     }
     spec_test(
@@ -153,9 +158,11 @@ def test_add_months(spec_test):
         {
             1: date(2003, 3, 1),
             2: date(2004, 2, 29),
-            3: date(2002, 12, 29),
-            4: date(2001, 10, 1),
-            5: date(1999, 12, 1),
+            3: date(2003, 3, 1),
+            4: date(2004, 3, 1),
+            5: date(2004, 3, 1),
+            6: date(2001, 10, 1),
+            7: date(1999, 12, 1),
         },
     )
 


### PR DESCRIPTION
SQLite performs a normalisation when a date arithmetic operation results in a date with an invalid number of days (e.g. 30 Feb 2000); namely it rolls over to the next month by incrementing the month and subtracting the number of days in the month.  For February dates, this results in dates between 1-3 March, depending on how far off the calculated date is (i.e. 31 Feb in a non-leap year will become 03 Mar). We now apply a correction so that we always roll over to the 1st of the next month.

Fixes #918 