### PR TITLE
fix: Fix dummy data generation for `date_of_death`

### DIFF
--- a/databuilder/dummy_data/generator.py
+++ b/databuilder/dummy_data/generator.py
@@ -173,7 +173,7 @@ class DummyPatientGenerator:
         }
         # Apply any FirstOfMonth constraints
         for key, value in row.items():
-            if key in table_info.columns:
+            if key in table_info.columns and value is not None:
                 if table_info.columns[key].get_constraint(Constraint.FirstOfMonth):
                     row[key] = value.replace(day=1)
         return [row]


### PR DESCRIPTION
When `date_of_death` is None, as it is allowed to be, we shouldn't attempt to apply the `FirstOfMonth` constraint to it.

There's a separate question as to whether this column _ought_ to have this constraint applied: I didn't think these dates were rounded as dates of birth were. But I'll confirm that separately and create another PR if necessary.

Closes #969