### PR TITLE
Incorporate mkdocs-opensafely-databuilder into databuilder repo

### DIFF
--- a/.github/workflows/check-docs.yml
+++ b/.github/workflows/check-docs.yml
@@ -21,8 +21,8 @@ jobs:
           python-version: "3.9"
           cache-dependency-path: requirements.*.txt
 
-      - name: Check public docs are up-to-date
-        run: just docs-check-public-docs-are-current
+      - name: Check generated docs are up-to-date
+        run: just docs-check-generated-docs-are-current
 
       - name: Check snippets work
         run: just docs-test

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -293,11 +293,16 @@ Some Data Builder [documentation](https://github.com/opensafely/documentation) i
 See the [spec tests docs](tests/spec/README.md) for further information on writing tests that
 contribute to the ehrQL docs.
 
-An intermediate step generates a JSON file (`public_docs.json`) containing the data needed to generate the documentation.
+An intermediate step generates the markdown files that are included in the documentation.
 
 To generate this file, run:
 
     just generate-docs
+
+This generates the markdown files in `docs/includes/generated_docs`.
+
+Note that it is currently a developer's responsibility to update the generated docs in a PR if required. There
+is a CI step that will check that the documentation is up to date.
 
 ### Updating the main OpenSAFELY documentation repository
 

--- a/Justfile
+++ b/Justfile
@@ -229,7 +229,7 @@ update-external-studies: devenv
     $BIN/python -m tests.acceptance.update_external_studies
 
 docs-serve: devenv generate-docs
-    BACKEND_DOCS_FILE=docs/public_docs.json "$BIN"/mkdocs serve
+    "$BIN"/mkdocs serve
 
 # Run the snippet tests
 docs-test: devenv

--- a/Justfile
+++ b/Justfile
@@ -295,14 +295,16 @@ docs-build-dataset-definitions-outputs-docker-project:
 
 
 # Check the dataset public docs are current
-docs-check-public-docs-are-current: generate-docs
+docs-check-generated-docs-are-current: generate-docs
     #!/usr/bin/env bash
     set -euo pipefail
 
-    if [[ -z $(git diff ./docs/public_docs.json) ]]
+    # https://stackoverflow.com/questions/3878624/how-do-i-programmatically-determine-if-there-are-uncommitted-changes
+    # git diff --exit-code won't pick up untracked files, which we also want to check for.
+    if [[ -z $(git status --porcelain ./docs/includes/generated_docs/; git clean -nd ./docs/includes/generated_docs/) ]]
     then
-      echo "public_docs.json is current."
+      echo "Generated docs directory is current and free of other files/directories."
     else
-      echo "public_docs.json is not current; run `just generate-docs` to update."
+      echo "Generated docs directory contains files/directories not in the repository."
       exit 1
     fi

--- a/Justfile
+++ b/Justfile
@@ -221,14 +221,14 @@ databricks-test *ARGS: devenv databricks-env
     export DATABRICKS_URL="$($BIN/python scripts/dbx url)"
     just test {{ ARGS }}
 
-generate-docs OUTPUT_FILE="docs/public_docs.json": devenv
-    $BIN/python -m databuilder.docs > {{ OUTPUT_FILE }}
-    echo "Generated data for documentation."
+generate-docs OUTPUT_DIR="docs/includes/generated_docs": devenv
+    $BIN/python -m databuilder.docs {{ OUTPUT_DIR }}
+    echo "Generated data for documentation in {{ OUTPUT_DIR }}"
 
 update-external-studies: devenv
     $BIN/python -m tests.acceptance.update_external_studies
 
-docs-serve: devenv
+docs-serve: devenv generate-docs
     BACKEND_DOCS_FILE=docs/public_docs.json "$BIN"/mkdocs serve
 
 # Run the snippet tests

--- a/databuilder/docs/__init__.py
+++ b/databuilder/docs/__init__.py
@@ -2,6 +2,9 @@ import operator
 
 from .backends import build_backends
 from .contracts import build_contracts
+from .render_includes.backends import render_backend
+from .render_includes.contracts import render_contracts
+from .render_includes.specs import render_specs
 from .schemas import build_schemas
 from .specs import build_specs
 
@@ -15,3 +18,17 @@ def generate_docs():
         "contracts": sorted(build_contracts(), key=operator.itemgetter("dotted_path")),
         "specs": build_specs(),
     }
+
+
+def render(docs_data, output_dir):
+    output_dir.mkdir(exist_ok=True, parents=True)
+    with open(output_dir / "contracts.md", "w") as outfile:
+        outfile.write(render_contracts(docs_data["contracts"]))
+
+    backends = docs_data["backends"]
+    for backend_data in backends:
+        with open(output_dir / f"{backend_data['name']}.md", "w") as outfile:
+            outfile.write(render_backend(backend_data))
+
+    with open(output_dir / "specs.md", "w") as outfile:
+        outfile.write(render_specs(docs_data["specs"]))

--- a/databuilder/docs/__main__.py
+++ b/databuilder/docs/__main__.py
@@ -1,6 +1,8 @@
-import json
+import sys
+from pathlib import Path
 
-from . import generate_docs
+from . import generate_docs, render
 
 if __name__ == "__main__":
-    print(json.dumps(generate_docs(), indent=2))
+    output_dir = sys.argv[1]
+    render(generate_docs(), Path(output_dir))

--- a/databuilder/docs/render_includes/backends.py
+++ b/databuilder/docs/render_includes/backends.py
@@ -1,0 +1,23 @@
+backend_template = """
+Contracts implemented:
+
+{contracts}
+
+"""
+
+
+def render_backend(backend_data):
+    contracts = [
+        (c, c.lower().replace("/", "")) for c in sorted(backend_data["contracts"])
+    ]
+    contracts = "\n".join(
+        f"* [`{name}`](contracts-reference.md#{link})" for name, link in contracts
+    )
+
+    return (
+        backend_template.format(
+            name=backend_data["name"],
+            contracts=contracts,
+        ).strip()
+        + "\n"
+    )

--- a/databuilder/docs/render_includes/contracts.py
+++ b/databuilder/docs/render_includes/contracts.py
@@ -1,0 +1,36 @@
+contract_template = """
+## {name}
+
+{docstring}
+
+| Column name | Description | Type | Constraints |
+| ----------- | ----------- | ---- | ----------- |
+{columns}
+
+{backend_support}
+"""
+
+
+def render_contracts(contracts_data):
+    outputs = []
+
+    for contract in contracts_data:
+
+        hierarchy = [h.title() for h in contract["hierarchy"]]
+        name = "/".join([*hierarchy, contract["name"]])
+        docstring = "\n".join(contract["docstring"])
+        columns = "\n".join(
+            f"| {c['name']} | {c['description']} | {c['type']} | {', '.join(c['constraints']).capitalize()}. |"
+            for c in contract["columns"]
+        )
+
+        output = contract_template.format(
+            name=name,
+            docstring=docstring,
+            columns=columns,
+            backend_support="",
+        )
+
+        outputs.append(output)
+
+    return "\n".join(outputs).strip() + "\n"

--- a/databuilder/docs/render_includes/contracts.py
+++ b/databuilder/docs/render_includes/contracts.py
@@ -15,7 +15,6 @@ def render_contracts(contracts_data):
     outputs = []
 
     for contract in contracts_data:
-
         hierarchy = [h.title() for h in contract["hierarchy"]]
         name = "/".join([*hierarchy, contract["name"]])
         docstring = "\n".join(contract["docstring"])

--- a/databuilder/docs/render_includes/specs.py
+++ b/databuilder/docs/render_includes/specs.py
@@ -1,0 +1,92 @@
+chapter_template = """
+## {id} {title}{text}
+"""
+
+section_template = """
+### {id} {title}{text}
+"""
+
+
+paragraph_template = """
+#### {id} {title}{text}
+
+This example makes use of {intro} containing the following data:
+
+{input_tables}
+
+```
+{series}
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+{output_rows}
+
+"""
+
+
+def build_rows(data):
+    # create rows in the form " 1 | 2 | 3"
+    rows = ["|".join(row) for row in data]
+
+    # add leading and trailing pipes
+    rows = [f"| {row} |" for row in rows]
+
+    return rows
+
+
+def iter_input_tables_intro(names):
+    name_lut = {
+        "e": "an event-level",
+        "p": "a patient-level",
+    }
+
+    for name in names:
+        yield f"{name_lut[name]} table named `{name}`"
+
+
+def iter_input_tables(tables):
+    for name, raw_rows in tables.items():
+        rows = build_rows(raw_rows)
+
+        # only create as many columns as the data has
+        columns = len(raw_rows[0])
+        rows.insert(1, f"|{' - |' * columns}")
+
+        yield "\n".join(rows)
+
+
+def render_specs(specs_data):
+    outputs = []
+    for chapter in specs_data:  # 3
+        add_descriptive_text(chapter)
+        output = chapter_template.format(**chapter)
+        outputs.append(output)
+
+        for section in chapter["sections"]:  # 3.1
+            add_descriptive_text(section)
+            output = section_template.format(**section)
+            outputs.append(output)
+
+            for paragraph in section["paragraphs"]:  # 3.1.1
+                intro = " and ".join(
+                    iter_input_tables_intro(paragraph["tables"].keys())
+                )
+                input_tables = "\n\n".join(iter_input_tables(paragraph["tables"]))
+                output_rows = "\n".join(build_rows(paragraph["output"]))
+                add_descriptive_text(paragraph)
+
+                output = paragraph_template.format(
+                    **paragraph,
+                    intro=intro,
+                    input_tables=input_tables,
+                    output_rows=output_rows,
+                )
+                outputs.append(output)
+
+    return "\n".join(outputs).strip() + "\n"
+
+
+def add_descriptive_text(data):
+    data["text"] = "\n" + data["text"] if "text" in data else ""

