### PR TITLE
Add Date operations to the generative tests

### DIFF
--- a/.github/workflows/generative-tests.yml
+++ b/.github/workflows/generative-tests.yml
@@ -16,4 +16,9 @@ jobs:
         with:
           install-just: true
           python-version: "3.9"
-      - run: GENTEST_EXAMPLES=40000 GENTEST_COMPREHENSIVE=t GENTEST_DEBUG=t just test-generative
+      - run: |
+          GENTEST_EXAMPLES=40000 \
+          GENTEST_COMPREHENSIVE=t \
+          GENTEST_DEBUG=t \
+          GENTEST_CHECK_IGNORED_ERRORS=t \
+          just test-generative

--- a/databuilder/query_model/nodes.py
+++ b/databuilder/query_model/nodes.py
@@ -598,7 +598,7 @@ def count_nodes(tree):  # pragma: no cover
     return len(all_nodes(tree))
 
 
-def node_types(tree):
+def node_types(tree):  # pragma: no cover
     return [type(node) for node in all_nodes(tree)]
 
 

--- a/tests/generative/recording.py
+++ b/tests/generative/recording.py
@@ -69,11 +69,15 @@ def check_comprehensive(recorder):  # pragma: no cover
 
 
 def check_not_too_many_ignored_errors(recorder):
-    if recorder.num_results:  # pragma: no cover
+    if recorder.num_results and os.environ.get(
+        "GENTEST_CHECK_IGNORED_ERRORS"
+    ):  # pragma: no cover
         # Avoid spurious ZeroDivisionError if there are no results
         # This should only happen if the generative tests fail on the first test,
         # or if we're only running a single example during development (and it
         # fails).
+
+        # Allow more errors (proportionally) for smaller numbers of examples
         assert recorder.num_ignored_errors / recorder.num_results <= 0.01
 
 

--- a/tests/generative/test_query_model.py
+++ b/tests/generative/test_query_model.py
@@ -135,7 +135,7 @@ def run_test(query_engines, data, variable, recorder):
     ]
 
     recorder.record_results(
-        len(results), len([r for r in results if r is IGNORE_RESULT])
+        len(results), len([r for (_, r) in results if r is IGNORE_RESULT])
     )
 
     for first, second in itertools.combinations(results, 2):

--- a/tests/generative/test_query_model.py
+++ b/tests/generative/test_query_model.py
@@ -186,6 +186,9 @@ IGNORED_ERRORS = [
         sqlalchemy.exc.OperationalError,
         re.compile(".+Case expressions may only be nested to level 10.+"),
     ),
+    # SQLite raises a parser stack overflow error if the variable strategy generates queries
+    # that result in many nested queries
+    (sqlalchemy.exc.OperationalError, re.compile(".+parser stack overflow")),
     # OUT-OF-RANGE DATES
     # The variable strategy will sometimes result in date operations that construct
     # invalid dates (e.g. a large positive or negative integer in a DateAddYears operation

--- a/tests/generative/variable_strategies.py
+++ b/tests/generative/variable_strategies.py
@@ -160,13 +160,11 @@ def variable(patient_tables, event_tables, schema, value_strategies):
         type_ = draw(any_type())
         return draw(binary_operation(type_, frame, Function.NE))
 
-    @st.composite
-    def and_(draw, type_, frame):
-        return draw(binary_operation(type_, frame, Function.And))
+    def and_(type_, frame):
+        return binary_operation(type_, frame, Function.And)
 
-    @st.composite
-    def or_(draw, type_, frame):
-        return draw(binary_operation(type_, frame, Function.Or))
+    def or_(type_, frame):
+        return binary_operation(type_, frame, Function.Or)
 
     @st.composite
     def lt(draw, _type, frame):
@@ -188,59 +186,37 @@ def variable(patient_tables, event_tables, schema, value_strategies):
         type_ = draw(comparable_type())
         return draw(binary_operation(type_, frame, Function.GE))
 
-    @st.composite
-    def add(draw, type_, frame):
-        return draw(binary_operation(type_, frame, Function.Add))
+    def add(type_, frame):
+        return binary_operation(type_, frame, Function.Add)
 
-    @st.composite
-    def subtract(draw, type_, frame):
-        return draw(binary_operation(type_, frame, Function.Subtract))
+    def subtract(type_, frame):
+        return binary_operation(type_, frame, Function.Subtract)
 
-    @st.composite
-    def multiply(draw, type_, frame):
-        return draw(binary_operation(type_, frame, Function.Multiply))
+    def multiply(type_, frame):
+        return binary_operation(type_, frame, Function.Multiply)
 
