### PR TITLE
Automatically cast strings to codes

### DIFF
--- a/databuilder/codes.py
+++ b/databuilder/codes.py
@@ -51,10 +51,6 @@ class OPCS4Code(BaseCode, system_id="opcs4"):
     "OPCS-4"
 
 
-class Read2Code(BaseCode, system_id="readv2"):
-    "Read V2"
-
-
 class SNOMEDCTCode(BaseCode, system_id="snomedct"):
     "SNOMED CT"
 

--- a/databuilder/codes.py
+++ b/databuilder/codes.py
@@ -4,6 +4,7 @@ enforce that queries use the appropriate coding system for a given column.
 """
 import csv
 import dataclasses
+import re
 from pathlib import Path
 
 # Populated by `BaseCode.__init_subclass__` below
@@ -21,6 +22,10 @@ class BaseCode:
     def __init_subclass__(cls, system_id, **kwargs):
         REGISTRY[system_id] = cls
 
+    def __post_init__(self):
+        if not self.regex.fullmatch(self.value):
+            raise ValueError(f"Invalid {self.__class__.__name__}: {self.value}")
+
     @classmethod
     def _primitive_type(cls):
         return str
@@ -34,25 +39,78 @@ class BaseCode:
 class BNFCode(BaseCode, system_id="bnf"):
     "Pseudo BNF"
 
+    regex = re.compile(
+        r"""
+        # Standard BNF code
+          # Chapter, Section, Paragraph, Sub-paragraph
+          [01][0-9]{6}
+          # Chemical
+          [0-9A-Z]{2}
+          # Product, strength-formulation, generic equivalent
+          ([A-Z][0-9A-Z]){3}
+        | # OR
+        # Appliances
+        2[0-3][0-9]{9}
+        """,
+        re.VERBOSE,
+    )
+
 
 class CTV3Code(BaseCode, system_id="ctv3"):
     "CTV3 (Read V3)"
 
-
-class DMDCode(BaseCode, system_id="dmd"):
-    "Dictionary of Medicines and Devices"
+    # Some of the CTV3 codes in the OpenCodelists coding system database (though not any
+    # actually used in codelists) violate the below format, either by having a leading
+    # dot or by starting with a tilde. However I have confirmed that, aside from a tiny
+    # handful of cases, these invalid codes are not used in the database so there should
+    # never be a need to create codelists which use them.
+    regex = re.compile(
+        r"""
+        [0-9A-Za-z]{5}
+        | [0-9A-Za-z]{4}\.{1}
+        | [0-9A-Za-z]{3}\.{2}
+        | [0-9A-Za-z]{2}\.{3}
+        """,
+        re.VERBOSE,
+    )
 
 
 class ICD10Code(BaseCode, system_id="icd10"):
     "ICD-10"
 
+    regex = re.compile(r"[A-Z][0-9]{2,3}")
+
 
 class OPCS4Code(BaseCode, system_id="opcs4"):
     "OPCS-4"
 
+    # The documented structure requires three digits, and a dot between the 2nd and 3rd
+    # digit, but the codes we have in OpenCodelists omit the dot and sometimes have only
+    # two digits.
+    # https://en.wikipedia.org/wiki/OPCS-4#Code_structure
+    regex = re.compile(
+        r"""
+        # Uppercase letter excluding I
+        [ABCDEFGHJKLMNOPQRSTUVWXYZ]
+        [0-9]{2,3}
+        """,
+        re.VERBOSE,
+    )
+
 
 class SNOMEDCTCode(BaseCode, system_id="snomedct"):
     "SNOMED CT"
+
+    # 6-18 digit number with no leading zeros
+    # https://confluence.ihtsdotools.org/display/DOCRELFMT/6.1+SCTID+Data+Type
+    regex = re.compile(r"[1-9][0-9]{5,17}")
+
+
+class DMDCode(BaseCode, system_id="dmd"):
+    "Dictionary of Medicines and Devices"
+
+    # Syntactically equivalent to SNOMED-CT
+    regex = SNOMEDCTCode.regex
 
 
 @dataclasses.dataclass()

--- a/databuilder/query_language.py
+++ b/databuilder/query_language.py
@@ -500,6 +500,12 @@ def years(value):
 
 
 class CodeFunctions:
+    def _cast(self, value):
+        if isinstance(value, str):
+            return self._type(value)
+        else:
+            return value
+
     def to_category(self, categorisation, default=None):
         return self.map_values(categorisation, default=default)
 

--- a/databuilder/query_language.py
+++ b/databuilder/query_language.py
@@ -118,7 +118,7 @@ class BaseSeries:
         # immutable Set type required by the query model. We don't accept arbitrary
         # iterables here because too many types in Python are iterable and there's the
         # potential for confusion amongst the less experienced of our users.
-        if isinstance(other, (tuple, list, set, frozenset)):
+        if isinstance(other, (tuple, list, set, frozenset, dict)):
             other = frozenset(map(self._cast, other))
         return _apply(qm.Function.In, self, other)
 

--- a/databuilder/query_language.py
+++ b/databuilder/query_language.py
@@ -525,6 +525,7 @@ def _wrap(qm_node):
     is_patient_level = has_one_row_per_patient(qm_node)
     try:
         cls = REGISTERED_TYPES[type_, is_patient_level]
+        return cls(qm_node)
     except KeyError:
         # If we don't have a match for exactly this type then we should have one for a
         # superclass
@@ -535,7 +536,9 @@ def _wrap(qm_node):
         ]
         assert len(matches) == 1
         cls = matches[0]
-    return cls(qm_node)
+        wrapped = cls(qm_node)
+        wrapped._type = type_
+        return wrapped
 
 
 def _apply(qm_cls, *args):

--- a/docs/includes/generated_docs/specs.md
+++ b/docs/includes/generated_docs/specs.md
@@ -1453,13 +1453,13 @@ This example makes use of a patient-level table named `p` containing the followi
 
 | patient|c1 |
 | - | - |
-| 1|abc |
-| 2|def |
-| 3|ghi |
+| 1|123000 |
+| 2|456000 |
+| 3|789000 |
 | 4| |
 
 ```
-p.c1.is_in([SNOMEDCTCode("abc"), SNOMEDCTCode("ghi")])
+p.c1.is_in([SNOMEDCTCode("123000"), SNOMEDCTCode("789000")])
 ```
 returns the following patient series:
 
@@ -1478,13 +1478,13 @@ This example makes use of a patient-level table named `p` containing the followi
 
 | patient|c1 |
 | - | - |
-| 1|abc |
-| 2|def |
-| 3|ghi |
+| 1|123000 |
+| 2|456000 |
+| 3|789000 |
 | 4| |
 
 ```
-p.c1.is_not_in([SNOMEDCTCode("abc"), SNOMEDCTCode("ghi")])
+p.c1.is_not_in([SNOMEDCTCode("123000"), SNOMEDCTCode("789000")])
 ```
 returns the following patient series:
 
@@ -1503,9 +1503,9 @@ This example makes use of a patient-level table named `p` containing the followi
 
 | patient|c1 |
 | - | - |
-| 1|abc |
-| 2|def |
-| 3|ghi |
+| 1|123000 |
+| 2|456000 |
+| 3|789000 |
 | 4| |
 
 ```
@@ -1531,9 +1531,9 @@ This example makes use of a patient-level table named `p` containing the followi
 
 | patient|c1 |
 | - | - |
-| 1|abc |
-| 2|def |
-| 3|ghi |
+| 1|123000 |
+| 2|456000 |
+| 3|789000 |
 | 4| |
 
 ```

--- a/tests/integration/query_model/test_nodes_with_codes.py
+++ b/tests/integration/query_model/test_nodes_with_codes.py
@@ -16,16 +16,16 @@ events = SelectTable("events", schema=TableSchema(code=Column(CTV3Code)))
 
 def test_comparisons_between_codes_are_ok():
     code = SelectColumn(events, "code")
-    assert Function.EQ(code, Value(CTV3Code("abc")))
+    assert Function.EQ(code, Value(CTV3Code("abc00")))
 
 
 def test_attempts_to_mix_coding_systems_are_rejected():
     code = SelectColumn(events, "code")
     with pytest.raises(TypeValidationError):
-        Function.EQ(code, Value(SNOMEDCTCode("abc")))
+        Function.EQ(code, Value(SNOMEDCTCode("123000")))
 
 
 def test_attempts_to_mix_codes_and_strings_are_rejected():
     code = SelectColumn(events, "code")
     with pytest.raises(TypeValidationError):
-        Function.EQ(code, Value("abc"))
+        Function.EQ(code, Value("abc00"))

--- a/tests/spec/code_series_ops/test_containment.py
+++ b/tests/spec/code_series_ops/test_containment.py
@@ -6,11 +6,11 @@ title = "Testing for containment using codes"
 
 table_data = {
     p: """
