### PR TITLE
Add `Regex` column constraint

### DIFF
--- a/databuilder/dummy_data/generator.py
+++ b/databuilder/dummy_data/generator.py
@@ -8,6 +8,7 @@ import structlog
 from databuilder.dummy_data.query_info import QueryInfo
 from databuilder.query_engines.in_memory import InMemoryQueryEngine
 from databuilder.query_engines.in_memory_database import InMemoryDatabase
+from databuilder.tables import Constraint
 from databuilder.utils.orm_utils import orm_classes_from_tables
 
 log = structlog.getLogger()
@@ -168,7 +169,7 @@ class DummyPatientGenerator:
         # Apply any FirstOfMonth constraints
         for key, value in row.items():
             if key in table_info.columns:
-                if table_info.columns[key].has_first_of_month_constraint:
+                if table_info.columns[key].get_constraint(Constraint.FirstOfMonth):
                     row[key] = value.replace(day=1)
         return [row]
 
@@ -233,7 +234,7 @@ class DummyPatientGenerator:
             # Clip to the available time range
             event_date = max(event_date, self.events_start)
             # Apply any FirstOfMonth constraints
-            if column_info.has_first_of_month_constraint:
+            if column_info.get_constraint(Constraint.FirstOfMonth):
                 event_date = event_date.replace(day=1)
             return event_date
         else:

--- a/databuilder/dummy_data/generator.py
+++ b/databuilder/dummy_data/generator.py
@@ -217,12 +217,6 @@ class DummyPatientGenerator:
             # TODO: As is this
             return self.rnd.random() * 100
         elif column_info.type is str:
-            # Generate appropriately formatted Middle Layer Super Output Area codes
-            if column_info.name == "msoa_code":
-                return f"E02{self.rnd.randrange(0, 8000):06d}"
-            # Generate appropriately formatted STP codes
-            if column_info.name == "practice_stp":
-                return f"E54{self.rnd.randrange(0, 99):06d}"
             # If the column must match a regex then generate matching strings
             if regex_constraint := column_info.get_constraint(Constraint.Regex):
                 generator = get_regex_generator(regex_constraint.regex)

--- a/databuilder/query_model/table_schema.py
+++ b/databuilder/query_model/table_schema.py
@@ -1,5 +1,7 @@
 import dataclasses
 
+from databuilder.utils.regex_utils import validate_regex
+
 
 class BaseConstraint:
     def __init_subclass__(cls, **kwargs):
@@ -28,6 +30,16 @@ class Constraint:
 
     class FirstOfMonth(BaseConstraint):
         description = "Must be the first day of a month"
+
+    class Regex(BaseConstraint):
+        regex: str
+
+        def __post_init__(self):
+            validate_regex(self.regex)
+
+        @property
+        def description(self):
+            return f"Must match the regular expression: {self.regex!r}"
 
 
 @dataclasses.dataclass(frozen=True)

--- a/databuilder/tables/beta/tpp.py
+++ b/databuilder/tables/beta/tpp.py
@@ -33,7 +33,10 @@ class practice_registrations(EventFrame):
     start_date = Series(datetime.date)
     end_date = Series(datetime.date)
     practice_pseudo_id = Series(int)