-    @st.composite
-    def date_add_years(draw, type_, frame):
-        return draw(
-            binary_operation_with_types(type_, int, frame, Function.DateAddYears)
-        )
+    def date_add_years(type_, frame):
+        return binary_operation_with_types(type_, int, frame, Function.DateAddYears)
 
-    @st.composite
-    def date_add_months(draw, type_, frame):
-        return draw(
-            binary_operation_with_types(type_, int, frame, Function.DateAddMonths)
-        )
+    def date_add_months(type_, frame):
+        return binary_operation_with_types(type_, int, frame, Function.DateAddMonths)
 
-    @st.composite
-    def date_add_days(draw, type_, frame):
-        return draw(
-            binary_operation_with_types(type_, int, frame, Function.DateAddDays)
-        )
+    def date_add_days(type_, frame):
+        return binary_operation_with_types(type_, int, frame, Function.DateAddDays)
 
-    @st.composite
-    def date_difference_in_years(draw, type_, frame):
-        return draw(
-            binary_operation(datetime.date, frame, Function.DateDifferenceInYears)
-        )
+    def date_difference_in_years(type_, frame):
+        return binary_operation(datetime.date, frame, Function.DateDifferenceInYears)
 
-    @st.composite
-    def date_difference_in_months(draw, type_, frame):
-        return draw(
-            binary_operation(datetime.date, frame, Function.DateDifferenceInMonths)
-        )
+    def date_difference_in_months(type_, frame):
+        return binary_operation(datetime.date, frame, Function.DateDifferenceInMonths)
 
-    @st.composite
-    def date_difference_in_days(draw, type_, frame):
-        return draw(
-            binary_operation(datetime.date, frame, Function.DateDifferenceInDays)
-        )
+    def date_difference_in_days(type_, frame):
+        return binary_operation(datetime.date, frame, Function.DateDifferenceInDays)
 
-    @st.composite
-    def binary_operation(draw, type_, frame, operator_func):
+    def binary_operation(type_, frame, operator_func):
         # A strategy for operations that take lhs and rhs arguments of the
         # same type
-        return draw(binary_operation_with_types(type_, type_, frame, operator_func))
+        return binary_operation_with_types(type_, type_, frame, operator_func)
 
     @st.composite
     def binary_operation_with_types(draw, lhs_type, rhs_type, frame, operator_func):

--- a/tests/generative/variable_strategies.py
+++ b/tests/generative/variable_strategies.py
@@ -128,51 +128,28 @@ def variable(patient_tables, event_tables, schema, value_strategies):
     @st.composite
     def is_null(draw, _type, frame):
         type_ = draw(any_type())
-        return Function.IsNull(
-            draw(series(type_, draw(one_row_per_patient_frame_or(frame))))
-        )
+        return Function.IsNull(draw(series(type_, frame)))
 
-    @st.composite
-    def not_(draw, type_, frame):
-        return Function.Not(
-            draw(series(type_, draw(one_row_per_patient_frame_or(frame))))
-        )
+    def not_(type_, frame):
+        return st.builds(Function.Not, series(type_, frame))
 
-    @st.composite
-    def year_from_date(draw, _type, frame):
-        return Function.YearFromDate(
-            draw(series(datetime.date, draw(one_row_per_patient_frame_or(frame))))
-        )
+    def year_from_date(_type, frame):
+        return st.builds(Function.YearFromDate, series(datetime.date, frame))
 
-    @st.composite
-    def month_from_date(draw, _type, frame):
-        return Function.MonthFromDate(
-            draw(series(datetime.date, draw(one_row_per_patient_frame_or(frame))))
-        )
+    def month_from_date(_type, frame):
+        return st.builds(Function.MonthFromDate, series(datetime.date, frame))
 
-    @st.composite
-    def day_from_date(draw, _type, frame):
-        return Function.DayFromDate(
-            draw(series(datetime.date, draw(one_row_per_patient_frame_or(frame))))
-        )
+    def day_from_date(_type, frame):
+        return st.builds(Function.DayFromDate, series(datetime.date, frame))
 
-    @st.composite
-    def to_first_of_year(draw, _type, frame):
-        return Function.ToFirstOfYear(
-            draw(series(datetime.date, draw(one_row_per_patient_frame_or(frame))))
-        )
+    def to_first_of_year(_type, frame):
+        return st.builds(Function.ToFirstOfYear, series(datetime.date, frame))
 
