### PR TITLE
Handle python date overflow errors for in-memory engine

### DIFF
--- a/databuilder/utils/date_utils.py
+++ b/databuilder/utils/date_utils.py
@@ -35,7 +35,13 @@ def date_difference_in_years(end, start):
 
 
 def date_add_days(date, num_days):
+    assert_valid_num_days(num_days)
     return date + datetime.timedelta(days=num_days)
+
+
+def assert_valid_num_days(num_days):
+    if abs(num_days) > 999999999:
+        raise ValueError(f"Number of days {num_days} is out of range")
 
 
 def assert_valid_year(year):

--- a/tests/generative/test_query_model.py
+++ b/tests/generative/test_query_model.py
@@ -98,6 +98,10 @@ def test_query_model(query_engines, variable, data, recorder):
         (Function.DateAddMonths, 8000 * 12),
         (Function.DateAddDays, -3000 * 366),
         (Function.DateAddDays, 8000 * 366),
+        (
+            Function.DateAddDays,
+            1500000000,
+        ),  # triggers python overflow error with timedelta
     ],
 )
 def test_handle_date_errors(query_engines, operation, rhs, recorder):
@@ -219,6 +223,10 @@ IGNORED_ERRORS = [
         ValueError,
         re.compile("year -?\\d+ is out of range"),
     ),  # DateAddYears, with an invalid calculated year
+    (
+        ValueError,
+        re.compile("Number of days -?\\d+ is out of range"),
+    ),  # DateAddDays, with a number of days out of the valid range
     (
         OverflowError,
         re.compile("date value out of range"),


### PR DESCRIPTION
Fixes #997 
This handles out-of-range days in python in a similar way to how we handle out-of-range years (which is to turn it into a slightly nicer ValueError).  We then catch and ignore the errors in the generative tests.

The minimal hypothesis example that triggered this is:
```
variable=Function.DateAddDays(
        lhs=SelectColumn(
            source=SelectPatientTable(
                name="p0",
                schema=TableSchema(
                    i1=Column(int, constraints=()),
                    i2=Column(int, constraints=()),
                    b1=Column(bool, constraints=()),
                    b2=Column(bool, constraints=()),
                    d1=Column(datetime.date, constraints=()),
                    d2=Column(datetime.date, constraints=()),
                    f1=Column(float, constraints=()),
                    f2=Column(float, constraints=()),
                ),
            ),
            name="d1",
        ),
        rhs=Value(1000000000)
)
```
(Note that sqlite returns None, and mssql raises an error that we already ignore in the generative tests.)