### PR TITLE
fix: Ensure Arrow dictionaries are Pandas-compatibile

### DIFF
--- a/databuilder/file_formats/arrow.py
+++ b/databuilder/file_formats/arrow.py
@@ -65,7 +65,11 @@ def get_field_and_convertor(name, spec):
         type_ = PYARROW_TYPE_MAP[spec.type]()
 
     if spec.categories is not None:
-        index_type = smallest_int_type_for_range(0, len(spec.categories) - 1)
+        # Although pyarrow.dictionary indices can obviously never be negative we use
+        # `-1` as the minimum below so we always get a signed type; this is because
+        # Pandas can't read dictionaries with unsigned index types. See:
+        # https://github.com/opensafely-core/databuilder/issues/945
+        index_type = smallest_int_type_for_range(-1, len(spec.categories) - 1)
         value_type = type_
         type_ = pyarrow.dictionary(index_type, value_type, ordered=True)
         column_to_pyarrow = make_column_to_pyarrow_with_categories(

--- a/tests/integration/file_formats/test_arrow.py
+++ b/tests/integration/file_formats/test_arrow.py
@@ -27,6 +27,6 @@ def test_write_dataset_arrow(tmp_path):
     assert output_columns == list(column_specs.keys())
     assert output_rows == results
     assert categories == ["M", "F", "I"]
-    assert index_type == pyarrow.uint8()
+    assert index_type == pyarrow.int8()
     assert table.column("patient_id").type == pyarrow.int64()
     assert table.column("year_of_birth").type == pyarrow.uint16()


### PR DESCRIPTION
This means ensuring that we always used a signed integer type for a `DictionaryArray` index.

There's a theoretical loss of storage efficiency here (a categorical with 127 < N <= 255 categories will get encoded as `int16` rather than `uint8`) but we expect it to be rare to have that many categories, and being readable by Pandas is a key feature.

We don't currently have a mechanism for testing this within Data Builder so I tested manually with the following `test_dataset.py` definition:
```py
from databuilder.ehrql import Dataset
from databuilder.tables.beta import tpp

dataset = Dataset()
dataset.sex = tpp.patients.sex
dataset.set_population(tpp.patients.exists_for_patient())
```

Without the fix, generating a dataset file and loading it with Pandas fails:
```
databuilder generate-dataset test_dataset.py --output test.arrow
python -c 'import pandas; pandas.read_feather("test.arrow")'
```

```
Traceback (most recent call last):
...
pyarrow.lib.ArrowTypeError: Converting unsigned dictionary indices to pandas not yet supported, index type: uint8
```

After applying the fix the file is read successfully.

Closes #945