-    @st.composite
-    def to_first_of_month(draw, _type, frame):
-        return Function.ToFirstOfMonth(
-            draw(series(datetime.date, draw(one_row_per_patient_frame_or(frame))))
-        )
+    def to_first_of_month(_type, frame):
+        return st.builds(Function.ToFirstOfMonth, series(datetime.date, frame))
 
-    @st.composite
-    def negate(draw, type_, frame):
-        return Function.Negate(
-            draw(series(type_, draw(one_row_per_patient_frame_or(frame))))
-        )
+    def negate(type_, frame):
+        return st.builds(Function.Negate, series(type_, frame))
 
     @st.composite
     def eq(draw, _type, frame):

--- a/tests/generative/variable_strategies.py
+++ b/tests/generative/variable_strategies.py
@@ -247,20 +247,27 @@ def variable(patient_tables, event_tables, schema, value_strategies):
         # A strategy for operations that take lhs and rhs arguments with specified lhs
         # and rhs types (which may be different)
 
-        # we can combine this frame with a series drawn from:
-        # - a new one-row-per-patient-frame
-        # - this frame itself
-        # If it's already a one-row-per-patient-frame, it uses the database, so can
-        # be combined with a value or a series
-        # If it's not a one-row-per-patient-frame, avoid combining with a value so we
-        # don't end up with operations that don't hit the database
+        # A binary operation has 2 inputs, which are
+        # 1) A series drawn from the specified frame
+        # 2) one of:
+        #    a) A series drawn from the specified frame
+        #    b) A series drawn from a one-row-per-patient-frame
+        #    c) A Value
+
+        # Define other_frame and other_series (#2 above)
+        # pick either a one-row-per-patient-frame or this frame
         other_frame = draw(st.one_of(one_row_per_patient_frame(), st.just(frame)))
         if is_one_row_per_patient_frame(other_frame):
+            # if other_frame is patient-level, the input will either be a value or a
+            # series drawn from other_frame
             other_strategy = draw(st.sampled_from([value, series]))
         else:
+            # if other_frame is event-level, the input will be a series drawn from the
+            # other_frame
             other_strategy = series
 
-        # Pick the order of the lhs and rhs from the two frames and associated strategies
+        # Pick the order of the lhs and rhs inputs built from the two frames and
+        # associated strategies
         lhs_frame, lhs_strategy = draw(
             st.sampled_from([(frame, series), (other_frame, other_strategy)])
         )

--- a/tests/generative/variable_strategies.py
+++ b/tests/generative/variable_strategies.py
@@ -73,6 +73,11 @@ def variable(patient_tables, event_tables, schema, value_strategies):
             count: ({int}, DomainConstraint.PATIENT),
             is_null: ({bool}, DomainConstraint.ANY),
             not_: ({bool}, DomainConstraint.ANY),
+            year_from_date: ({int}, DomainConstraint.ANY),
+            month_from_date: ({int}, DomainConstraint.ANY),
+            day_from_date: ({int}, DomainConstraint.ANY),
+            to_first_of_year: ({datetime.date}, DomainConstraint.ANY),
+            to_first_of_month: ({datetime.date}, DomainConstraint.ANY),
             negate: ({int, float}, DomainConstraint.ANY),
             eq: ({bool}, DomainConstraint.ANY),
             ne: ({bool}, DomainConstraint.ANY),
@@ -125,6 +130,36 @@ def variable(patient_tables, event_tables, schema, value_strategies):
     def not_(draw, type_, frame):
         return Function.Not(
             draw(series(type_, draw(one_row_per_patient_frame_or(frame))))
+        )
+
+    @st.composite
+    def year_from_date(draw, _type, frame):
+        return Function.YearFromDate(
+            draw(series(datetime.date, draw(one_row_per_patient_frame_or(frame))))
+        )
+
+    @st.composite
+    def month_from_date(draw, _type, frame):
+        return Function.MonthFromDate(
+            draw(series(datetime.date, draw(one_row_per_patient_frame_or(frame))))
+        )
+
+    @st.composite
+    def day_from_date(draw, _type, frame):
+        return Function.DayFromDate(
+            draw(series(datetime.date, draw(one_row_per_patient_frame_or(frame))))
+        )
+
+    @st.composite
+    def to_first_of_year(draw, _type, frame):
+        return Function.ToFirstOfYear(
+            draw(series(datetime.date, draw(one_row_per_patient_frame_or(frame))))
+        )
+
+    @st.composite
+    def to_first_of_month(draw, _type, frame):
+        return Function.ToFirstOfMonth(
+            draw(series(datetime.date, draw(one_row_per_patient_frame_or(frame))))
         )
 
     @st.composite