-    practice_stp = Series(str)
+    practice_stp = Series(
+        str,
+        constraints=[Constraint.Regex("E540000[0-9]{2}")],
+    )
     practice_nuts1_region_name = Series(
         str,
         constraints=[
@@ -98,7 +101,10 @@ class addresses(EventFrame):
     address_type = Series(int)
     rural_urban_classification = Series(int)
     imd_rounded = Series(int)
-    msoa_code = Series(str)
+    msoa_code = Series(
+        str,
+        constraints=[Constraint.Regex("E020[0-9]{5}")],
+    )
     has_postcode = Series(bool)
     # Is the address potentially a match for a care home? (Using TPP's algorithm)
     care_home_is_potential_match = Series(bool)

--- a/databuilder/utils/regex_utils.py
+++ b/databuilder/utils/regex_utils.py
@@ -1,0 +1,163 @@
+# Note: in Python 3.11 this has been renamed to `re._parser`
+import sre_parse as parser
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+
+
+class RegexError(Exception):
+    pass
+
+
+def create_regex_generator(regex_str):
+    """
+    Accepts a regular expression string and returns a callable for generating random
+    strings matching that expression.
+
+    The callable itself takes an instance of `random.Random` so that the caller can
+    control the random generation.
+    """
+    parsed = parser.parse(regex_str)
+    return pattern_from_list(parsed).generate
+
+
+def validate_regex(regex_str):
+    try:
+        create_regex_generator(regex_str)
+    except parser.error as exc:
+        raise RegexError(exc)
+    return True
+
+
+# MODELS
+#
+# Classes which represent elements of a regular expression and generate strings matching
+# that element
+#
+
+
+class RegexElement(ABC):
+    @abstractmethod
+    def generate(self, rnd):
+        raise NotImplementedError()
+
+
+@dataclass(frozen=True)
+class Literal(RegexElement):
+    char: str
+
+    def generate(self, rnd):
+        return self.char
+
+
+@dataclass(frozen=True)
+class Pattern(RegexElement):
+    elements: tuple[RegexElement]
+
+    def generate(self, rnd):
+        return "".join(elem.generate(rnd) for elem in self.elements)
+
+
+@dataclass(frozen=True)
+class Branch(RegexElement):
+    branches: tuple[RegexElement]
+
+    def generate(self, rnd):
+        branch = rnd.choice(self.branches)
+        return branch.generate(rnd)
+
+
+@dataclass(frozen=True)
+class Repeat(RegexElement):
+    element: RegexElement
+    min_repeats: int
+    max_repeats: int
+
+    def generate(self, rnd):
+        repeats = rnd.randint(self.min_repeats, self.max_repeats)
+        return "".join(self.element.generate(rnd) for _ in range(repeats))
+
+
+@dataclass(frozen=True)
+class Range(RegexElement):
+    min_char_index: int
+    max_char_index: int
+
+    def generate(self, rnd):
+        char_index = rnd.randint(self.min_char_index, self.max_char_index)
+        return chr(char_index)
+
+
+# TRANSFORM
+#
+# Functions to turn a parsed regular expression into a collection of models
+#
+
+
+# We don't attempt to support the full range of regular expressions available in Python
+UNSUPPORTED_REGEX = RegexError("Regex uses unsupported features")
+
+
+def create_regex_element(type_, args):
+    handler = DISPATCH_TABLE.get(type_)
+    if handler is None:
+        raise UNSUPPORTED_REGEX
+    return handler(args)
+
+
+def handle_literal(char_index):
+    return Literal(chr(char_index))
+
+
+def pattern_from_list(items):
+    return Pattern(
+        tuple(create_regex_element(type_, args) for type_, args in items),
+    )
+
+
+def handle_subpattern(args):
+    group_num, add_flags, del_flags, items = args
+    # We don't care about the group number of this subpattern, and we can't handle flags
+    # being set/unset within the subpattern
+    if add_flags != 0 or del_flags != 0:
+        raise UNSUPPORTED_REGEX
+    return pattern_from_list(items)
+
+
+def handle_branch(args):
+    dummy, branches = args
+    # As far as I call from the parser source code this argument no longer serves a
+    # purpose and is always null
+    assert dummy is None
+    return Branch(tuple(pattern_from_list(i) for i in branches))
+
+
+def handle_in(options):
+    return Branch(
+        tuple(create_regex_element(type_, args) for type_, args in options),
+    )
+
+
+def handle_max_repeat(args):
+    min_repeats, max_repeats, pattern_args = args
+    # Cap unlimited repetitions (e.g. "a*") at 10
+    if max_repeats == parser.MAXREPEAT:
+        max_repeats = 10
+    return Repeat(
+        pattern_from_list(pattern_args),
+        min_repeats,
+        max_repeats,
+    )
+
+
+def handle_range(args):
+    return Range(min_char_index=args[0], max_char_index=args[1])
+
+
+DISPATCH_TABLE = {
+    parser.LITERAL: handle_literal,
+    parser.SUBPATTERN: handle_subpattern,
+    parser.BRANCH: handle_branch,
+    parser.IN: handle_in,
+    parser.MAX_REPEAT: handle_max_repeat,
+    parser.RANGE: handle_range,
+}

--- a/tests/unit/dummy_data/test_generator.py
+++ b/tests/unit/dummy_data/test_generator.py
@@ -121,8 +121,9 @@ def test_get_random_value_on_first_of_month(dummy_patient_generator):
         type=datetime.date,
         constraints=(Constraint.FirstOfMonth(),),
     )
-    value = dummy_patient_generator.get_random_value(column_info)
-    assert value.day == 1
+    values = [dummy_patient_generator.get_random_value(column_info) for _ in range(10)]
+    assert len(set(values)) > 1, "dates are all identical"
+    assert all(value.day == 1 for value in values)
 
 
 def test_get_random_str(dummy_patient_generator):

--- a/tests/unit/dummy_data/test_generator.py
+++ b/tests/unit/dummy_data/test_generator.py
@@ -133,18 +133,6 @@ def test_get_random_str(dummy_patient_generator):
     assert len(lengths) > 1, "strings are all the same length"
 
 
-def test_get_random_msoa_code(dummy_patient_generator):
-    column_info = ColumnInfo(name="msoa_code", type=str)
-    value = dummy_patient_generator.get_random_value(column_info)
-    assert re.match(r"E020[0-9]{5}", value)
-
-
-def test_get_random_practice_stp(dummy_patient_generator):
-    column_info = ColumnInfo(name="practice_stp", type=str)
-    value = dummy_patient_generator.get_random_value(column_info)
-    assert re.match(r"E540000[0-9]{2}", value)
-
-
 def test_get_random_str_with_regex(dummy_patient_generator):
     column_info = ColumnInfo(
         name="test",

--- a/tests/unit/dummy_data/test_generator.py
+++ b/tests/unit/dummy_data/test_generator.py
@@ -145,6 +145,17 @@ def test_get_random_practice_stp(dummy_patient_generator):
     assert re.match(r"E540000[0-9]{2}", value)
 
 
+def test_get_random_str_with_regex(dummy_patient_generator):
+    column_info = ColumnInfo(
+        name="test",
+        type=str,
+        constraints=(Constraint.Regex("AB[X-Z]{5}"),),
+    )
+    values = [dummy_patient_generator.get_random_value(column_info) for _ in range(10)]
+    assert len(set(values)) > 1, "strings are all identical"
+    assert all(re.match(r"AB[X-Z]{5}", value) for value in values)
+
+
 @pytest.fixture(scope="module")
 def dummy_patient_generator():
     dataset = Dataset()

--- a/tests/unit/dummy_data/test_generator.py
+++ b/tests/unit/dummy_data/test_generator.py
@@ -110,7 +110,7 @@ def test_dummy_data_generator_timeout_with_no_results(patched_time):
 
 @pytest.mark.parametrize("type_", [bool, int, float, str, datetime.date])
 def test_dummy_patient_generator_get_random_value(dummy_patient_generator, type_):
-    column_info = ColumnInfo(name="test", categories=None, type=type_)
+    column_info = ColumnInfo(name="test", type=type_)
     value = dummy_patient_generator.get_random_value(column_info)
     assert isinstance(value, type_)
 
@@ -118,9 +118,8 @@ def test_dummy_patient_generator_get_random_value(dummy_patient_generator, type_
 def test_get_random_value_on_first_of_month(dummy_patient_generator):
     column_info = ColumnInfo(
         name="test",
-        categories=None,
         type=datetime.date,
-        has_first_of_month_constraint=True,
+        constraints=(Constraint.FirstOfMonth(),),
     )
     value = dummy_patient_generator.get_random_value(column_info)
     assert value.day == 1

--- a/tests/unit/dummy_data/test_query_info.py
+++ b/tests/unit/dummy_data/test_query_info.py
@@ -5,7 +5,6 @@ from databuilder.codes import CTV3Code
 from databuilder.dummy_data.query_info import ColumnInfo, QueryInfo, TableInfo
 from databuilder.ehrql import Dataset, days
 from databuilder.query_language import compile
-from databuilder.query_model.table_schema import Column, TableSchema
 from databuilder.tables import Constraint, EventFrame, PatientFrame, Series, table
 
 
@@ -13,7 +12,12 @@ from databuilder.tables import Constraint, EventFrame, PatientFrame, Series, tab
 class patients(PatientFrame):
     date_of_birth = Series(datetime.date)
     sex = Series(
-        str, constraints=[Constraint.Categorical(["male", "female", "intersex"])]
+        str,
+        constraints=[
+            Constraint.Categorical(
+                ["male", "female", "intersex"],
+            )
+        ],
     )
 
 
@@ -36,41 +40,25 @@ def test_query_info_from_variable_definitions():
         tables={
             "events": TableInfo(
                 name="events",
-                schema=TableSchema(
-                    date=Column(datetime.date),
-                    code=Column(CTV3Code),
-                ),
                 has_one_row_per_patient=False,
                 columns={},
             ),
             "patients": TableInfo(
                 name="patients",
-                schema=TableSchema(
-                    date_of_birth=Column(datetime.date),
-                    sex=Column(
-                        str,
-                        constraints=(
-                            Constraint.Categorical(
-                                values=("male", "female", "intersex")
-                            ),
-                        ),
-                    ),
-                ),
                 has_one_row_per_patient=True,
                 columns={
                     "date_of_birth": ColumnInfo(
                         name="date_of_birth",
                         type=datetime.date,
-                        categories=None,
-                        has_first_of_month_constraint=False,
-                        values_used=set(),
                     ),
                     "sex": ColumnInfo(
                         name="sex",
                         type=str,
-                        categories=("male", "female", "intersex"),
-                        has_first_of_month_constraint=False,
-                        values_used=set(),
+                        constraints=(
+                            Constraint.Categorical(
+                                values=("male", "female", "intersex")
+                            ),
+                        ),
                     ),
                 },
             ),

--- a/tests/unit/query_model/test_table_schema.py
+++ b/tests/unit/query_model/test_table_schema.py
@@ -4,6 +4,7 @@ import re
 import pytest
 
 from databuilder.query_model.table_schema import Column, Constraint, TableSchema
+from databuilder.utils.regex_utils import RegexError
 
 
 def test_table_schema_equality():
@@ -92,6 +93,19 @@ def test_categorical_constraint_casts_lists_to_tuple():
 
 def test_categorical_constraint_description():
     assert Constraint.Categorical([1, 2, 3]).description == "Must be one of: 1, 2, 3"
+
+
+def test_regex_constraint_description():
+    assert (
+        Constraint.Regex("ABC[0-9]").description
+        == "Must match the regular expression: 'ABC[0-9]'"
+    )
+
+
+def test_regex_constraint_validates_regex():
+    with pytest.raises(RegexError, match="unsupported"):
+        # This regex is valid but not supported by our generator code
+        Constraint.Regex("(?i:TEST)")
 
 
 def test_column_casts_constraint_lists_to_tuple():

--- a/tests/unit/utils/test_regex_utils.py
+++ b/tests/unit/utils/test_regex_utils.py
@@ -1,0 +1,65 @@
+import random
+
+import pytest
+
+from databuilder.utils import regex_utils
+
+
+@pytest.mark.parametrize(
+    "re_str,examples",
+    [
+        # Branches
+        (
+            "abc(foo|bar)",
+            ["abcbar", "abcfoo"],
+        ),
+        # Ranges
+        (
+            "[A-Z][0-9]",
+            ["D1", "V1", "H0", "L9", "E2"],
+        ),
+        # Repeats
+        (
+            "A{2,4}_?B{2}",
+            ["AAABB", "AABB", "AA_BB", "AABB", "AAA_BB"],
+        ),
+        # Unbounded repeats
+        (
+            "a+b*",
+            ["aaaaaaaab", "ab", "aaaaaaaaaa", "aab", "aaaaaabbb"],
+        ),
+        # All together now ...
+        (
+            "(none|alpha[A-Z]{3,5}|digit[0-9]{3,5})",
+            ["alphaCVD", "alphaALT", "alphaFAH", "none", "digit18445"],
+        ),
+    ],
+)
+def test_create_regex_generator(re_str, examples):
+    generator = regex_utils.create_regex_generator(re_str)
+    rnd = random.Random(1234)
+    assert [generator(rnd) for _ in examples] == examples
+
+
+def test_validate_regex():
+    assert regex_utils.validate_regex("E[A-Z]{3}-(foo|bar)")
+
+
+@pytest.mark.parametrize(
+    "re_str,error",
+    [
+        # Parse errors from Python's regex engine are bubbled up
+        ("abc(123", r"missing \), unterminated subpattern at position 3"),
+        # Valid regexes which use unhandled constructs (e.g. non-greedy matches) should
+        # raise an "unsupported" error
+        ("t+?test", "unsupported"),
+        # Subpattern groups are supported, but attempting to set flags inside the group
+        # is not
+        ("(?i:TEST)", "unsupported"),
+        # And neither is unsetting flags
+        ("(?-i:TEST)", "unsupported"),
+    ],
+)
+def test_validate_regex_error(re_str, error):
+    with pytest.raises(regex_utils.RegexError, match=error):
+        regex_utils.validate_regex(re_str)


### PR DESCRIPTION
This adds a new constraint for asserting that the contents of a string column conform to a certain format e.g.
```py
msoa_code = Series(
    str,
    constraints=[Constraint.Regex("E020[0-9]{5}")],
)
```

This has several benefits:
 * it is included in the documentation for the column;
 * we can use it to guide the generation of dummy data (by ensuring that any strings we generate match the regex) and thus remove the special case logic that has to know about the formats of particular columns;
 * when we eventually come to validate the contents of the database against our schema we will be able to check our assumptions about the format are correct.