### PR TITLE
Limit range of dates in generative tests

### DIFF
--- a/tests/generative/test_query_model.py
+++ b/tests/generative/test_query_model.py
@@ -45,7 +45,7 @@ value_strategies = {
     int: st.integers(min_value=0, max_value=10),
     bool: st.booleans(),
     datetime.date: st.dates(
-        min_value=datetime.date(1900, 1, 1), max_value=datetime.date(2100, 12, 31)
+        min_value=datetime.date(2010, 1, 1), max_value=datetime.date(2020, 12, 31)
     ),
     float: st.floats(min_value=0.0, max_value=11.0, width=16, allow_infinity=False),
 }


### PR DESCRIPTION
Closes #912

I changed the lower and upper bounds, and reran the generative tests with `GENTEST_EXAMPLES=200`, to see what happened, but the tests passed without issue. What have I missed?