### PR TITLE
Implement additional ONS_CIS columns

### DIFF
--- a/databuilder/backends/tpp.py
+++ b/databuilder/backends/tpp.py
@@ -219,5 +219,8 @@ class TPPBackend(BaseBackend):
         source="ONS_CIS_New",
         columns=dict(
             visit_date="visit_date",
+            visit_num="visit_num",
+            nhs_data_share="nhs_data_share",
+            last_linkage_dt="last_linkage_dt",
         ),
     )

--- a/databuilder/backends/tpp.py
+++ b/databuilder/backends/tpp.py
@@ -216,7 +216,7 @@ class TPPBackend(BaseBackend):
     )
 
     ons_cis = MappedTable(
-        source="ONS_CIS",
+        source="ONS_CIS_New",
         columns=dict(
             visit_date="visit_date",
         ),

--- a/databuilder/backends/tpp.py
+++ b/databuilder/backends/tpp.py
@@ -220,7 +220,7 @@ class TPPBackend(BaseBackend):
         columns=dict(
             visit_date="visit_date",
             visit_num="visit_num",
-            nhs_data_share="nhs_data_share",
+            is_opted_out_of_nhs_data_share="nhs_data_share",
             last_linkage_dt="last_linkage_dt",
         ),
     )

--- a/databuilder/tables/beta/tpp.py
+++ b/databuilder/tables/beta/tpp.py
@@ -17,6 +17,7 @@ __all__ = [
     "emergency_care_attendances",
     "hospital_admissions",
     "appointments",
+    "ons_cis",
 ]
 
 
@@ -193,3 +194,6 @@ class ons_cis(EventFrame):
     """
 
     visit_date = Series(datetime.date)
+    visit_num = Series(int)
+    nhs_data_share = Series(int)
+    last_linkage_dt = Series(datetime.date)

--- a/databuilder/tables/beta/tpp.py
+++ b/databuilder/tables/beta/tpp.py
@@ -195,5 +195,5 @@ class ons_cis(EventFrame):
 
     visit_date = Series(datetime.date)
     visit_num = Series(int)
-    nhs_data_share = Series(int)
+    is_opted_out_of_nhs_data_share = Series(bool)
     last_linkage_dt = Series(datetime.date)

--- a/docs/public_docs.json
+++ b/docs/public_docs.json
@@ -721,6 +721,24 @@
               "description": "",
               "type": "date",
               "constraints": []
+            },
+            {
+              "name": "visit_num",
+              "description": "",
+              "type": "int",
+              "constraints": []
+            },
+            {
+              "name": "is_opted_out_of_nhs_data_share",
+              "description": "",
+              "type": "bool",
+              "constraints": []
+            },
+            {
+              "name": "last_linkage_dt",
+              "description": "",
+              "type": "date",
+              "constraints": []
             }
           ]
         },

--- a/tests/integration/backends/test_tpp.py
+++ b/tests/integration/backends/test_tpp.py
@@ -9,7 +9,6 @@ from databuilder.tables.beta import tpp
 from tests.lib.tpp_schema import (
     APCS,
     EC,
-    ONS_CIS,
     APCS_Der,
     Appointment,
     CodedEvent,
@@ -20,6 +19,7 @@ from tests.lib.tpp_schema import (
     HouseholdMember,
     MedicationDictionary,
     MedicationIssue,
+    ONS_CIS_New,
     ONSDeaths,
     Organisation,
     Patient,
@@ -476,7 +476,7 @@ def test_household_memberships_2020(select_all):
 def test_ons_cis(select_all):
     results = select_all(
         Patient(Patient_ID=1),
-        ONS_CIS(
+        ONS_CIS_New(
             Patient_ID=1,
             visit_date=date(2021, 10, 20),
         ),

--- a/tests/integration/backends/test_tpp.py
+++ b/tests/integration/backends/test_tpp.py
@@ -479,12 +479,18 @@ def test_ons_cis(select_all):
         ONS_CIS_New(
             Patient_ID=1,
             visit_date=date(2021, 10, 20),
+            visit_num=1,
+            last_linkage_dt=date(2022, 8, 15),
+            nhs_data_share=1,
         ),
     )
     assert results == [
         {
             "patient_id": 1,
             "visit_date": date(2021, 10, 20),
+            "visit_num": 1,
+            "nhs_data_share": 1,
+            "last_linkage_dt": date(2022, 8, 15),
         },
     ]
 

--- a/tests/integration/backends/test_tpp.py
+++ b/tests/integration/backends/test_tpp.py
@@ -489,7 +489,7 @@ def test_ons_cis(select_all):
             "patient_id": 1,
             "visit_date": date(2021, 10, 20),
             "visit_num": 1,
-            "nhs_data_share": 1,
+            "is_opted_out_of_nhs_data_share": True,
             "last_linkage_dt": date(2022, 8, 15),
         },
     ]

--- a/tests/lib/tpp_schema.py
+++ b/tests/lib/tpp_schema.py
@@ -263,8 +263,8 @@ class Patient(Base):
         back_populates="Patient",
         cascade="all, delete, delete-orphan",
     )
-    ONS_CIS = relationship(
-        "ONS_CIS",
+    ONS_CIS_New = relationship(
+        "ONS_CIS_New",
         back_populates="Patient",
         cascade="all, delete, delete-orphan",
     )
@@ -940,14 +940,14 @@ class Therapeutics(Base):
     Der_LoadDate = Column(String)
 
 
-class ONS_CIS(Base):
-    __tablename__ = "ONS_CIS"
+class ONS_CIS_New(Base):
+    __tablename__ = "ONS_CIS_New"
 
     # fake pk to satisfy the ORM
     pk = Column(Integer, primary_key=True)
 
     Patient_ID = Column(Integer, ForeignKey("Patient.Patient_ID"))
-    Patient = relationship("Patient", back_populates="ONS_CIS")
+    Patient = relationship("Patient", back_populates="ONS_CIS_New")
     visit_date = Column(Date)
 
 

--- a/tests/lib/tpp_schema.py
+++ b/tests/lib/tpp_schema.py
@@ -949,6 +949,9 @@ class ONS_CIS_New(Base):
     Patient_ID = Column(Integer, ForeignKey("Patient.Patient_ID"))
     Patient = relationship("Patient", back_populates="ONS_CIS_New")
     visit_date = Column(Date)
+    visit_num = Column(Integer)
+    nhs_data_share = Column(Integer)
+    last_linkage_dt = Column(Date)
 
 
 class UKRR(Base):


### PR DESCRIPTION
See #972 

- Use ONS_CIS_New table instead of ONS_CIS (ONS_CIS_New should contain the same data as ONS_CIS, but with some additional columns)
- Add the columns that are needed for the ONS mental health study:
    - visit_date
    - visit_num
    - nhs_data_share
    - last_linkage_dt

`nhs_data_share` is an int column in the table, but ONS have confirmed that it can take one of two values, 0 ("opt-in") or 1("opt-out").  The `ons_cis` table is a QueryTable that converts the `nhs_data_share` column to its corresponding label.  This avoids issues with 0 values which actually represent a data value, and makes the output similar to cohort-extractor.  The ONS mental health study will combine ons cis outputs from cohort-extractor and databuilder, so we'll want them to be consistent in the way they output.