-          |  c1
-        --+-----
-        1 | abc
-        2 | def
-        3 | ghi
+          |   c1
+        --+--------
+        1 | 123000
+        2 | 456000
+        3 | 789000
         4 |
         """,
 }
@@ -19,7 +19,7 @@ table_data = {
 def test_is_in(spec_test):
     spec_test(
         table_data,
-        p.c1.is_in([SNOMEDCTCode("abc"), SNOMEDCTCode("ghi")]),
+        p.c1.is_in([SNOMEDCTCode("123000"), SNOMEDCTCode("789000")]),
         {
             1: True,
             2: False,
@@ -32,7 +32,7 @@ def test_is_in(spec_test):
 def test_is_not_in(spec_test):
     spec_test(
         table_data,
-        p.c1.is_not_in([SNOMEDCTCode("abc"), SNOMEDCTCode("ghi")]),
+        p.c1.is_not_in([SNOMEDCTCode("123000"), SNOMEDCTCode("789000")]),
         {
             1: False,
             2: True,
@@ -46,8 +46,8 @@ def test_is_in_codelist_csv(spec_test):
     codelist = codelist_from_csv_lines(
         [
             "code",
-            "abc",
-            "ghi",
+            "123000",
+            "789000",
         ],
         column="code",
         system="snomedct",

--- a/tests/spec/code_series_ops/test_map_codes_to_categories.py
+++ b/tests/spec/code_series_ops/test_map_codes_to_categories.py
@@ -6,11 +6,11 @@ title = "Test mapping codes to categories using a categorised codelist"
 
 table_data = {
     p: """
