### PR TITLE
Fix MSSQL date issues

### DIFF
--- a/databuilder/query_engines/mssql.py
+++ b/databuilder/query_engines/mssql.py
@@ -4,7 +4,6 @@ import secrets
 import sqlalchemy
 import structlog
 from sqlalchemy.schema import CreateIndex, DropTable
-from sqlalchemy.sql.elements import BindParameter
 from sqlalchemy.sql.functions import Function as SQLFunction
 
 from databuilder import sqlalchemy_types
@@ -43,16 +42,7 @@ class MSSQLQueryEngine(BaseSQLQueryEngine):
         assert part in {"YEAR", "MONTH", "DAY"}
         return SQLFunction(part, date, type_=sqlalchemy_types.Integer)
 
-    def cast_if_literal(self, date):
-        # DATEADD will turn string literal dates into datetimes, which is not what we
-        # want, so if it's a string literal, explictly cast it to a Date first.
-        # see https://learn.microsoft.com/en-us/sql/t-sql/functions/dateadd-transact-sql?view=sql-server-ver16#return-types
-        if isinstance(date, BindParameter):
-            return sqlalchemy.cast(date, sqlalchemy_types.Date)
-        return date
-
     def date_add_days(self, date, num_days):
-        date = self.cast_if_literal(date)
         return SQLFunction(
             "DATEADD",
             sqlalchemy.text("day"),
@@ -62,7 +52,6 @@ class MSSQLQueryEngine(BaseSQLQueryEngine):
         )
 
     def date_add_months(self, date, num_months):
-        date = self.cast_if_literal(date)
         new_date = SQLFunction(
             "DATEADD",
             sqlalchemy.text("month"),

--- a/tests/integration/query_engines/test_mssql_dialect.py
+++ b/tests/integration/query_engines/test_mssql_dialect.py
@@ -1,0 +1,16 @@
+import datetime
+
+import sqlalchemy
+
+
+def test_date_literals_have_correct_type(mssql_engine):
+    case_statement = sqlalchemy.case(
+        (
+            sqlalchemy.literal(1) == 1,
+            datetime.date(2000, 10, 5),
+        ),
+    )
+    query = sqlalchemy.select(case_statement.label("output"))
+    with mssql_engine.sqlalchemy_engine().connect() as conn:
+        results = list(conn.execute(query))
+    assert results[0].output == datetime.date(2000, 10, 5)

--- a/tests/integration/query_engines/test_mssql_dialect.py
+++ b/tests/integration/query_engines/test_mssql_dialect.py
@@ -1,6 +1,9 @@
 import datetime
 
+import pytest
 import sqlalchemy
+
+from databuilder.query_engines.mssql_dialect import MSSQLDialect
 
 
 def test_date_literals_have_correct_type(mssql_engine):
@@ -14,3 +17,19 @@ def test_date_literals_have_correct_type(mssql_engine):
     with mssql_engine.sqlalchemy_engine().connect() as conn:
         results = list(conn.execute(query))
     assert results[0].output == datetime.date(2000, 10, 5)
+
+
+def test_casts_to_date():
+    # This fails unless our MSSQL dialect sets the appropriate minimum server version.
+    # By default it will treat DATE as an alias for DATETIME. See:
+    # https://github.com/sqlalchemy/sqlalchemy/blob/rel_1_4_46/lib/sqlalchemy/dialects/mssql/base.py#L1623-L1627
+    table = sqlalchemy.table("foo", sqlalchemy.Column("bar"))
+    clause = sqlalchemy.cast(table.c.bar, sqlalchemy.Date)
+    compiled = str(clause.compile(dialect=MSSQLDialect()))
+    assert compiled == "CAST(foo.bar AS DATE)"
+
+
+def test_enforces_minimum_server_version(mssql_engine, monkeypatch):
+    monkeypatch.setattr(MSSQLDialect, "minimum_server_version", (999999,))
+    with pytest.raises(RuntimeError, match=r"we require at least \(999999,\)"):
+        mssql_engine.sqlalchemy_engine().connect()

--- a/tests/unit/query_engines/test_mssql_dialect.py
+++ b/tests/unit/query_engines/test_mssql_dialect.py
@@ -15,12 +15,18 @@ def test_mssql_date_types():
     # want to do.
     date_col = sqlalchemy.Column("date_col", sqlalchemy_types.Date())
     datetime_col = sqlalchemy.Column("datetime_col", sqlalchemy_types.DateTime())
-    assert _str(date_col > "2021-08-03") == "date_col > '20210803'"
-    assert _str(datetime_col < "2021-03-23") == "datetime_col < '2021-03-23T00:00:00'"
-    assert _str(date_col == datetime.date(2021, 5, 15)) == "date_col = '20210515'"
+    assert _str(date_col > "2021-08-03") == "date_col > CAST('20210803' AS DATE)"
+    assert (
+        _str(datetime_col < "2021-03-23")
+        == "datetime_col < CAST('2021-03-23T00:00:00' AS DATETIME)"
+    )
+    assert (
+        _str(date_col == datetime.date(2021, 5, 15))
+        == "date_col = CAST('20210515' AS DATE)"
+    )
     assert (
         _str(datetime_col == datetime.datetime(2021, 5, 15, 9, 10, 0))
-        == "datetime_col = '2021-05-15T09:10:00'"
+        == "datetime_col = CAST('2021-05-15T09:10:00' AS DATETIME)"
     )
     assert _str(date_col == None) == "date_col IS NULL"  # noqa: E711
     assert _str(datetime_col == None) == "datetime_col IS NULL"  # noqa: E711


### PR DESCRIPTION
This fixes two related date handling issues in MSSQL:

 * date literals could be misinterpreted in some contexts so we now explicitly cast them to their intended type;

 * the SQL generated by `dump-dataset-sql` didn't match what we run in production because SQLAlchemy changes what it generates depending on the version of the server it's connected to, so we now enforce a minimum supported version.

Closes #998