### PR TITLE
Don't use "magic" SQLAlchemy functions

### DIFF
--- a/databuilder/query_engines/base_sql.py
+++ b/databuilder/query_engines/base_sql.py
@@ -410,9 +410,7 @@ class BaseSQLQueryEngine(BaseQueryEngine):
         return self.aggregate_series_by_patient(node.source, self.calculate_mean)
 
     def calculate_mean(self, sql_expr):
-        # Unlike `sum/min/max` the `avg` function doesn't automatically acquire the
-        # correct return type
-        return sqlalchemy.func.avg(sql_expr, type_=sqlalchemy_types.Float)
+        return SQLFunction("AVG", sql_expr, type_=sqlalchemy_types.Float)
 
     # `Exists` and `Count` are Frame-level (rather than Series-level) aggregations and
     # so have a different implementation. They can operate on both many- and

--- a/databuilder/query_engines/mssql.py
+++ b/databuilder/query_engines/mssql.py
@@ -35,7 +35,7 @@ class MSSQLQueryEngine(BaseSQLQueryEngine):
         # have to explicitly cast to float
         if not expr_has_type(sql_expr, sqlalchemy_types.Float):
             sql_expr = sqlalchemy.cast(sql_expr, sqlalchemy_types.Float)
-        return sqlalchemy.func.avg(sql_expr, type_=sqlalchemy_types.Float)
+        return SQLFunction("AVG", sql_expr, type_=sqlalchemy_types.Float)
 
     def date_difference_in_days(self, end, start):
         return SQLFunction(


### PR DESCRIPTION
SQLAlchemy knows about certain common SQL functions and aggregations (including `MIN`, `MAX`, `SUM` and `COUNT`) and makes these available in the `sqlalchemy.func` namespace.

However, if you reference a function in this namespace which SQLAlchemy _doesn't_ know about it will just create one for you with a matching name but no type information. This is probably quite convenient in some circumstances, but I don't think we should be making use of these in Data Builder.

I inadvertently violated my own prohibition against these in a previous commit, so this PR fixes that.