### PR TITLE
Notify Slack on generative test failures

### DIFF
--- a/.github/workflows/generative-tests.yml
+++ b/.github/workflows/generative-tests.yml
@@ -22,3 +22,13 @@ jobs:
           GENTEST_DEBUG=t \
           GENTEST_CHECK_IGNORED_ERRORS=t \
           just test-generative
+
+      - name: "Notify Slack on Failure"
+        if: failure()
+        uses: voxmedia/github-action-slack-notify-build@3665186a8c1a022b28a1dbe0954e73aa9081ea9e # v1.6.0
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+        with:
+          channel_id: C03FB777L1M
+          status: "Generative Test Failure"
+          color: danger


### PR DESCRIPTION
I created a new Slack app for this purpose, Data Builder Bot, because I wanted far more limited privileges than Bennett Bot has. I just want to be able to write to channels and not read anything. It's possible that we'll have a more general need for a write-only bot, in which case we can (hopefully) rename this to something less repo-specific.

Closes #957