### PR TITLE
Automatic cast from int literals to floats

### DIFF
--- a/databuilder/query_language.py
+++ b/databuilder/query_language.py
@@ -244,6 +244,12 @@ class StrPatientSeries(StrFunctions, PatientSeries):
 
 
 class NumericFunctions(ComparableFunctions):
+    @staticmethod
+    def _cast(value):
+        if isinstance(value, float):
+            return int(value)
+        return value
+
     def __neg__(self):
         return _apply(qm.Function.Negate, self)
 
@@ -286,33 +292,27 @@ class NumericAggregations(ComparableAggregations):
 class IntEventSeries(NumericFunctions, NumericAggregations, EventSeries):
     _type = int
 
-    @staticmethod
-    def _cast(value):
-        return int(value)
-
 
 class IntPatientSeries(NumericFunctions, PatientSeries):
     _type = int
 
+
+class FloatFunctions(NumericFunctions):
     @staticmethod
     def _cast(value):
-        return int(value)
+        if isinstance(value, int):
+            return float(value)
+        if isinstance(value, IntEventSeries, IntPatientSeries):
+            return value.as_float()
+        return value
 
 
-class FloatEventSeries(NumericFunctions, NumericAggregations, EventSeries):
+class FloatEventSeries(FloatFunctions, NumericAggregations, EventSeries):
     _type = float
 
-    @staticmethod
-    def _cast(value):
-        return float(value)
 
-
-class FloatPatientSeries(NumericFunctions, PatientSeries):
+class FloatPatientSeries(FloatFunctions, PatientSeries):
     _type = float
-
-    @staticmethod
-    def _cast(value):
-        return float(value)
 
 
 # DATE SERIES

--- a/databuilder/query_language.py
+++ b/databuilder/query_language.py
@@ -286,17 +286,33 @@ class NumericAggregations(ComparableAggregations):
 class IntEventSeries(NumericFunctions, NumericAggregations, EventSeries):
     _type = int
 
+    @staticmethod
+    def _cast(value):
+        return int(value)
+
 
 class IntPatientSeries(NumericFunctions, PatientSeries):
     _type = int
+
+    @staticmethod
+    def _cast(value):
+        return int(value)
 
 
 class FloatEventSeries(NumericFunctions, NumericAggregations, EventSeries):
     _type = float
 
+    @staticmethod
+    def _cast(value):
+        return float(value)
+
 
 class FloatPatientSeries(NumericFunctions, PatientSeries):
     _type = float
+
+    @staticmethod
+    def _cast(value):
+        return float(value)
 
 
 # DATE SERIES

--- a/databuilder/query_language.py
+++ b/databuilder/query_language.py
@@ -244,12 +244,6 @@ class StrPatientSeries(StrFunctions, PatientSeries):
 
 
 class NumericFunctions(ComparableFunctions):
-    @staticmethod
-    def _cast(value):
-        if isinstance(value, float):
-            return int(value)
-        return value
-
     def __neg__(self):
         return _apply(qm.Function.Negate, self)
 
@@ -300,10 +294,11 @@ class IntPatientSeries(NumericFunctions, PatientSeries):
 class FloatFunctions(NumericFunctions):
     @staticmethod
     def _cast(value):
+        """
+        Casting int literals to floats. We dont support casting to float for IntSeries.
+        """
         if isinstance(value, int):
             return float(value)
-        if isinstance(value, IntEventSeries, IntPatientSeries):
-            return value.as_float()
         return value
 
 

--- a/tests/unit/test_query_language.py
+++ b/tests/unit/test_query_language.py
@@ -45,7 +45,7 @@ patients_schema = TableSchema(
     date_of_birth=Column(date), i=Column(int), f=Column(float)
 )
 patients = PatientFrame(SelectPatientTable("patients", patients_schema))
-events_schema = TableSchema(event_date=Column(date), i=Column(int), f=Column(float))
+events_schema = TableSchema(event_date=Column(date), f=Column(float))
 events = EventFrame(SelectTable("coded_events", events_schema))
 
 

--- a/tests/unit/test_query_language.py
+++ b/tests/unit/test_query_language.py
@@ -188,13 +188,9 @@ class TestDateSeries:
 @pytest.mark.parametrize(
     "lhs,op,rhs,expected_type",
     [
-        (patients.i, "+", 10.0, IntPatientSeries),
         (patients.f, "-", 10, FloatPatientSeries),
-        (patients.i, ">", 10.0, BoolPatientSeries),
         (patients.f, "<", 10, BoolPatientSeries),
-        (events.i, "+", 10.0, IntEventSeries),
         (events.f, "-", 10, FloatEventSeries),
-        (events.i, ">", 10.0, BoolEventSeries),
         (events.f, "<", 10, BoolEventSeries),
     ],
 )

--- a/tests/unit/test_query_language.py
+++ b/tests/unit/test_query_language.py
@@ -192,6 +192,8 @@ class TestDateSeries:
         (patients.f, "<", 10, BoolPatientSeries),
         (events.f, "-", 10, FloatEventSeries),
         (events.f, "<", 10, BoolEventSeries),
+        (events.f, "<", 10, BoolEventSeries),
+        (events.f, "<", 10.0, BoolEventSeries),
     ],
 )
 def test_automatic_cast(lhs, op, rhs, expected_type):

--- a/tests/unit/test_query_language.py
+++ b/tests/unit/test_query_language.py
@@ -37,7 +37,9 @@ from databuilder.query_model.nodes import (
     Value,
 )
 
-patients_schema = TableSchema(date_of_birth=Column(date), i=Column(int))
+patients_schema = TableSchema(
+    date_of_birth=Column(date), i=Column(int), f=Column(float)
+)
 patients = PatientFrame(SelectPatientTable("patients", patients_schema))
 events_schema = TableSchema(event_date=Column(date))
 events = EventFrame(SelectTable("coded_events", events_schema))
@@ -177,6 +179,14 @@ class TestDateSeries:
         assert_produces(
             DateEventSeries(qm_date_series).year, Function.YearFromDate(qm_date_series)
         )
+
+
+def test_automatic_cast_to_float():
+    patients.f > 10
+
+
+def test_automatic_cast_to_int():
+    patients.i > 10.0
 
 
 def test_is_in():

--- a/tests/unit/test_query_language.py
+++ b/tests/unit/test_query_language.py
@@ -189,10 +189,11 @@ class TestDateSeries:
     "lhs,op,rhs,expected_type",
     [
         (patients.f, "-", 10, FloatPatientSeries),
+        (patients.f, "+", 10, FloatPatientSeries),
         (patients.f, "<", 10, BoolPatientSeries),
         (events.f, "-", 10, FloatEventSeries),
         (events.f, "<", 10, BoolEventSeries),
-        (events.f, "<", 10, BoolEventSeries),
+        (events.f, ">", 10, BoolEventSeries),
         (events.f, "<", 10.0, BoolEventSeries),
     ],
 )


### PR DESCRIPTION
Closes #540 

This adds support for automatic casting from ints to floats.
We currently don't support IntSeries because we dont think we need it at the moment (and it'd be easier to add later than to remove). 
We also don't support casting from float to int for reasons described in the limitations section of #540 