-          |  c1
-        --+-----
-        1 | abc
-        2 | def
-        3 | ghi
+          |   c1
+        --+--------
+        1 | 123000
+        2 | 456000
+        3 | 789000
         4 |
         """,
 }
@@ -20,8 +20,8 @@ def test_map_codes_to_categories(spec_test):
     codelist = codelist_from_csv_lines(
         [
             "code,my_categorisation",
-            "abc,cat1",
-            "ghi,cat2",
+            "123000,cat1",
+            "789000,cat2",
         ],
         column="code",
         system="snomedct",

--- a/tests/spec/conftest.py
+++ b/tests/spec/conftest.py
@@ -3,8 +3,6 @@ import datetime
 import pytest
 
 from databuilder.ehrql import Dataset
-from databuilder.query_language import compile
-from databuilder.query_model.nodes import get_series_type
 
 
 @pytest.fixture(params=["execute", "dump_sql"])
@@ -24,13 +22,9 @@ def spec_test(request, engine):
         dataset = make_dataset(table_data, population)
         dataset.v = series
 
-        # Get the type according to the query model
-        variables = compile(dataset)
-        variable_type = get_series_type(variables["v"])
-
         # If we're comparing floats then we want only approximate equality to account
         # for rounding differences
-        if variable_type is float:
+        if series._type is float:
             expected_results = pytest.approx(expected_results, rel=1e-5)
 
         # Extract data, and check it's as expected.
@@ -42,8 +36,8 @@ def spec_test(request, engine):
         # Assert types are as expected
         for patient_id, value in results_dict.items():
             if value is not None:
-                assert isinstance(value, variable_type), (
-                    f"Expected {variable_type} got {type(value)} in "
+                assert isinstance(value, series._type), (
+                    f"Expected {series._type} got {type(value)} in "
                     f"result {{{patient_id}: {value}}}"
                 )
 

--- a/tests/unit/dummy_data/test_query_info.py
+++ b/tests/unit/dummy_data/test_query_info.py
@@ -72,16 +72,16 @@ def test_query_info_records_values():
     dataset = Dataset()
     dataset.set_population(events.exists_for_patient())
     # Simple equality comparison
-    dataset.q1 = events.take(events.code == CTV3Code("abc")).exists_for_patient()
+    dataset.q1 = events.take(events.code == CTV3Code("abc00")).exists_for_patient()
     # String contains
     dataset.q2 = patients.sex.contains("ale")
     # Set contains
     dataset.q3 = events.take(
-        events.code.is_in([CTV3Code("def"), CTV3Code("ghi")])
+        events.code.is_in([CTV3Code("def00"), CTV3Code("ghi00")])
     ).exists_for_patient()
     # Equality comparison where the column is not selected directly from the table
     old = events.take(events.date < "2000-01-01")
-    dataset.q4 = old.sort_by(old.date).first_for_patient().code == CTV3Code("jkl")
+    dataset.q4 = old.sort_by(old.date).first_for_patient().code == CTV3Code("jkl00")
 
     variable_definitions = compile(dataset)
     query_info = QueryInfo.from_variable_definitions(variable_definitions)
@@ -89,7 +89,7 @@ def test_query_info_records_values():
     code_column_info = query_info.tables["events"].columns["code"]
 
     assert sex_column_info.values_used == {"ale"}
-    assert code_column_info.values_used == {"abc", "def", "ghi", "jkl"}
+    assert code_column_info.values_used == {"abc00", "def00", "ghi00", "jkl00"}
 
 
 def test_query_info_ignores_complex_comparisons():

--- a/tests/unit/query_model/test_column_specs.py
+++ b/tests/unit/query_model/test_column_specs.py
@@ -30,7 +30,9 @@ def test_get_column_specs():
             category=Column(
                 SNOMEDCTCode,
                 constraints=[
-                    Constraint.Categorical([SNOMEDCTCode("abc"), SNOMEDCTCode("def")])
+                    Constraint.Categorical(
+                        [SNOMEDCTCode("123000"), SNOMEDCTCode("456000")]
+                    )
                 ],
             ),
         ),
@@ -46,7 +48,9 @@ def test_get_column_specs():
         "patient_id": ColumnSpec(type=int, nullable=False, categories=None),
         "dob": ColumnSpec(type=datetime.date, nullable=True, categories=None),
         "code": ColumnSpec(type=str, nullable=True, categories=None),
-        "category": ColumnSpec(type=str, nullable=True, categories=("abc", "def")),
+        "category": ColumnSpec(
+            type=str, nullable=True, categories=("123000", "456000")
+        ),
     }
 
 

--- a/tests/unit/test_codes.py
+++ b/tests/unit/test_codes.py
@@ -9,19 +9,19 @@ def test_codelist_from_csv(tmp_path):
     csv_file = tmp_path / "codes.csv"
     csv_text = """
         CodeID,foo
