### PR TITLE
Update Black to 23.1.0 in the `.pre-commit-config`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ default_language_version:
 
 repos:
   - repo: https://github.com/psf/black
-    rev: 22.6.0
+    rev: 23.1.0
     hooks:
     - id: black
 


### PR DESCRIPTION
Dependabot still misses these, unfortunately.