### PR TITLE
fix: Generate more rows in dummy data tables

### DIFF
--- a/databuilder/dummy_data/generator.py
+++ b/databuilder/dummy_data/generator.py
@@ -190,7 +190,7 @@ class DummyPatientGenerator:
 
     def empty_rows(self, table_info):
         # Generate a small handful of events for event-level tables
-        max_rows = 1 if table_info.has_one_row_per_patient else 8
+        max_rows = 1 if table_info.has_one_row_per_patient else 16
         row_count = self.rnd.randrange(max_rows + 1)
         return [{} for _ in range(row_count)]
 


### PR DESCRIPTION
This is all utterly unscientific, but without this change I found that the [study][1] I was working on translating didn't generate enough data for the analysis scripts to run. Some columns which should have contained dates ended up completely empty which meant that Stata couldn't guess the type from the CSV and so the script died with a type error.

Doubling the number of events makes dummy data generation a bit slower, but solved this specific problem.

[1]: https://github.com/opensafely/bias/pull/3