@@ -276,11 +311,6 @@ known_missing_operations = {
     AggregateByPatient.Sum,
     Function.CastToFloat,
     Function.CastToInt,
-    Function.YearFromDate,
-    Function.MonthFromDate,
-    Function.DayFromDate,
-    Function.ToFirstOfYear,
-    Function.ToFirstOfMonth,
     Function.DateAddYears,
     Function.DateAddMonths,
     Function.DateAddDays,

--- a/tests/generative/variable_strategies.py
+++ b/tests/generative/variable_strategies.py
@@ -93,6 +93,9 @@ def variable(patient_tables, event_tables, schema, value_strategies):
             date_add_years: ({datetime.date}, DomainConstraint.ANY),
             date_add_months: ({datetime.date}, DomainConstraint.ANY),
             date_add_days: ({datetime.date}, DomainConstraint.ANY),
+            date_difference_in_years: ({int}, DomainConstraint.ANY),
+            date_difference_in_months: ({int}, DomainConstraint.ANY),
+            date_difference_in_days: ({int}, DomainConstraint.ANY),
         }
         series_types = series_constraints.keys()
 
@@ -240,6 +243,24 @@ def variable(patient_tables, event_tables, schema, value_strategies):
         )
 
     @st.composite
+    def date_difference_in_years(draw, type_, frame):
+        return draw(
+            binary_operation(datetime.date, frame, Function.DateDifferenceInYears)
+        )
+
+    @st.composite
+    def date_difference_in_months(draw, type_, frame):
+        return draw(
+            binary_operation(datetime.date, frame, Function.DateDifferenceInMonths)
+        )
+
+    @st.composite
+    def date_difference_in_days(draw, type_, frame):
+        return draw(
+            binary_operation(datetime.date, frame, Function.DateDifferenceInDays)
+        )
+
+    @st.composite
     def binary_operation(draw, type_, frame, operator_func):
         # A strategy for operations that take lhs and rhs arguments of the
         # same type
@@ -338,9 +359,6 @@ known_missing_operations = {
     AggregateByPatient.Sum,
     Function.CastToFloat,
     Function.CastToInt,
-    Function.DateDifferenceInYears,
-    Function.DateDifferenceInMonths,
-    Function.DateDifferenceInDays,
 }
 
 

--- a/tests/generative/variable_strategies.py
+++ b/tests/generative/variable_strategies.py
@@ -13,7 +13,6 @@ from databuilder.query_model.nodes import (
     SelectTable,
     Sort,
     Value,
-    node_types,
 )
 from tests.lib.query_model_utils import get_all_operations
 
@@ -313,7 +312,7 @@ def variable(patient_tables, event_tables, schema, value_strategies):
     def valid_variable(draw):
         type_ = draw(any_type())
         frame = draw(one_row_per_patient_frame())
-        return draw(series(type_, frame).filter(uses_the_database))
+        return draw(series(type_, frame))
 
     return valid_variable()
 
@@ -347,11 +346,6 @@ def assert_includes_all_operations(operations):  # pragma: no cover
     assert (
         not unexpected_present
     ), f"unexpectedly seen operations: {[o.__name__ for o in unexpected_present]}"
-
-
-def uses_the_database(v):
-    database_uses = [SelectPatientTable, SelectTable]
-    return any(t in database_uses for t in node_types(v))
 
 
 def is_one_row_per_patient_frame(frame):

--- a/tests/generative/variable_strategies.py
+++ b/tests/generative/variable_strategies.py
@@ -67,7 +67,6 @@ def variable(patient_tables, event_tables, schema, value_strategies):
 
         # Order matters: "simpler" first (see header comment)
         series_constraints = {
-            value: ({int, float, bool, datetime.date}, DomainConstraint.PATIENT),
             select_column: ({int, float, bool, datetime.date}, DomainConstraint.ANY),
             exists: ({bool}, DomainConstraint.PATIENT),
             count: ({int}, DomainConstraint.PATIENT),


### PR DESCRIPTION
Adds:
```
    Function.YearFromDate
    Function.MonthFromDate
    Function.DayFromDate
    Function.ToFirstOfYear
    Function.ToFirstOfMonth
    Function.DateAddYears
    Function.DateAddMonths
    Function.DateAddDays
    Function.DateDifferenceInYears
    Function.DateDifferenceInMonths
    Function.DateDifferenceInDays
```

Also adds a new ignored error for sqlite, which was caused in one of my local runs by a many-nested query of date operations, and fixes the ignored error counting in the test recordings.

Also had to add the suppression of the too-many-filters health check.  It's still passing the comprehensive check with only ~300 examples, and producing around 275 combinations and 190 unique queries.

Fixes #950 