-        abc,123
-        def,456
-        ghi ,789
+        abc00,123
+        def00,456
+        ghi00 ,789
         ,
         """
     csv_file.write_text(textwrap.dedent(csv_text.strip()))
     codelist = codelist_from_csv(csv_file, "CodeID", "ctv3")
-    assert codelist.codes == {CTV3Code("abc"), CTV3Code("def"), CTV3Code("ghi")}
+    assert codelist.codes == {CTV3Code("abc00"), CTV3Code("def00"), CTV3Code("ghi00")}
 
 
 def test_codelist_from_csv_missing_column(tmp_path):
     csv_file = tmp_path / "codes.csv"
-    csv_file.write_text("CodeID,foo\nabc,123\n,def,456\n ghi ,789")
+    csv_file.write_text("CodeID,foo\nabc00,123\n,def00,456\n ghi00 ,789")
     with pytest.raises(CodelistError, match="no_col_here"):
         codelist_from_csv(csv_file, "no_col_here", "ctv3")
 
@@ -42,22 +42,22 @@ def test_codelist_from_csv_with_categories(tmp_path):
     csv_file = tmp_path / "codes.csv"
     csv_text = """
         CodeID,cat1,__str__
-        abc,123,foo
-        def,456,bar,
-        ghi ,789
+        abc00,123,foo
+        def00,456,bar,
+        ghi00 ,789
         ,
         """
     csv_file.write_text(textwrap.dedent(csv_text.strip()))
     codelist = codelist_from_csv(csv_file, "CodeID", "ctv3")
     # Sensibly named category is accessible as an attribute
     assert codelist.cat1 == {
-        CTV3Code("abc"): "123",
-        CTV3Code("def"): "456",
-        CTV3Code("ghi"): "789",
+        CTV3Code("abc00"): "123",
+        CTV3Code("def00"): "456",
+        CTV3Code("ghi00"): "789",
     }
     # Poorly named category is still accessible via the dictionary
     assert codelist.category_maps["__str__"] == {
-        CTV3Code("abc"): "foo",
-        CTV3Code("def"): "bar",
-        CTV3Code("ghi"): "",
+        CTV3Code("abc00"): "foo",
+        CTV3Code("def00"): "bar",
+        CTV3Code("ghi00"): "",
     }

--- a/tests/unit/test_codes.py
+++ b/tests/unit/test_codes.py
@@ -2,7 +2,16 @@ import textwrap
 
 import pytest
 
-from databuilder.codes import CodelistError, CTV3Code, codelist_from_csv
+from databuilder.codes import (
+    BNFCode,
+    CodelistError,
+    CTV3Code,
+    DMDCode,
+    ICD10Code,
+    OPCS4Code,
+    SNOMEDCTCode,
+    codelist_from_csv,
+)
 
 
 def test_codelist_from_csv(tmp_path):
@@ -61,3 +70,57 @@ def test_codelist_from_csv_with_categories(tmp_path):
         CTV3Code("def00"): "bar",
         CTV3Code("ghi00"): "",
     }
+
+
+@pytest.mark.parametrize(
+    "cls,value",
+    [
+        (BNFCode, "0101010I0AAAEAE"),
+        (BNFCode, "23965909711"),
+        (CTV3Code, "ABC01"),
+        (CTV3Code, "De4.."),
+        (ICD10Code, "A01"),
+        (ICD10Code, "A012"),
+        (OPCS4Code, "B23"),
+        (OPCS4Code, "B234"),
+        (SNOMEDCTCode, "1234567890"),
+    ],
+)
+def test_valid_codes(cls, value):
+    assert cls(value).value == value
+
+
+@pytest.mark.parametrize(
+    "cls,value",
+    [
+        # Digit (5) instead of letter as first character of Product
+        (BNFCode, "0101010I05AAEAE"),
+        # Appliance but too many digits
+        (BNFCode, "239659097111"),
+        # Wrong length
+        (CTV3Code, "ABC0"),
+        # Dot other than at the end
+        (CTV3Code, "ABC.0"),
+        # Letter other than at the start
+        (ICD10Code, "AA1"),
+        # Wrong length
+        (ICD10Code, "A0124"),
+        # I is not an allowed first character
+        (OPCS4Code, "I00"),
+        # Too short
+        (SNOMEDCTCode, "123"),
+        # Too long
+        (SNOMEDCTCode, "12345678901234567890"),
+        # Leading zero
+        (SNOMEDCTCode, "0123456789"),
+    ],
+)
+def test_invalid_codes(cls, value):
+    with pytest.raises(ValueError):
+        cls(value)
+
+
+def test_syntactically_equivalent_codes():
+    # No point duplicating the tests here, but we'll need to test them if we ever stop
+    # sharing the regex
+    assert DMDCode.regex == SNOMEDCTCode.regex

--- a/tests/unit/test_query_language.py
+++ b/tests/unit/test_query_language.py
@@ -3,10 +3,12 @@ from inspect import signature
 
 import pytest
 
+from databuilder.codes import SNOMEDCTCode
 from databuilder.query_language import (
     BaseSeries,
     BoolEventSeries,
     BoolPatientSeries,
+    CodePatientSeries,
     Dataset,
     DateDifference,
     DateEventSeries,
@@ -481,3 +483,14 @@ def test_ehrql_date_string_equivalence(fn_name):
         str_args = [str_args]
 
     assert f(*date_args).qm_node == f(*str_args).qm_node
+
+
+def test_code_series_instances_have_correct_type_attribute():
+    @table
+    class p(PatientFrame):
+        code = Series(SNOMEDCTCode)
+
+    # The series itself is a generic "BaseCode" series
+    assert isinstance(p.code, CodePatientSeries)
+    # But it knows the specfic coding system type it wraps
+    assert p.code._type is SNOMEDCTCode

--- a/tests/unit/test_query_language.py
+++ b/tests/unit/test_query_language.py
@@ -494,3 +494,21 @@ def test_code_series_instances_have_correct_type_attribute():
     assert isinstance(p.code, CodePatientSeries)
     # But it knows the specfic coding system type it wraps
     assert p.code._type is SNOMEDCTCode
+
+
+def test_strings_are_cast_to_codes():
+    @table
+    class p(PatientFrame):
+        code = Series(SNOMEDCTCode)
+
+    eq_series = p.code == "123000"
+    assert eq_series.qm_node.rhs == Value(SNOMEDCTCode("123000"))
+
+    is_in_series = p.code.is_in(["456000", "789000"])
+    assert is_in_series.qm_node.rhs == Value(
+        frozenset({SNOMEDCTCode("456000"), SNOMEDCTCode("789000")})
+    )
+
+    # Test invalid codes are rejected
+    with pytest.raises(ValueError, match="Invalid SNOMEDCTCode"):
+        p.code == "abc"

--- a/tests/unit/test_query_language.py
+++ b/tests/unit/test_query_language.py
@@ -509,6 +509,12 @@ def test_strings_are_cast_to_codes():
         frozenset({SNOMEDCTCode("456000"), SNOMEDCTCode("789000")})
     )
 
+    mapping = {"456000": "foo", "789000": "bar"}
+    mapped_series = p.code.is_in(mapping)
+    assert mapped_series.qm_node.rhs == Value(
+        frozenset({SNOMEDCTCode("456000"), SNOMEDCTCode("789000")})
+    )
+
     # Test invalid codes are rejected
     with pytest.raises(ValueError, match="Invalid SNOMEDCTCode"):
         p.code == "abc"


### PR DESCRIPTION
This adds validation to the `BaseCode` constructor so that it's no longer possible to create, e.g. `SNOMEDCTCode` instances containing strings which could never be valid SNOMED-CT codes.

With this validation in place we can then use the same mechanism as for handling ISO format date strings to cast strings to the appropriate coding system of the column they're being used with.

This means there's no longer a need for users to import the coding system types, which we don't want them doing anyway as we hadn't made them part of the `databuilder.ehrql` namespace.

