### PR TITLE
Add Cloudflare Pages documentation preview

### DIFF
--- a/.github/workflows/check-docs.yml
+++ b/.github/workflows/check-docs.yml
@@ -32,3 +32,13 @@ jobs:
 
       - name: Check dataset definition outputs are up-to-date
         run: just docs-check-dataset-definitions-outputs-are-current
+
+      # This check becomes somewhat redundant if we fix up the Cloudflare Pages preview
+      # to work with Dependabot, because the deployment will also do the build.
+      # See https://github.com/opensafely/documentation/issues/930 which documents this problem.
+      #
+      # However, for any PR, Cloudflare Pages previews sometimes fail for mysterious reasons,
+      # and this requires logging into Cloudflare Pages to inspect.
+      # So it is perhaps useful to distinguish a Cloudflare failure with an actual issue.
+      - name: Check docs build
+        run: just docs-build

--- a/.github/workflows/pages-deployment.yml
+++ b/.github/workflows/pages-deployment.yml
@@ -36,7 +36,7 @@ jobs:
         uses: cloudflare/pages-action@c2ad89679f0dee1ff4bcf9b8bbe1cf52d176cb29  # v1.3.0
         with:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          apiToken: ${{ secrets.CLOUDFLARE_DIRECT_UPLOAD_API_TOKEN }}
           directory: "site"
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}
           projectName: "databuilder-docs"

--- a/.github/workflows/pages-deployment.yml
+++ b/.github/workflows/pages-deployment.yml
@@ -1,0 +1,42 @@
+on: [push]
+
+jobs:
+  deploy:
+
+    permissions:
+      contents: read
+      deployments: write
+
+    runs-on: ubuntu-latest
+
+    name: Deploy to Cloudflare Pages
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+
+      - name: Install Python and just
+        uses: opensafely-core/setup-action@v1
+        with:
+          install-just: true
+          python-version: '3.9'
+
+      - name: Check docs are current
+        run: just docs-check-generated-docs-are-current
+
+      - name: Build site
+        run: just docs-build
+
+      - name: Add a version file
+        run: echo ${{ github.sha }} > site/version.html
+
+      - name: Publish
+        if: ${{ github.actor != 'dependabot[bot]' }}
+        uses: cloudflare/pages-action@c2ad89679f0dee1ff4bcf9b8bbe1cf52d176cb29  # v1.3.0
+        with:
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          directory: "site"
+          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+          projectName: "databuilder-docs"

--- a/Justfile
+++ b/Justfile
@@ -228,8 +228,13 @@ generate-docs OUTPUT_DIR="docs/includes/generated_docs": devenv
 update-external-studies: devenv
     $BIN/python -m tests.acceptance.update_external_studies
 
-docs-serve: devenv generate-docs
-    "$BIN"/mkdocs serve
+# Run the documentation server: to configure the port, append: ---dev-addr localhost:<port>
+docs-serve *ARGS: devenv generate-docs
+    "$BIN"/mkdocs serve {{ ARGS }}
+
+# Build the documentation
+docs-build *ARGS: devenv generate-docs
+    "$BIN"/mkdocs build {{ ARGS }}
 
 # Run the snippet tests
 docs-test: devenv


### PR DESCRIPTION
This PR adds a preview of the documentation generated by Cloudflare Pages.

It also allows developers running the `docs-serve` and `docs-build` recipes to append extra arguments to MkDocs, which is useful to specify, for instance, another development server port.
 
Previews will not yet appear for Dependabot PRs without addressing the problem described in opensafely/documentation/issues/930 for more. (The benefit to fixing is relatively small, but the actual fix requires a bit of thinking about because it has possible security implications.)