--- a/docs/contracts/data-backends.md
+++ b/docs/contracts/data-backends.md
@@ -9,12 +9,12 @@ This page lists the OpenSAFELY Contracts implemented by each available
 backend.
 
 ## TPP
-!!! backend:TPPBackend
+---8<-- 'includes/generated_docs/TPPBackend.md'
 
 ## Databricks
-!!! backend:DatabricksBackend
+---8<-- 'includes/generated_docs/DatabricksBackend.md'
 
 ## Graphnet
-!!! backend:GraphnetBackend
+---8<-- 'includes/generated_docs/GraphnetBackend.md'
 
 !!! parent_snippet:'includes/glossary.md'

--- a/docs/contracts/reference.md
+++ b/docs/contracts/reference.md
@@ -6,12 +6,10 @@ This page will be a reference for OpenSAFELY Contracts.
 
 It is likely that much or all of this content will be automatically
 generated from the [Data Builder contracts
-code](https://github.com/opensafely-core/databuilder/tree/main/databuilder/contracts)
-via a [MkDocs
-plugin](https://github.com/opensafely-core/mkdocs-opensafely-backend-contracts).
+code](https://github.com/opensafely-core/databuilder/tree/main/databuilder/contracts).
 
 
-!!! contracts
+---8<-- 'includes/generated_docs/contracts.md'
 
 
 !!! parent_snippet:'includes/glossary.md'

--- a/docs/ehrql/reference.md
+++ b/docs/ehrql/reference.md
@@ -46,6 +46,6 @@ Every example here consists of:
 !!! note
     The examples here are automatically generated from [Data Builder's specification tests](https://github.com/opensafely-core/databuilder/tree/main/tests/spec).
 
-!!! specs
+---8<-- 'includes/generated_docs/specs.md'
 
 !!! parent_snippet:'includes/glossary.md'

--- a/docs/includes/generated_docs/DatabricksBackend.md
+++ b/docs/includes/generated_docs/DatabricksBackend.md
@@ -1,0 +1,1 @@
+Contracts implemented:

--- a/docs/includes/generated_docs/GraphnetBackend.md
+++ b/docs/includes/generated_docs/GraphnetBackend.md
@@ -1,0 +1,1 @@
+Contracts implemented:

--- a/docs/includes/generated_docs/TPPBackend.md
+++ b/docs/includes/generated_docs/TPPBackend.md
@@ -1,0 +1,1 @@
+Contracts implemented:

--- a/docs/includes/generated_docs/contracts.md
+++ b/docs/includes/generated_docs/contracts.md
@@ -1,0 +1,126 @@
+## Universal/patients
+
+
+
+| Column name | Description | Type | Constraints |
+| ----------- | ----------- | ---- | ----------- |
+| date_of_birth | Patient's date of birth, rounded to first of month | date | Must be the first day of a month, must have a value. |
+| sex | Patient's sex | str | Must have a value, must be one of: 'female', 'male', 'intersex', 'unknown'. |
+| date_of_death | Patient's date of death | date | . |
+
+
+
+
+## Wip/clinical_events
+
+TODO.
+
+| Column name | Description | Type | Constraints |
+| ----------- | ----------- | ---- | ----------- |
+| code |  | str | . |
+| system |  | str | . |
+| date |  | date | . |
+| numeric_value |  | float | . |
+
+
+
+
+## Wip/covid_test_results
+
+TODO.
+
+| Column name | Description | Type | Constraints |
+| ----------- | ----------- | ---- | ----------- |
+| date |  | date | . |
+| positive_result |  | bool | . |
+
+
+
+
+## Wip/hospital_admissions
+
+TODO.
+
+| Column name | Description | Type | Constraints |
+| ----------- | ----------- | ---- | ----------- |
+| admission_date |  | date | . |
+| primary_diagnosis |  | str | . |
+| admission_method |  | int | . |
+| episode_is_finished |  | bool | . |
+| spell_id |  | int | . |
+
+
+
+
+## Wip/hospitalisations
+
+TODO.
+
+| Column name | Description | Type | Constraints |
+| ----------- | ----------- | ---- | ----------- |
+| date |  | date | . |
+| code |  | str | . |
+| system |  | str | . |
+
+
+
+
+## Wip/hospitalisations_without_system
+
+TODO.
+
+| Column name | Description | Type | Constraints |
+| ----------- | ----------- | ---- | ----------- |
+| code |  | str | . |
+
+
+
+
+## Wip/patient_address
+
+TODO.
+
+| Column name | Description | Type | Constraints |
+| ----------- | ----------- | ---- | ----------- |
+| patientaddress_id |  | int | . |
+| date_start |  | date | . |
+| date_end |  | date | . |
+| index_of_multiple_deprivation_rounded |  | int | . |
+| has_postcode |  | bool | . |
+
+
+
+
+## Wip/patients
+
+TODO.
+
+| Column name | Description | Type | Constraints |
+| ----------- | ----------- | ---- | ----------- |
+| date_of_birth |  | date | . |
+
+
+
+
+## Wip/practice_registrations
+
+TODO.
+
+| Column name | Description | Type | Constraints |
+| ----------- | ----------- | ---- | ----------- |
+| pseudo_id |  | int | . |
+| nuts1_region_name |  | str | . |
+| date_start |  | date | . |
+| date_end |  | date | . |
+
+
+
+
+## Wip/prescriptions
+
+TODO.
+
+| Column name | Description | Type | Constraints |
+| ----------- | ----------- | ---- | ----------- |
+| prescribed_dmd_code |  | str | . |
+| processing_date |  | date | . |

--- a/docs/includes/generated_docs/specs.md
+++ b/docs/includes/generated_docs/specs.md
@@ -1,0 +1,2607 @@
+## 1 Filtering an event frame
+
+
+### 1.1 Including rows
+
+
+#### 1.1.1 Take with column
+
+This example makes use of an event-level table named `e` containing the following data:
+
+| patient|i1|b1 |
+| - | - | - |
+| 1|101|T |
+| 1|102|T |
+| 1|103| |
+| 2|201|T |
+| 2|202| |
+| 2|203|F |
+| 3|301| |
+| 3|302|F |
+
+```
+e.take(e.b1).i1.sum_for_patient()
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|203 |
+| 2|201 |
+| 3| |
+
+
+
+#### 1.1.2 Take with expr
+
+This example makes use of an event-level table named `e` containing the following data:
+
+| patient|i1|i2 |
+| - | - | - |
+| 1|101|111 |
+| 1|102|112 |
+| 1|103|113 |
+| 2|201|211 |
+| 2|202|212 |
+| 2|203|213 |
+| 3|301| |
+
+```
+e.take((e.i1 + e.i2) < 413).i1.sum_for_patient()
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|306 |
+| 2|201 |
+| 3| |
+
+
+
+#### 1.1.3 Take with constant true
+
+This example makes use of an event-level table named `e` containing the following data:
+
+| patient|i1 |
+| - | - |
+| 1|101 |
+| 1|102 |
+| 2|201 |
+
+```
+e.take(True).count_for_patient()
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|2 |
+| 2|1 |
+
+
+
+#### 1.1.4 Take with constant false
+
+This example makes use of an event-level table named `e` containing the following data:
+
+| patient|i1 |
+| - | - |
+| 1|101 |
+| 1|102 |
+| 2|201 |
+
+```
+e.take(False).count_for_patient()
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|0 |
+| 2|0 |
+
+
+
+#### 1.1.5 Chain multiple takes
+
+This example makes use of an event-level table named `e` containing the following data:
+
+| patient|i1|b1 |
+| - | - | - |
+| 1|1|T |
+| 1|2|T |
+| 1|3|F |
+
+```
+e.take(e.i1 >= 2).take(e.b1).i1.sum_for_patient()
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|2 |
+
+
+
+### 1.2 Excluding rows
+
+
+#### 1.2.1 Drop with column
+
+This example makes use of an event-level table named `e` containing the following data:
+
+| patient|i1|b1 |
+| - | - | - |
+| 1|101|T |
+| 1|102|T |
+| 1|103| |
+| 2|201|T |
+| 2|202| |
+| 2|203|F |
+| 3|301|T |
+| 3|302|T |
+
+```
+e.drop(e.b1).i1.sum_for_patient()
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|103 |
+| 2|405 |
+| 3| |
+
+
+
+#### 1.2.2 Drop with expr
+
+This example makes use of an event-level table named `e` containing the following data:
+
+| patient|i1|i2 |
+| - | - | - |
+| 1|101|111 |
+| 1|102|112 |
+| 1|103|113 |
+| 2|201|211 |
+| 2|202|212 |
+| 2|203|213 |
+| 3|301| |
+
+```
+e.drop((e.i1 + e.i2) < 413).i1.sum_for_patient()
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1| |
+| 2|405 |
+| 3|301 |
+
+
+
+#### 1.2.3 Drop with constant true
+
+This example makes use of an event-level table named `e` containing the following data:
+
+| patient|i1 |
+| - | - |
+| 1|101 |
+| 1|102 |
+| 2|201 |
+
+```
+e.drop(True).count_for_patient()
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|0 |
+| 2|0 |
+
+
+
+#### 1.2.4 Drop with constant false
+
+This example makes use of an event-level table named `e` containing the following data:
+
+| patient|i1 |
+| - | - |
+| 1|101 |
+| 1|102 |
+| 2|201 |
+
+```
+e.drop(False).count_for_patient()
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|2 |
+| 2|1 |
+
+
+
+## 2 Picking one row for each patient from an event frame
+
+
+### 2.1 Picking the first or last row for each patient
+
+
+#### 2.1.1 Sort by column pick first
+
+This example makes use of an event-level table named `e` containing the following data:
+
+| patient|i1 |
+| - | - |
+| 1|101 |
+| 1|102 |
+| 1|103 |
+| 2|203 |
+| 2|202 |
+| 2|201 |
+
+```
+e.sort_by(e.i1).first_for_patient().i1
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|101 |
+| 2|201 |
+
+
+
+#### 2.1.2 Sort by column pick last
+
+This example makes use of an event-level table named `e` containing the following data:
+
+| patient|i1 |
+| - | - |
+| 1|101 |
+| 1|102 |
+| 1|103 |
+| 2|203 |
+| 2|202 |
+| 2|201 |
+
+```
+e.sort_by(e.i1).last_for_patient().i1
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|103 |
+| 2|203 |
+
+
+
+### 2.2 Sort by more than one column and pick the first or last row for each patient
+
+
+#### 2.2.1 Sort by multiple columns pick first
+
+This example makes use of an event-level table named `e` containing the following data:
+
+| patient|i1|i2 |
+| - | - | - |
+| 1|101|3 |
+| 1|102|2 |
+| 1|102|1 |
+| 2|203|1 |
+| 2|202|2 |
+| 2|202|3 |
+
+```
+e.sort_by(e.i1, e.i2).first_for_patient().i2
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|3 |
+| 2|2 |
+
+
+
+#### 2.2.2 Sort by multiple columns pick last
+
+This example makes use of an event-level table named `e` containing the following data:
+
+| patient|i1|i2 |
+| - | - | - |
+| 1|101|3 |
+| 1|102|2 |
+| 1|102|1 |
+| 2|203|1 |
+| 2|202|2 |
+| 2|202|3 |
+
+```
+e.sort_by(e.i1, e.i2).last_for_patient().i2
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|2 |
+| 2|1 |
+
+
+
+### 2.3 Picking the first or last row for each patient where a column contains NULLs
+
+
+#### 2.3.1 Sort by column with nulls and pick first
+
+This example makes use of an event-level table named `e` containing the following data:
+
+| patient|i1 |
+| - | - |
+| 1| |
+| 1|102 |
+| 1|103 |
+| 2|203 |
+| 2|202 |
+| 2| |
+
+```
+e.sort_by(e.i1).first_for_patient().i1
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1| |
+| 2| |
+
+
+
+#### 2.3.2 Sort by column with nulls and pick last
+
+This example makes use of an event-level table named `e` containing the following data:
+
+| patient|i1 |
+| - | - |
+| 1| |
+| 1|102 |
+| 1|103 |
+| 2|203 |
+| 2|202 |
+| 2| |
+
+```
+e.sort_by(e.i1).last_for_patient().i1
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|103 |
+| 2|203 |
+
+
+
+## 3 Aggregating event and patient frames
+
+
+### 3.1 Determining whether a row exists for each patient
+
+
+#### 3.1.1 Exists for patient on event frame
+
+This example makes use of a patient-level table named `p` and an event-level table named `e` containing the following data:
+
+| patient|b1 |
+| - | - |
+| 1| |
+| 2| |
+| 3| |
+
+| patient|b1 |
+| - | - |
+| 1| |
+| 1| |
+| 2| |
+
+```
+e.exists_for_patient()
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|T |
+| 2|T |
+| 3|F |
+
+
+
+#### 3.1.2 Exists for patient on patient frame
+
+This example makes use of a patient-level table named `p` and an event-level table named `e` containing the following data:
+
+| patient|b1 |
+| - | - |
+| 1| |
+| 2| |
+| 3| |
+
+| patient|b1 |
+| - | - |
+| 1| |
+| 1| |
+| 2| |
+
+```
+p.exists_for_patient()
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|T |
+| 2|T |
+| 3|T |
+
+
+
+### 3.2 Counting the rows for each patient
+
+
+#### 3.2.1 Count for patient on event frame
+
+This example makes use of a patient-level table named `p` and an event-level table named `e` containing the following data:
+
+| patient|b1 |
+| - | - |
+| 1| |
+| 2| |
+| 3| |
+
+| patient|b1 |
+| - | - |
+| 1| |
+| 1| |
+| 2| |
+
+```
+e.count_for_patient()
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|2 |
+| 2|1 |
+| 3|0 |
+
+
+
+#### 3.2.2 Count for patient on patient frame
+
+This example makes use of a patient-level table named `p` and an event-level table named `e` containing the following data:
+
+| patient|b1 |
+| - | - |
+| 1| |
+| 2| |
+| 3| |
+
+| patient|b1 |
+| - | - |
+| 1| |
+| 1| |
+| 2| |
+
+```
+p.count_for_patient()
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|1 |
+| 2|1 |
+| 3|1 |
+
+
+
+## 4 Aggregating event series
+
+
+### 4.1 Minimum and maximum aggregations
+
+
+#### 4.1.1 Minimum for patient
+
+This example makes use of an event-level table named `e` containing the following data:
+
+| patient|i1 |
+| - | - |
+| 1|101 |
+| 1|102 |
+| 1|103 |
+| 2|201 |
+| 2| |
+| 3| |
+
+```
+e.i1.minimum_for_patient()
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|101 |
+| 2|201 |
+| 3| |
+
+
+
+#### 4.1.2 Maximum for patient
+
+This example makes use of an event-level table named `e` containing the following data:
+
+| patient|i1 |
+| - | - |
+| 1|101 |
+| 1|102 |
+| 1|103 |
+| 2|201 |
+| 2| |
+| 3| |
+
+```
+e.i1.maximum_for_patient()
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|103 |
+| 2|201 |
+| 3| |
+
+
+
+### 4.2 Sum aggregation
+
+
+#### 4.2.1 Sum for patient
+
+This example makes use of an event-level table named `e` containing the following data:
+
+| patient|i1 |
+| - | - |
+| 1|101 |
+| 1|102 |
+| 1|103 |
+| 2|201 |
+| 2| |
+| 2|203 |
+| 3| |
+
+```
+e.i1.sum_for_patient()
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|306 |
+| 2|404 |
+| 3| |
+
+
+
+## 5 Combining series
+
+
+### 5.1 Combining two patient series
+
+
+#### 5.1.1 Patient series and patient series
+
+This example makes use of a patient-level table named `p` containing the following data:
+
+| patient|i1|i2 |
+| - | - | - |
+| 1|101|102 |
+| 2|201|202 |
+
+```
+p.i1 + p.i2
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|203 |
+| 2|403 |
+
+
+
+### 5.2 Combining a patient series with a value
+
+
+#### 5.2.1 Patient series and value
+
+This example makes use of a patient-level table named `p` containing the following data:
+
+| patient|i1 |
+| - | - |
+| 1|101 |
+| 2|201 |
+
+```
+p.i1 + 1
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|102 |
+| 2|202 |
+
+
+
+#### 5.2.2 Value and patient series
+
+This example makes use of a patient-level table named `p` containing the following data:
+
+| patient|i1 |
+| - | - |
+| 1|101 |
+| 2|201 |
+
+```
+1 + p.i1
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|102 |
+| 2|202 |
+
+
+
+### 5.3 Combining two event series
+
+
+#### 5.3.1 Event series and event series
+
+This example makes use of an event-level table named `e` containing the following data:
+
+| patient|i1|i2|s1 |
+| - | - | - | - |
+| 1|101|111|b |
+| 1|102|112|a |
+| 2|201|211|b |
+| 2|202|212|a |
+
+```
+(e.i1 + e.i2).sum_for_patient()
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|426 |
+| 2|826 |
+
+
+
+#### 5.3.2 Event series and sorted event series
+The sort order of the underlying event series does not affect their combination.
+
+This example makes use of an event-level table named `e` containing the following data:
+
+| patient|i1|i2|s1 |
+| - | - | - | - |
+| 1|101|111|b |
+| 1|102|112|a |
+| 2|201|211|b |
+| 2|202|212|a |
+
+```
+(e.i1 + e.sort_by(e.s1).i2).minimum_for_patient()
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|212 |
+| 2|412 |
+
+
+
+### 5.4 Combining an event series with a patient series
+
+
+#### 5.4.1 Event series and patient series
+
+This example makes use of a patient-level table named `p` and an event-level table named `e` containing the following data:
+
+| patient|i1 |
+| - | - |
+| 1|101 |
+| 2|201 |
+
+| patient|i1 |
+| - | - |
+| 1|111 |
+| 1|112 |
+| 2|211 |
+| 2|212 |
+
+```
+(e.i1 + p.i1).sum_for_patient()
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|425 |
+| 2|825 |
+
+
+
+#### 5.4.2 Patient series and event series
+
+This example makes use of a patient-level table named `p` and an event-level table named `e` containing the following data:
+
+| patient|i1 |
+| - | - |
+| 1|101 |
+| 2|201 |
+
+| patient|i1 |
+| - | - |
+| 1|111 |
+| 1|112 |
+| 2|211 |
+| 2|212 |
+
+```
+(p.i1 + e.i1).sum_for_patient()
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|425 |
+| 2|825 |
+
+
+
+### 5.5 Combining an event series with a value
+
+
+#### 5.5.1 Event series and value
+
+This example makes use of an event-level table named `e` containing the following data:
+
+| patient|i1 |
+| - | - |
+| 1|101 |
+| 1|102 |
+| 2|201 |
+| 2|202 |
+
+```
+(e.i1 + 1).sum_for_patient()
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|205 |
+| 2|405 |
+
+
+
+#### 5.5.2 Value and event series
+
+This example makes use of an event-level table named `e` containing the following data:
+
+| patient|i1 |
+| - | - |
+| 1|101 |
+| 1|102 |
+| 2|201 |
+| 2|202 |
+
+```
+(1 + e.i1).sum_for_patient()
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|205 |
+| 2|405 |
+
+
+
+## 6 Operations on all series
+
+
+### 6.1 Testing for equality
+
+
+#### 6.1.1 Equals
+
+This example makes use of a patient-level table named `p` containing the following data:
+
+| patient|i1|i2 |
+| - | - | - |
+| 1|101|101 |
+| 2|201|202 |
+| 3|301| |
+| 4|| |
+
+```
+p.i1 == p.i2
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|T |
+| 2|F |
+| 3| |
+| 4| |
+
+
+
+#### 6.1.2 Not equals
+
+This example makes use of a patient-level table named `p` containing the following data:
+
+| patient|i1|i2 |
+| - | - | - |
+| 1|101|101 |
+| 2|201|202 |
+| 3|301| |
+| 4|| |
+
+```
+p.i1 != p.i2
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|F |
+| 2|T |
+| 3| |
+| 4| |
+
+
+
+#### 6.1.3 Is null
+
+This example makes use of a patient-level table named `p` containing the following data:
+
+| patient|i1|i2 |
+| - | - | - |
+| 1|101|101 |
+| 2|201|202 |
+| 3|301| |
+| 4|| |
+
+```
+p.i1.is_null()
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|F |
+| 2|F |
+| 3|F |
+| 4|T |
+
+
+
+#### 6.1.4 Is not null
+
+This example makes use of a patient-level table named `p` containing the following data:
+
+| patient|i1|i2 |
+| - | - | - |
+| 1|101|101 |
+| 2|201|202 |
+| 3|301| |
+| 4|| |
+
+```
+p.i1.is_not_null()
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|T |
+| 2|T |
+| 3|T |
+| 4|F |
+
+
+
+### 6.2 Testing for containment
+
+
+#### 6.2.1 Is in
+
+This example makes use of a patient-level table named `p` containing the following data:
+
+| patient|i1 |
+| - | - |
+| 1|101 |
+| 2|201 |
+| 3|301 |
+| 4| |
+
+```
+p.i1.is_in([101, 301])
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|T |
+| 2|F |
+| 3|T |
+| 4| |
+
+
+
+#### 6.2.2 Is not in
+
+This example makes use of a patient-level table named `p` containing the following data:
+
+| patient|i1 |
+| - | - |
+| 1|101 |
+| 2|201 |
+| 3|301 |
+| 4| |
+
+```
+p.i1.is_not_in([101, 301])
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|F |
+| 2|T |
+| 3|F |
+| 4| |
+
+
+
+### 6.3 Map from one set of values to another
+
+
+#### 6.3.1 Map values
+
+This example makes use of a patient-level table named `p` containing the following data:
+
+| patient|i1 |
+| - | - |
+| 1|101 |
+| 2|201 |
+| 3|301 |
+| 4| |
+
+```
+p.i1.map_values({101: "a", 201: "b", 301: "a"}, default="c")
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|a |
+| 2|b |
+| 3|a |
+| 4|c |
+
+
+
+### 6.4 Replace missing values
+
+
+#### 6.4.1 If null then integer column
+
+This example makes use of a patient-level table named `p` containing the following data:
+
+| patient|i1 |
+| - | - |
+| 1|101 |
+| 2|201 |
+| 3|301 |
+| 4| |
+
+```
+p.i1.if_null_then(0)
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|101 |
+| 2|201 |
+| 3|301 |
+| 4|0 |
+
+
+
+#### 6.4.2 If null then boolean column
+
+This example makes use of a patient-level table named `p` containing the following data:
+
+| patient|i1 |
+| - | - |
+| 1|101 |
+| 2|201 |
+| 3|301 |
+| 4| |
+
+```
+p.i1.is_in([101, 201]).if_null_then(False)
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|T |
+| 2|T |
+| 3|F |
+| 4|F |
+
+
+
+## 7 Operations on boolean series
+
+
+### 7.1 Logical operations
+
+
+#### 7.1.1 Not
+
+This example makes use of a patient-level table named `p` containing the following data:
+
+| patient|b1 |
+| - | - |
+| 1|T |
+| 2| |
+| 3|F |
+
+```
+~p.b1
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|F |
+| 2| |
+| 3|T |
+
+
+
+#### 7.1.2 And
+
+This example makes use of a patient-level table named `p` containing the following data:
+
+| patient|b1|b2 |
+| - | - | - |
+| 1|T|T |
+| 2|T| |
+| 3|T|F |
+| 4||T |
+| 5|| |
+| 6||F |
+| 7|F|T |
+| 8|F| |
+| 9|F|F |
+
+```
+p.b1 & p.b2
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|T |
+| 2| |
+| 3|F |
+| 4| |
+| 5| |
+| 6|F |
+| 7|F |
+| 8|F |
+| 9|F |
+
+
+
+#### 7.1.3 Or
+
+This example makes use of a patient-level table named `p` containing the following data:
+
+| patient|b1|b2 |
+| - | - | - |
+| 1|T|T |
+| 2|T| |
+| 3|T|F |
+| 4||T |
+| 5|| |
+| 6||F |
+| 7|F|T |
+| 8|F| |
+| 9|F|F |
+
+```
+p.b1 | p.b2
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|T |
+| 2|T |
+| 3|T |
+| 4|T |
+| 5| |
+| 6| |
+| 7|T |
+| 8| |
+| 9|F |
+
+
+
+## 8 Operations on integer series
+
+
+### 8.1 Arithmetic operations
+
+
+#### 8.1.1 Negate
+
+This example makes use of a patient-level table named `p` containing the following data:
+
+| patient|i1|i2 |
+| - | - | - |
+| 1|101|111 |
+| 2|201| |
+
+```
+-p.i2
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|-111 |
+| 2| |
+
+
+
+#### 8.1.2 Add
+
+This example makes use of a patient-level table named `p` containing the following data:
+
+| patient|i1|i2 |
+| - | - | - |
+| 1|101|111 |
+| 2|201| |
+
+```
+p.i1 + p.i2
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|212 |
+| 2| |
+
+
+
+#### 8.1.3 Subtract
+
+This example makes use of a patient-level table named `p` containing the following data:
+
+| patient|i1|i2 |
+| - | - | - |
+| 1|101|111 |
+| 2|201| |
+
+```
+p.i1 - p.i2
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|-10 |
+| 2| |
+
+
+
+#### 8.1.4 Multiply
+
+This example makes use of a patient-level table named `p` containing the following data:
+
+| patient|i1|i2 |
+| - | - | - |
+| 1|101|111 |
+| 2|201| |
+
+```
+p.i1 * p.i2
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|11211 |
+| 2| |
+
+
+
+#### 8.1.5 Multiply with constant
+
+This example makes use of a patient-level table named `p` containing the following data:
+
+| patient|i1|i2 |
+| - | - | - |
+| 1|101|111 |
+| 2|201| |
+
+```
+10 * p.i2
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|1110 |
+| 2| |
+
+
+
+### 8.2 Comparison operations
+
+
+#### 8.2.1 Less than
+
+This example makes use of a patient-level table named `p` containing the following data:
+
+| patient|i1|i2 |
+| - | - | - |
+| 1|101|201 |
+| 2|201|201 |
+| 3|301|201 |
+| 4||201 |
+
+```
+p.i1 < p.i2
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|T |
+| 2|F |
+| 3|F |
+| 4| |
+
+
+
+#### 8.2.2 Less than or equal to
+
+This example makes use of a patient-level table named `p` containing the following data:
+
+| patient|i1|i2 |
+| - | - | - |
+| 1|101|201 |
+| 2|201|201 |
+| 3|301|201 |
+| 4||201 |
+
+```
+p.i1 <= p.i2
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|T |
+| 2|T |
+| 3|F |
+| 4| |
+
+
+
+#### 8.2.3 Greater than
+
+This example makes use of a patient-level table named `p` containing the following data:
+
+| patient|i1|i2 |
+| - | - | - |
+| 1|101|201 |
+| 2|201|201 |
+| 3|301|201 |
+| 4||201 |
+
+```
+p.i1 > p.i2
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|F |
+| 2|F |
+| 3|T |
+| 4| |
+
+
+
+#### 8.2.4 Greater than or equal to
+
+This example makes use of a patient-level table named `p` containing the following data:
+
+| patient|i1|i2 |
+| - | - | - |
+| 1|101|201 |
+| 2|201|201 |
+| 3|301|201 |
+| 4||201 |
+
+```
+p.i1 >= p.i2
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|F |
+| 2|T |
+| 3|T |
+| 4| |
+
+
+
+## 9 Operations on all series containing codes
+
+
+### 9.1 Testing for containment using codes
+
+
+#### 9.1.1 Is in
+
+This example makes use of a patient-level table named `p` containing the following data:
+
+| patient|c1 |
+| - | - |
+| 1|abc |
+| 2|def |
+| 3|ghi |
+| 4| |
+
+```
+p.c1.is_in([SNOMEDCTCode("abc"), SNOMEDCTCode("ghi")])
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|T |
+| 2|F |
+| 3|T |
+| 4| |
+
+
+
+#### 9.1.2 Is not in
+
+This example makes use of a patient-level table named `p` containing the following data:
+
+| patient|c1 |
+| - | - |
+| 1|abc |
+| 2|def |
+| 3|ghi |
+| 4| |
+
+```
+p.c1.is_not_in([SNOMEDCTCode("abc"), SNOMEDCTCode("ghi")])
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|F |
+| 2|T |
+| 3|F |
+| 4| |
+
+
+
+#### 9.1.3 Is in codelist csv
+
+This example makes use of a patient-level table named `p` containing the following data:
+
+| patient|c1 |
+| - | - |
+| 1|abc |
+| 2|def |
+| 3|ghi |
+| 4| |
+
+```
+p.c1.is_in(codelist)
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|T |
+| 2|F |
+| 3|T |
+| 4| |
+
+
+
+### 9.2 Test mapping codes to categories using a categorised codelist
+
+
+#### 9.2.1 Map codes to categories
+
+This example makes use of a patient-level table named `p` containing the following data:
+
+| patient|c1 |
+| - | - |
+| 1|abc |
+| 2|def |
+| 3|ghi |
+| 4| |
+
+```
+p.c1.to_category(codelist.my_categorisation)
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|cat1 |
+| 2| |
+| 3|cat2 |
+| 4| |
+
+
+
+## 10 Logical case expressions
+
+
+### 10.1 Logical case expressions
+
+
+#### 10.1.1 Case with expression
+
+This example makes use of a patient-level table named `p` containing the following data:
+
+| patient|i1 |
+| - | - |
+| 1|6 |
+| 2|7 |
+| 3|8 |
+| 4|9 |
+| 5| |
+
+```
+case(
+    when(p.i1 < 8).then(p.i1),
+    when(p.i1 > 8).then(100),
+)
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|6 |
+| 2|7 |
+| 3| |
+| 4|100 |
+| 5| |
+
+
+
+#### 10.1.2 Case with default
+
+This example makes use of a patient-level table named `p` containing the following data:
+
+| patient|i1 |
+| - | - |
+| 1|6 |
+| 2|7 |
+| 3|8 |
+| 4|9 |
+| 5| |
+
+```
+case(
+    when(p.i1 < 8).then(p.i1),
+    when(p.i1 > 8).then(100),
+    default=0,
+)
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|6 |
+| 2|7 |
+| 3|0 |
+| 4|100 |
+| 5|0 |
+
+
+
+#### 10.1.3 Case with boolean column
+
+This example makes use of a patient-level table named `p` containing the following data:
+
+| patient|i1|b1 |
+| - | - | - |
+| 1|6|T |
+| 2|7|F |
+| 3|9|F |
+| 4| |
+
+```
+case(
+    when(p.b1).then(p.i1),
+    when(p.i1 > 8).then(100),
+)
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|6 |
+| 2| |
+| 3|100 |
+| 4| |
+
+
+
+## 11 Operations on all series containing dates
+
+
+### 11.1 Operations which apply to all series containing dates
+
+
+#### 11.1.1 Get year
+
+This example makes use of a patient-level table named `p` containing the following data:
+
+| patient|d1|i1 |
+| - | - | - |
+| 1|1990-01-02|100 |
+| 2|2000-03-04|200 |
+| 3|| |
+
+```
+p.d1.year
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|1990 |
+| 2|2000 |
+| 3| |
+
+
+
+#### 11.1.2 Get month
+
+This example makes use of a patient-level table named `p` containing the following data:
+
+| patient|d1|i1 |
+| - | - | - |
+| 1|1990-01-02|100 |
+| 2|2000-03-04|200 |
+| 3|| |
+
+```
+p.d1.month
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|1 |
+| 2|3 |
+| 3| |
+
+
+
+#### 11.1.3 Get day
+
+This example makes use of a patient-level table named `p` containing the following data:
+
+| patient|d1|i1 |
+| - | - | - |
+| 1|1990-01-02|100 |
+| 2|2000-03-04|200 |
+| 3|| |
+
+```
+p.d1.day
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|2 |
+| 2|4 |
+| 3| |
+
+
+
+#### 11.1.4 To first of year
+
+This example makes use of a patient-level table named `p` containing the following data:
+
+| patient|d1 |
+| - | - |
+| 1|1990-01-01 |
+| 2|2000-12-15 |
+| 3|2020-12-31 |
+| 4| |
+
+```
+p.d1.to_first_of_year()
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|1990-01-01 |
+| 2|2000-01-01 |
+| 3|2020-01-01 |
+| 4| |
+
+
+
+#### 11.1.5 To first of month
+
+This example makes use of a patient-level table named `p` containing the following data:
+
+| patient|d1 |
+| - | - |
+| 1|1990-01-01 |
+| 2|1990-01-31 |
+| 3| |
+
+```
+p.d1.to_first_of_month()
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|1990-01-01 |
+| 2|1990-01-01 |
+| 3| |
+
+
+
+#### 11.1.6 Add days
+
+This example makes use of a patient-level table named `p` containing the following data:
+
+| patient|d1|i1 |
+| - | - | - |
+| 1|1990-01-02|100 |
+| 2|2000-03-04|200 |
+| 3|| |
+
+```
+p.d1 + days(p.i1)
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|1990-04-12 |
+| 2|2000-09-20 |
+| 3| |
+
+
+
+#### 11.1.7 Subtract days
+
+This example makes use of a patient-level table named `p` containing the following data:
+
+| patient|d1|i1 |
+| - | - | - |
+| 1|1990-01-02|100 |
+| 2|2000-03-04|200 |
+| 3|| |
+
+```
+p.d1 - days(p.i1)
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|1989-09-24 |
+| 2|1999-08-17 |
+| 3| |
+
+
+
+#### 11.1.8 Add months
+
+This example makes use of a patient-level table named `p` containing the following data:
+
+| patient|d1|i1 |
+| - | - | - |
+| 1|2003-01-29|1 |
+| 2|2004-01-29|1 |
+| 3|2003-01-31|1 |
+| 4|2004-01-31|1 |
+| 5|2004-03-31|-1 |
+| 6|2000-10-31|11 |
+| 7|2000-10-31|-11 |
+
+```
+p.d1 + months(p.i1)
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|2003-03-01 |
+| 2|2004-02-29 |
+| 3|2003-03-01 |
+| 4|2004-03-01 |
+| 5|2004-03-01 |
+| 6|2001-10-01 |
+| 7|1999-12-01 |
+
+
+
+#### 11.1.9 Add years
+
+This example makes use of a patient-level table named `p` containing the following data:
+
+| patient|d1|i1 |
+| - | - | - |
+| 1|2000-06-15|5 |
+| 2|2000-06-15|-5 |
+| 3|2004-02-29|1 |
+| 4|2004-02-29|-1 |
+| 5|2004-02-29|4 |
+| 6|2004-02-29|-4 |
+| 7|2003-03-01|1 |
+
+```
+p.d1 + years(p.i1)
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|2005-06-15 |
+| 2|1995-06-15 |
+| 3|2005-03-01 |
+| 4|2003-03-01 |
+| 5|2008-02-29 |
+| 6|2000-02-29 |
+| 7|2004-03-01 |
+
+
+
+#### 11.1.10 Add date to duration
+
+This example makes use of a patient-level table named `p` containing the following data:
+
+| patient|d1|i1 |
+| - | - | - |
+| 1|1990-01-02|100 |
+| 2|2000-03-04|200 |
+| 3|| |
+
+```
+days(100) + p.d1
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|1990-04-12 |
+| 2|2000-06-12 |
+| 3| |
+
+
+
+#### 11.1.11 Difference between dates in years
+
+This example makes use of a patient-level table named `p` containing the following data:
+
+| patient|d1 |
+| - | - |
+| 1|2020-02-29 |
+| 2|2020-02-28 |
+| 3|2019-01-01 |
+| 4|2021-03-01 |
+| 5|2023-01-01 |
+| 6| |
+
+```
+(date(2021, 2, 28) - p.d1).years
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|0 |
+| 2|1 |
+| 3|2 |
+| 4|-1 |
+| 5|-2 |
+| 6| |
+
+
+
+#### 11.1.12 Difference between dates in months
+
+This example makes use of a patient-level table named `p` containing the following data:
+
+| patient|d1|d2 |
+| - | - | - |
+| 1|2000-02-28|2000-01-30 |
+| 2|2000-03-01|2000-01-30 |
+| 3|2000-03-28|2000-02-28 |
+| 4|2000-03-30|2000-01-30 |
+| 5|2000-02-27|2000-01-30 |
+| 6|2000-01-27|2000-01-30 |
+| 7|1999-12-26|2000-01-27 |
+| 8|2005-02-28|2004-02-29 |
+| 9|2010-01-01|2000-01-01 |
+| 10|2000-01-01| |
+
+```
+(p.d1 - p.d2).months
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|0 |
+| 2|1 |
+| 3|1 |
+| 4|2 |
+| 5|0 |
+| 6|-1 |
+| 7|-2 |
+| 8|11 |
+| 9|120 |
+| 10| |
+
+
+
+#### 11.1.13 Difference between dates in days
+
+This example makes use of a patient-level table named `p` containing the following data:
+
+| patient|d1|d2 |
+| - | - | - |
+| 1|2000-01-01|2000-01-01 |
+| 2|2000-03-01|2000-01-01 |
+| 3|2001-03-01|2001-01-01 |
+| 4|1999-12-31|2001-01-01 |
+
+```
+(p.d1 - p.d2).days
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|0 |
+| 2|60 |
+| 3|59 |
+| 4|-367 |
+
+
+
+#### 11.1.14 Reversed date differences
+
+This example makes use of a patient-level table named `p` containing the following data:
+
+| patient|d1 |
+| - | - |
+| 1|1990-01-30 |
+| 2|1970-01-15 |
+
+```
+(p.d1 - "1980-01-20").years
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|10 |
+| 2|-11 |
+
+
+
+#### 11.1.15 Add days to static date
+
+This example makes use of a patient-level table named `p` containing the following data:
+
+| patient|i1 |
+| - | - |
+| 1|10 |
+| 2|-10 |
+
+```
+date(2000, 1, 1) + days(p.i1)
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|2000-01-11 |
+| 2|1999-12-22 |
+
+
+
+#### 11.1.16 Add months to static date
+
+This example makes use of a patient-level table named `p` containing the following data:
+
+| patient|i1 |
+| - | - |
+| 1|10 |
+| 2|-10 |
+
+```
+date(2000, 1, 1) + months(p.i1)
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|2000-11-01 |
+| 2|1999-03-01 |
+
+
+
+#### 11.1.17 Add years to static date
+
+This example makes use of a patient-level table named `p` containing the following data:
+
+| patient|i1 |
+| - | - |
+| 1|10 |
+| 2|-10 |
+
+```
+date(2000, 1, 1) + years(p.i1)
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|2010-01-01 |
+| 2|1990-01-01 |
+
+
+
+### 11.2 Comparisons involving dates
+
+
+#### 11.2.1 Is before
+
+This example makes use of a patient-level table named `p` containing the following data:
+
+| patient|d1 |
+| - | - |
+| 1|1990-01-01 |
+| 2|2000-01-01 |
+| 3|2010-01-01 |
+| 4| |
+
+```
+p.d1.is_before(date(2000, 1, 1))
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|T |
+| 2|F |
+| 3|F |
+| 4| |
+
+
+
+#### 11.2.2 Is on or before
+
+This example makes use of a patient-level table named `p` containing the following data:
+
+| patient|d1 |
+| - | - |
+| 1|1990-01-01 |
+| 2|2000-01-01 |
+| 3|2010-01-01 |
+| 4| |
+
+```
+p.d1.is_on_or_before(date(2000, 1, 1))
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|T |
+| 2|T |
+| 3|F |
+| 4| |
+
+
+
+#### 11.2.3 Is after
+
+This example makes use of a patient-level table named `p` containing the following data:
+
+| patient|d1 |
+| - | - |
+| 1|1990-01-01 |
+| 2|2000-01-01 |
+| 3|2010-01-01 |
+| 4| |
+
+```
+p.d1.is_after(date(2000, 1, 1))
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|F |
+| 2|F |
+| 3|T |
+| 4| |
+
+
+
+#### 11.2.4 Is on or after
+
+This example makes use of a patient-level table named `p` containing the following data:
+
+| patient|d1 |
+| - | - |
+| 1|1990-01-01 |
+| 2|2000-01-01 |
+| 3|2010-01-01 |
+| 4| |
+
+```
+p.d1.is_on_or_after(date(2000, 1, 1))
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|F |
+| 2|T |
+| 3|T |
+| 4| |
+
+
+
+#### 11.2.5 Is in
+
+This example makes use of a patient-level table named `p` containing the following data:
+
+| patient|d1 |
+| - | - |
+| 1|1990-01-01 |
+| 2|2000-01-01 |
+| 3|2010-01-01 |
+| 4| |
+
+```
+p.d1.is_in([date(2010, 1, 1), date(1900, 1, 1)])
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|F |
+| 2|F |
+| 3|T |
+| 4| |
+
+
+
+#### 11.2.6 Is not in
+
+This example makes use of a patient-level table named `p` containing the following data:
+
+| patient|d1 |
+| - | - |
+| 1|1990-01-01 |
+| 2|2000-01-01 |
+| 3|2010-01-01 |
+| 4| |
+
+```
+p.d1.is_not_in([date(2010, 1, 1), date(1900, 1, 1)])
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|T |
+| 2|T |
+| 3|F |
+| 4| |
+
+
+
+#### 11.2.7 Is between
+
+This example makes use of a patient-level table named `p` containing the following data:
+
+| patient|d1 |
+| - | - |
+| 1|2010-01-01 |
+| 2|2010-01-02 |
+| 3|2010-01-03 |
+| 4|2010-01-04 |
+| 5|2010-01-05 |
+| 6| |
+
+```
+p.d1.is_between(date(2010, 1, 2), date(2010, 1, 4))
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|F |
+| 2|F |
+| 3|T |
+| 4|F |
+| 5|F |
+| 6| |
+
+
+
+#### 11.2.8 Is on or between
+
+This example makes use of a patient-level table named `p` containing the following data:
+
+| patient|d1 |
+| - | - |
+| 1|2010-01-01 |
+| 2|2010-01-02 |
+| 3|2010-01-03 |
+| 4|2010-01-04 |
+| 5|2010-01-05 |
+| 6| |
+
+```
+p.d1.is_on_or_between(date(2010, 1, 2), date(2010, 1, 4))
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|F |
+| 2|T |
+| 3|T |
+| 4|T |
+| 5|F |
+| 6| |
+
+
+
+#### 11.2.9 Is between backwards
+
+This example makes use of a patient-level table named `p` containing the following data:
+
+| patient|d1 |
+| - | - |
+| 1|2010-01-01 |
+| 2|2010-01-02 |
+| 3|2010-01-03 |
+| 4|2010-01-04 |
+| 5|2010-01-05 |
+| 6| |
+
+```
+p.d1.is_between(date(2010, 1, 4), date(2010, 1, 2))
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|F |
+| 2|F |
+| 3|F |
+| 4|F |
+| 5|F |
+| 6| |
+
+
+
+#### 11.2.10 Is on or between backwards
+
+This example makes use of a patient-level table named `p` containing the following data:
+
+| patient|d1 |
+| - | - |
+| 1|2010-01-01 |
+| 2|2010-01-02 |
+| 3|2010-01-03 |
+| 4|2010-01-04 |
+| 5|2010-01-05 |
+| 6| |
+
+```
+p.d1.is_on_or_between(date(2010, 1, 4), date(2010, 1, 2))
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|F |
+| 2|F |
+| 3|F |
+| 4|F |
+| 5|F |
+| 6| |
+
+
+
+### 11.3 Types usable in comparisons involving dates
+
+
+#### 11.3.1 Accepts python date object
+
+This example makes use of a patient-level table named `p` containing the following data:
+
+| patient|d1|d2 |
+| - | - | - |
+| 1|1990-01-01|1980-01-01 |
+| 2|2000-01-01|1980-01-01 |
+| 3|2010-01-01|2020-01-01 |
+| 4||2020-01-01 |
+
+```
+p.d1.is_before(datetime.date(2000, 1, 20))
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|T |
+| 2|T |
+| 3|F |
+| 4| |
+
+
+
+#### 11.3.2 Accepts iso formated date string
+
+This example makes use of a patient-level table named `p` containing the following data:
+
+| patient|d1|d2 |
+| - | - | - |
+| 1|1990-01-01|1980-01-01 |
+| 2|2000-01-01|1980-01-01 |
+| 3|2010-01-01|2020-01-01 |
+| 4||2020-01-01 |
+
+```
+p.d1.is_before("2000-01-20")
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|T |
+| 2|T |
+| 3|F |
+| 4| |
+
+
+
+#### 11.3.3 Accepts another date series
+
+This example makes use of a patient-level table named `p` containing the following data:
+
+| patient|d1|d2 |
+| - | - | - |
+| 1|1990-01-01|1980-01-01 |
+| 2|2000-01-01|1980-01-01 |
+| 3|2010-01-01|2020-01-01 |
+| 4||2020-01-01 |
+
+```
+p.d1.is_before(p.d2)
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|F |
+| 2|F |
+| 3|T |
+| 4| |
+
+
+
+## 12 Operations on all series containing strings
+
+
+### 12.1 Testing whether one string contains another string
+
+
+#### 12.1.1 Contains fixed value
+
+This example makes use of a patient-level table named `p` containing the following data:
+
+| patient|s1 |
+| - | - |
+| 1|ab |
+| 2|ab12 |
+| 3|12ab |
+| 4|12ab45 |
+| 5|a b |
+| 6|AB |
+| 7| |
+
+```
+p.s1.contains("ab")
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|T |
+| 2|T |
+| 3|T |
+| 4|T |
+| 5|F |
+| 6|F |
+| 7| |
+
+
+
+#### 12.1.2 Contains fixed value with special characters
+
+This example makes use of a patient-level table named `p` containing the following data:
+
+| patient|s1 |
+| - | - |
+| 1|/a%b_ |
+| 2|/ab_ |
+| 3|/a%bc |
+| 4|a%b_ |
+
+```
+p.s1.contains("/a%b_")
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|T |
+| 2|F |
+| 3|F |
+| 4|F |
+
+
+
+#### 12.1.3 Contains value from column
+
+This example makes use of a patient-level table named `p` containing the following data:
+
+| patient|s1|s2 |
+| - | - | - |
+| 1|ab|ab |
+| 2|cd12|cd |
+| 3|12ef|ef |
+| 4|12gh45|gh |
+| 5|i j|ij |
+| 6|KL|kl |
+| 7||mn |
+| 8|ab| |
+
+```
+p.s1.contains(p.s2)
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|T |
+| 2|T |
+| 3|T |
+| 4|T |
+| 5|F |
+| 6|F |
+| 7| |
+| 8| |
+
+
+
+#### 12.1.4 Contains value from column with special characters
+
+This example makes use of a patient-level table named `p` containing the following data:
+
+| patient|s1|s2 |
+| - | - | - |
+| 1|/a%b_|/a%b_ |
+| 2|/ab_|/a%b_ |
+| 3|/a%bc|/a%b_ |
+| 4|a%b_|/a%b_ |
+
+```
+p.s1.contains(p.s2)
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|T |
+| 2|F |
+| 3|F |
+| 4|F |
+
+
+
+## 13 Defining the dataset population
+
+
+### 13.1 Defining a population
+
+`set_population` is used to limit the population from which data is extracted.
+
+
+
+#### 13.1.1 Population with single table
+Extract a column from a patient table after limiting the population by another column.
+
+This example makes use of a patient-level table named `p` containing the following data:
+
+| patient|b1|i1 |
+| - | - | - |
+| 1|F|10 |
+| 2|T|20 |
+| 3|F|30 |
+
+```
+p.i1
+set_population(~p.b1)
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|10 |
+| 3|30 |
+
+
+
+#### 13.1.2 Population with multiple tables
+Limit the patient population by a column in one table, and return values from another
+table.
+
+This example makes use of a patient-level table named `p` and an event-level table named `e` containing the following data:
+
+| patient|i1 |
+| - | - |
+| 1|10 |
+| 2|20 |
+| 3|0 |
+
+| patient|i1 |
+| - | - |
+| 1|101 |
+| 1|102 |
+| 3|301 |
+| 4|401 |
+
+```
+e.exists_for_patient()
+set_population(p.i1 > 0)
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|T |
+| 2|F |
+
+
+
+#### 13.1.3 Case with case expression
+Limit the patient population by a case expression.
+
+This example makes use of a patient-level table named `p` containing the following data:
+
+| patient|i1 |
+| - | - |
+| 1|6 |
+| 2|7 |
+| 3|9 |
+| 4| |
+
+```
+p.i1
+set_population(
+    case(
+        when(p.i1 <= 8).then(True),
+        when(p.i1 > 8).then(False),
+    )
+)
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|6 |
+| 2|7 |
+
+
+
+## 14 Defining a table using inline data
+
+
+### 14.1 Defining a table using inline data
+
+
+#### 14.1.1 Table from rows
+
+This example makes use of a patient-level table named `p` containing the following data:
+
+| patient|i1 |
+| - | - |
+| 1|10 |
+| 2|20 |
+| 3|30 |
+
+```
+p.i1 + t.n
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|110 |
+| 2| |
+| 3|330 |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -16,7 +16,6 @@ watch:
 
 
 plugins:
-  - mkdocs-opensafely-databuilder
   - table-reader:
       base_path: "docs_dir"
 

--- a/requirements.dev.in
+++ b/requirements.dev.in
@@ -28,5 +28,4 @@ pyupgrade
 # docs
 mkdocs
 mkdocs-material
-https://github.com/opensafely-core/mkdocs-opensafely-databuilder/archive/99f9f3ec5025d5cf9030cafb1189576a4ebf6a7c.zip#mkdocs-opensafely-databuilder
 mkdocs-table-reader-plugin

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -280,9 +280,6 @@ mkdocs-material-extensions==1.1.1 \
     --hash=sha256:9c003da71e2cc2493d910237448c672e00cefc800d3d6ae93d2fc69979e3bd93 \
     --hash=sha256:e41d9f38e4798b6617ad98ca8f7f1157b1e4385ac1459ca1e4ea219b556df945
     # via mkdocs-material
-mkdocs-opensafely-databuilder @ https://github.com/opensafely-core/mkdocs-opensafely-databuilder/archive/99f9f3ec5025d5cf9030cafb1189576a4ebf6a7c.zip \
-    --hash=sha256:011613b325ee9b10aec31a652c5b00a39995f2e50a5df7a5f2bf5f2c78897f49
-    # via -r requirements.dev.in
 mkdocs-table-reader-plugin==2.0 \
     --hash=sha256:c3d3b063a19e5a619f6062cb5963bd3d04c1f4e4f5d4ff75d9e33f3e79a1d535 \
     --hash=sha256:cb2f5ca1b666e4a7452d196810558ba815f597de01822686c2208d57cb21f9d2

--- a/tests/unit/test_docs.py
+++ b/tests/unit/test_docs.py
@@ -1,5 +1,8 @@
-from databuilder.docs import generate_docs
+from databuilder.docs import generate_docs, render
 from databuilder.docs.common import reformat_docstring
+from databuilder.docs.render_includes.backends import render_backend
+from databuilder.docs.render_includes.contracts import render_contracts
+from databuilder.docs.render_includes.specs import render_specs
 
 
 def test_reformat_docstring():
@@ -62,3 +65,293 @@ def test_generate_docs():
                     leading_whitespace_count = len(line) - len(line.strip())
                     assert leading_whitespace_count > 0
                     assert leading_whitespace_count % 4 == 0
+
+
+def test_render(tmp_path):
+    assert not set(tmp_path.iterdir())
+    render(generate_docs(), tmp_path)
+    assert {pt.name for pt in tmp_path.iterdir()} == {
+        "specs.md",
+        "contracts.md",
+        "TPPBackend.md",
+        "GraphnetBackend.md",
+        "DatabricksBackend.md",
+    }
+
+
+def test_render_specs():
+    specs = [
+        {
+            "id": "1",
+            "title": "Filtering an event frame",
+            "sections": [
+                {
+                    "id": "1.1",
+                    "title": "Including rows",
+                    "paragraphs": [
+                        {
+                            "id": "1.1.1",
+                            "title": "Take with column",
+                            "tables": {
+                                "e": [
+                                    ["", "i1", "b1"],
+                                    ["1", "101", "T"],
+                                    ["2", "201", "T"],
+                                    ["2", "203", "F"],
+                                    ["3", "302", "F"],
+                                ]
+                            },
+                            "series": "e.take(e.b1).i1.sum_for_patient()",
+                            "output": [["1", "203"], ["2", "201"], ["3", ""]],
+                        }
+                    ],
+                }
+            ],
+        }
+    ]
+
+    expected = """## 1 Filtering an event frame
+
+
+### 1.1 Including rows
+
+
+#### 1.1.1 Take with column
+
+This example makes use of an event-level table named `e` containing the following data:
+
+| |i1|b1 |
+| - | - | - |
+| 1|101|T |
+| 2|201|T |
+| 2|203|F |
+| 3|302|F |
+
+```
+e.take(e.b1).i1.sum_for_patient()
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|203 |
+| 2|201 |
+| 3| |
+"""
+    assert render_specs(specs) == expected
+
+
+def test_render_specs_with_multiline_series():
+    specs = [
+        {
+            "id": "1",
+            "title": "Logical case expressions",
+            "sections": [
+                {
+                    "id": "1.1",
+                    "title": "Logical case expressions",
+                    "paragraphs": [
+                        {
+                            "id": "1.1.1",
+                            "title": "Case with expression",
+                            "tables": {
+                                "p": [
+                                    ["patient", "i1"],
+                                    ["1", "6"],
+                                    ["2", "7"],
+                                    ["3", "8"],
+                                    ["4", "9"],
+                                    ["5", ""],
+                                ]
+                            },
+                            "series": "case(\n    when(p.i1 < 8).then(p.i1),\n    when(p.i1 > 8).then(100),\n)",
+                            "output": [
+                                ["1", "6"],
+                                ["2", "7"],
+                                ["3", ""],
+                                ["4", "100"],
+                                ["5", ""],
+                            ],
+                        }
+                    ],
+                }
+            ],
+        }
+    ]
+
+    expected = """## 1 Logical case expressions
+
+
+### 1.1 Logical case expressions
+
+
+#### 1.1.1 Case with expression
+
+This example makes use of a patient-level table named `p` containing the following data:
+
+| patient|i1 |
+| - | - |
+| 1|6 |
+| 2|7 |
+| 3|8 |
+| 4|9 |
+| 5| |
+
+```
+case(
+    when(p.i1 < 8).then(p.i1),
+    when(p.i1 > 8).then(100),
+)
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|6 |
+| 2|7 |
+| 3| |
+| 4|100 |
+| 5| |
+"""
+    assert render_specs(specs) == expected
+
+
+def test_specs_with_additional_text():
+    specs = [
+        {
+            "id": "1",
+            "title": "Filtering an event frame",
+            "text": "Chapters may have additional descriptive text blocks",
+            "sections": [
+                {
+                    "id": "1.1",
+                    "title": "Including rows",
+                    "text": "Additional text can also be added at a section level",
+                    "paragraphs": [
+                        {
+                            "id": "1.1.1",
+                            "title": "Take with column",
+                            "text": "Further additional text can be provided for a paragraph",
+                            "tables": {
+                                "e": [
+                                    ["", "i1", "b1"],
+                                    ["1", "101", "T"],
+                                    ["2", "201", "T"],
+                                    ["2", "203", "F"],
+                                    ["3", "302", "F"],
+                                ]
+                            },
+                            "series": "e.take(e.b1).i1.sum_for_patient()",
+                            "output": [["1", "203"], ["2", "201"], ["3", ""]],
+                        }
+                    ],
+                }
+            ],
+        }
+    ]
+    assert render_specs(specs) == (
+        """## 1 Filtering an event frame
+Chapters may have additional descriptive text blocks
+
+
+### 1.1 Including rows
+Additional text can also be added at a section level
+
+
+#### 1.1.1 Take with column
+Further additional text can be provided for a paragraph
+
+This example makes use of an event-level table named `e` containing the following data:
+
+| |i1|b1 |
+| - | - | - |
+| 1|101|T |
+| 2|201|T |
+| 2|203|F |
+| 3|302|F |
+
+```
+e.take(e.b1).i1.sum_for_patient()
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|203 |
+| 2|201 |
+| 3| |
+"""
+    )
+
+
+def test_render_contracts():
+    contracts = [
+        {
+            "name": "DummyClass",
+            "hierarchy": ["some", "path"],
+            "dotted_path": "dummy_module.DummyClass",
+            "docstring": ["Dummy docstring"],
+            "columns": [
+                {
+                    "name": "patient_id",
+                    "description": "a column description",
+                    "type": "PseudoPatientId",
+                    "constraints": ["Must have a value", "Must be unique"],
+                }
+            ],
+            "backend_support": [],
+        },
+        {
+            "name": "DummyClass2",
+            "hierarchy": ["some", "path"],
+            "dotted_path": "dummy_module2.DummyClass2",
+            "docstring": ["Dummy docstring2.", "", "Second line."],
+            "columns": [],
+            "backend_support": [],
+        },
+    ]
+    expected = """## Some/Path/DummyClass
+
+Dummy docstring
+
+| Column name | Description | Type | Constraints |
+| ----------- | ----------- | ---- | ----------- |
+| patient_id | a column description | PseudoPatientId | Must have a value, must be unique. |
+
+
+
+
+## Some/Path/DummyClass2
+
+Dummy docstring2.
+
+Second line.
+
+| Column name | Description | Type | Constraints |
+| ----------- | ----------- | ---- | ----------- |
+"""
+    assert render_contracts(contracts) == expected
+
+
+def test_render_backend():
+    backends = [
+        {
+            "name": "DummyBackend1",
+            "contracts": ["Some/Path/DummyClass", "Some/Path/DummyClass2"],
+        },
+        {"name": "DummyBackend2", "contracts": ["some/path/DummyClass"]},
+    ]
+    assert render_backend(backends[0]) == (
+        """Contracts implemented:
+
+* [`Some/Path/DummyClass`](contracts-reference.md#somepathdummyclass)
+* [`Some/Path/DummyClass2`](contracts-reference.md#somepathdummyclass2)
+"""
+    )
+
+    assert render_backend(backends[1]) == (
+        """Contracts implemented:
+
+* [`some/path/DummyClass`](contracts-reference.md#somepathdummyclass)
+"""
+    )


### PR DESCRIPTION
Fixes #977 

This removes the dependency on the mkdocs-opensafely-databuilder plugin, and moves the rendering code (and tests) from the plugin into this repo, with minimal changes.

the `generate-docs` command now generates the json as before, and then passes it through the renderers to generate the markdown files to be included in the docs.  The previous markers for the mkdocs-opensafely-databuilder plugin are just replaced with snippet markers.

Note that the public_docs.json file is not deleted yet, to avoid breaking the main docs when this PR is merged.  After this one is merged, the mkdocs-opensafely-databuilder can be removed from the main docs repo, and the public_docs.json file will no longer be required.
