### PR TITLE
Make type mismatch errors in spec tests more helpful

### DIFF
--- a/tests/spec/conftest.py
+++ b/tests/spec/conftest.py
@@ -24,9 +24,13 @@ def spec_test(request, engine):
         dataset = make_dataset(table_data, population)
         dataset.v = series
 
-        # If we're expecting floats then we want only approximate equality to account
+        # Get the type according to the query model
+        variables = compile(dataset)
+        variable_type = get_series_type(variables["v"])
+
+        # If we're comparing floats then we want only approximate equality to account
         # for rounding differences
-        if any(isinstance(v, float) for v in expected_results.values()):
+        if variable_type is float:
             expected_results = pytest.approx(expected_results, rel=1e-5)
 
         # Extract data, and check it's as expected.
@@ -36,8 +40,6 @@ def spec_test(request, engine):
         assert results_dict == expected_results
 
         # Assert types are as expected
-        variables = compile(dataset)
-        variable_type = get_series_type(variables["v"])
         for patient_id, value in results_dict.items():
             if value is not None:
                 assert isinstance(value, variable_type), (

--- a/tests/spec/conftest.py
+++ b/tests/spec/conftest.py
@@ -35,10 +35,15 @@ def spec_test(request, engine):
         assert len(results) == len(results_dict), "Duplicate patient IDs found"
         assert results_dict == expected_results
 
-        # assert types are as expected
+        # Assert types are as expected
         variables = compile(dataset)
         variable_type = get_series_type(variables["v"])
-        assert all([r[1] is None or isinstance(r[1], variable_type) for r in results])
+        for patient_id, value in results_dict.items():
+            if value is not None:
+                assert isinstance(value, variable_type), (
+                    f"Expected {variable_type} got {type(value)} in "
+                    f"result {{{patient_id}: {value}}}"
+                )
 
     # Test that we can generate SQL with literal parmeters for debugging purposes
     def run_test_dump_sql(table_data, series, expected_results, population=None):


### PR DESCRIPTION
Previously it would tell you that there was a mismatch but not what types it expected or got, or where the mismatch occurred.
