### PR TITLE
Bump pre-commit's isort to 5.12.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
         - "flake8-no-pep420"
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
     - id: isort
 


### PR DESCRIPTION
The previous version of isort didn't pin Poetry, so when Poetry became pickier about parsing pyproject.yaml, it broke. However, because pre-commit is a pain, we have to bump isort ourselves.