### PR TITLE
Groundwork for table-from-file feature

### DIFF
--- a/databuilder/query_language.py
+++ b/databuilder/query_language.py
@@ -667,6 +667,24 @@ def get_table_schema_from_class(cls):
     return qm.TableSchema(**schema)
 
 
+# Defines a PatientFrame along with the data it contains. Takes a list (or
+# any iterable) of row tuples of the form:
+#
+#    (patient_id, column_1_in_schema, column_2_in_schema, ...)
+#
+def table_from_rows(rows):
+    def decorator(cls):
+        if cls.__bases__ != (PatientFrame,):
+            raise SchemaError("`@table_from_rows` can only be used with `PatientFrame`")
+        qm_node = qm.InlinePatientTable(
+            rows=qm.IterWrapper(rows),
+            schema=get_table_schema_from_class(cls),
+        )
+        return cls(qm_node)
+
+    return decorator
+
+
 # A descriptor which will return the appropriate type of series depending on the type of
 # frame it belongs to i.e. a PatientSeries subclass for PatientFrames and an EventSeries
 # subclass for EventFrames. This lets schema authors use a consistent syntax when

--- a/databuilder/query_language.py
+++ b/databuilder/query_language.py
@@ -650,16 +650,21 @@ def table(cls):
             "Schema class must subclass either `PatientFrame` or `EventFrame`"
         )
 
-    table_name = cls.__name__
+    qm_node = qm_class(
+        name=cls.__name__,
+        schema=get_table_schema_from_class(cls),
+    )
+    return cls(qm_node)
+
+
+def get_table_schema_from_class(cls):
     # Get all `Series` objects on the class and determine the schema from them
     schema = {
         series.name: qm.Column(series.type_, constraints=series.constraints)
         for series in vars(cls).values()
         if isinstance(series, Series)
     }
-
-    qm_node = qm_class(table_name, qm.TableSchema(**schema))
-    return cls(qm_node)
+    return qm.TableSchema(**schema)
 
 
 # A descriptor which will return the appropriate type of series depending on the type of

--- a/databuilder/tables/__init__.py
+++ b/databuilder/tables/__init__.py
@@ -1,4 +1,10 @@
-from databuilder.query_language import EventFrame, PatientFrame, Series, table
+from databuilder.query_language import (
+    EventFrame,
+    PatientFrame,
+    Series,
+    table,
+    table_from_rows,
+)
 from databuilder.query_model.table_schema import Constraint
 
 __all__ = [
@@ -7,4 +13,5 @@ __all__ = [
     "PatientFrame",
     "Series",
     "table",
+    "table_from_rows",
 ]

--- a/tests/spec/table_from_rows/__init__.py
+++ b/tests/spec/table_from_rows/__init__.py
@@ -1,0 +1,1 @@
+title = "Defining a table using inline data"

--- a/tests/spec/table_from_rows/test_table_from_rows.py
+++ b/tests/spec/table_from_rows/test_table_from_rows.py
@@ -1,0 +1,39 @@
+import pytest
+
+from databuilder.tables import PatientFrame, Series, table_from_rows
+
+from ..tables import p
+
+title = "Defining a table using inline data"
+
+table_data = {
+    p: """
+          | i1
+        --+----
+        1 | 10
+        2 | 20
+        3 | 30
+        """,
+}
+
+
+@pytest.mark.xfail
+def test_table_from_rows(spec_test):
+    inline_data = [
+        (1, 100),
+        (3, 300),
+    ]
+
+    @table_from_rows(inline_data)
+    class t(PatientFrame):
+        n = Series(int)
+
+    spec_test(
+        table_data,
+        p.i1 + t.n,
+        {
+            1: 10 + 100,
+            2: None,
+            3: 30 + 300,
+        },
+    )

--- a/tests/spec/toc.py
+++ b/tests/spec/toc.py
@@ -56,4 +56,7 @@ contents = {
     "population": [
         "test_population",
     ],
+    "table_from_rows": [
+        "test_table_from_rows",
+    ],
 }

--- a/tests/unit/test_query_language.py
+++ b/tests/unit/test_query_language.py
@@ -22,11 +22,13 @@ from databuilder.query_language import (
     days,
     months,
     table,
+    table_from_rows,
     years,
 )
 from databuilder.query_model.nodes import (
     Column,
     Function,
+    InlinePatientTable,
     SelectColumn,
     SelectPatientTable,
     SelectTable,
@@ -248,6 +250,25 @@ def test_must_reference_instance_not_class():
 
     with pytest.raises(SchemaError, match="Missing `@table` decorator"):
         some_table.some_int
+
+
+def test_table_from_rows():
+    @table_from_rows([(1, 100), (2, 200)])
+    class some_table(PatientFrame):
+        some_int = Series(int)
+
+    assert isinstance(some_table, PatientFrame)
+    assert isinstance(some_table.qm_node, InlinePatientTable)
+
+
+def test_table_from_rows_only_accepts_patient_frame():
+    with pytest.raises(
+        SchemaError, match="`@table_from_rows` can only be used with `PatientFrame`"
+    ):
+
+        @table_from_rows([])
+        class some_table(EventFrame):
+            some_int = Series(int)
 
 
 def test_boolean_operators_raise_errors():


### PR DESCRIPTION
This PR lays the groundwork for implementing the [table-from-file](https://github.com/opensafely-core/databuilder/issues/793) feature, which means the necessary query model changes, the minimal ehrQL needed to write a test, and a minimal failing spec test (currently marked as `xfail`).

To help break the task down, this PR introduces a `@table_from_rows` decorator which takes its data as a list of row tuples. I don't expect this to stick around: it should be replaced by a `@table_from_file` decorator which takes a path to a file. But it enables us to worry about loading data from files as a separate step once we have the other core bits of machinery in place.

The next step is to teach the various query engines how to handle the `InlinePatientTable` node. I suggest starting with the `InMemoryQueryEngine` before tackling `BaseSQLQueryEngine`. There's a bit more detail in the "Query Engines" section of the notes [here](https://github.com/opensafely-core/databuilder/issues/793#issuecomment-1373957956).
