### PR TITLE
Bump gentest ignored error limit from 1% to 1.5%

### DIFF
--- a/tests/generative/recording.py
+++ b/tests/generative/recording.py
@@ -79,7 +79,7 @@ def check_not_too_many_ignored_errors(recorder):
 
         # Allow more errors (proportionally) for smaller numbers of examples
         error_rate = recorder.num_ignored_errors / recorder.num_results
-        error_limit = 0.01
+        error_limit = 0.015
         assert error_rate <= error_limit, (
             f"{recorder.num_ignored_errors=}, "
             f"{recorder.num_results=}, "

--- a/tests/generative/recording.py
+++ b/tests/generative/recording.py
@@ -78,7 +78,14 @@ def check_not_too_many_ignored_errors(recorder):
         # fails).
 
         # Allow more errors (proportionally) for smaller numbers of examples
-        assert recorder.num_ignored_errors / recorder.num_results <= 0.01
+        error_rate = recorder.num_ignored_errors / recorder.num_results
+        error_limit = 0.01
+        assert error_rate <= error_limit, (
+            f"{recorder.num_ignored_errors=}, "
+            f"{recorder.num_results=}, "
+            f"{error_rate=}, "
+            f"{error_limit=}"
+        )
 
 
 def show_input_summary(recorder):  # pragma: no cover


### PR DESCRIPTION
We've recently added new operations and new classes of ignored error and this has brought our rate up to 1.14%.