### PR TITLE
fix: Allow the in-memory engine to combine differently sorted event series

### DIFF
--- a/tests/spec/combine_series/test_event_series_and_event_series.py
+++ b/tests/spec/combine_series/test_event_series_and_event_series.py
@@ -4,12 +4,12 @@ title = "Combining two event series"
 
 table_data = {
     e: """
-          |  i1 |  i2
-        --+-----+-----
-        1 | 101 | 111
-        1 | 102 | 112
-        2 | 201 | 211
-        2 | 202 | 212
+          |  i1 |  i2 | s1
+        --+-----+-----+---
+        1 | 101 | 111 | b
+        1 | 102 | 112 | a
+        2 | 201 | 211 | b
+        2 | 202 | 212 | a
     """,
 }
 
@@ -21,5 +21,19 @@ def test_event_series_and_event_series(spec_test):
         {
             1: (101 + 111) + (102 + 112),
             2: (201 + 211) + (202 + 212),
+        },
+    )
+
+
+def test_event_series_and_sorted_event_series(spec_test):
+    """
+    The sort order of the underlying event series does not affect their combination.
+    """
+    spec_test(
+        table_data,
+        (e.i1 + e.sort_by(e.s1).i2).minimum_for_patient(),
+        {
+            1: (101 + 111),
+            2: (201 + 211),
         },
     )

--- a/tests/unit/query_engines/test_in_memory_database.py
+++ b/tests/unit/query_engines/test_in_memory_database.py
@@ -1,3 +1,5 @@
+import pytest
+
 from databuilder.query_engines.in_memory_database import (
     EventColumn,
     EventTable,
@@ -538,6 +540,27 @@ def test_apply_function_to_rows_and_values():
     assert apply_function_to_rows_and_values(sum_, args) == Rows(
         {1: (101 + 1000 + 102), 2: (201 + 1000 + 202)}
     )
+
+
+@pytest.mark.parametrize(
+    "func_to_apply,extra_args",
+    [
+        (sum, [1000, -200]),
+        (min, [200]),
+        (max, [200, 300]),
+    ],
+)
+def test_apply_function_to_rows_and_values_with_different_key_order(
+    func_to_apply, extra_args
+):
+    def func(*args):
+        return func_to_apply(args)
+
+    same_order_args = [Rows({1: 101, 2: 201}), Rows({1: 102, 2: 202}), *extra_args]
+    diff_order_args = [Rows({1: 101, 2: 201}), Rows({2: 202, 1: 102}), *extra_args]
+    assert apply_function_to_rows_and_values(
+        func, same_order_args
+    ) == apply_function_to_rows_and_values(func, diff_order_args)
 
 
 def test_apply_function_with_no_event_columns():


### PR DESCRIPTION
Fixes #917 

We have a check in the in-memory database when applying a function to Rows (i.e. combining event-series data) which asserts that the keys for each `Rows` instance that's being combined are the same.  If one of the event series is the result of a Sort, the keys may be the same, but in a different order.  That doesn't matter for combining the series, as long as the keys themselves still represent the same rows (which they do), so the assertion on keys now ignores their order. 