### PR TITLE
Prepare for removal of `Codelist` class

### DIFF
--- a/docs/ehrql/tutorial/7a.md
+++ b/docs/ehrql/tutorial/7a.md
@@ -43,25 +43,13 @@ You need to specify, as strings:
 
 * the CSV filename
 * the name of the CSV column containing the codes
-* the coding system; this must be specified as one of the following:
-  * `"BNFCode"`
-  * `"CTV3Code"`
-  * `"DMDCode"`
-  * `"ICD10Code"`
-  * `"OPCS4Code"`
-  * `"Read2Code"`
-  * `"SNOMEDCTCode"`
-
-!!! todo
-    Retrieve the code class names automatically.
-    Where is best to specify these?
 
 ???+ example "`codelist_from_csv()`"
 
     ```python
     from databuilder.codes import codelist_from_csv
 
-    codelist = codelist_from_csv(filename="my_codelist.csv", column="code", system="SNOMEDCTCode")
+    codelist = codelist_from_csv(filename="my_codelist.csv", column="code")
     ```
 
 ### Checking if a code is in a codelist
@@ -78,11 +66,11 @@ You can use `isin` and `isnotin` to check for specific codes.
 ???+ example "Dataset definition"
 
     ```python
-    from databuilder.codes import codelist_from_csv, SNOMEDCTCode
-    from databuilder.ehrql import Dataset
+    from databuilder.codes import SNOMEDCTCode
+    from databuilder.ehrql import Dataset, codelist_from_csv
     from databuilder.tables.example.tutorial import clinical_events
 
-    codelist = codelist_from_csv(filename="my_codelist.csv", column="code", system="SNOMEDCTCode")
+    codelist = codelist_from_csv(filename="my_codelist.csv", column="code")
     a1_code = SNOMEDCTCode("a1")
     a2_code = SNOMEDCTCode("a2")
 

--- a/docs/includes/generated_docs/specs.md
+++ b/docs/includes/generated_docs/specs.md
@@ -1537,7 +1537,7 @@ This example makes use of a patient-level table named `p` containing the followi
 | 4| |
 
 ```
-p.c1.to_category(codelist.my_categorisation)
+p.c1.to_category(codelist)
 ```
 returns the following patient series:
 

--- a/tests/acceptance/test_external_studies.py
+++ b/tests/acceptance/test_external_studies.py
@@ -46,9 +46,10 @@ STUDY_DIR = Path(__file__).parent / "external_studies"
 
 
 @pytest.mark.parametrize("name", EXTERNAL_STUDIES.keys())
-def test_external_study(name):
+def test_external_study(name, monkeypatch):
     study_path = STUDY_DIR / name
     dataset_def_path = study_path / EXTERNAL_STUDIES[name]["dataset_definition"]
+    monkeypatch.chdir(study_path)
     # Test that we can compile the dataset definition to a valid query model graph. I
     # think this is sufficient for these tests which are intended to ensure we don't
     # accidentally break the API. If we're unable to execute a valid query, that's a

--- a/tests/spec/code_series_ops/test_containment.py
+++ b/tests/spec/code_series_ops/test_containment.py
@@ -50,7 +50,6 @@ def test_is_in_codelist_csv(spec_test):
             "789000",
         ],
         column="code",
-        system="snomedct",
     )
 
     spec_test(

--- a/tests/spec/code_series_ops/test_map_codes_to_categories.py
+++ b/tests/spec/code_series_ops/test_map_codes_to_categories.py
@@ -24,12 +24,12 @@ def test_map_codes_to_categories(spec_test):
             "789000,cat2",
         ],
         column="code",
-        system="snomedct",
+        category_column="my_categorisation",
     )
 
     spec_test(
         table_data,
-        p.c1.to_category(codelist.my_categorisation),
+        p.c1.to_category(codelist),
         {
             1: "cat1",
             2: None,

--- a/tests/unit/test_codes.py
+++ b/tests/unit/test_codes.py
@@ -11,6 +11,7 @@ from databuilder.codes import (
     OPCS4Code,
     SNOMEDCTCode,
     codelist_from_csv,
+    codelist_from_csv_lines,
 )
 
 
@@ -18,21 +19,12 @@ def test_codelist_from_csv(tmp_path):
     csv_file = tmp_path / "codes.csv"
     csv_text = """
         CodeID,foo
-        abc00,123
-        def00,456
-        ghi00 ,789
-        ,
+        abc00,
+        def00,
         """
     csv_file.write_text(textwrap.dedent(csv_text.strip()))
     codelist = codelist_from_csv(csv_file, "CodeID", "ctv3")
-    assert codelist.codes == {CTV3Code("abc00"), CTV3Code("def00"), CTV3Code("ghi00")}
-
-
-def test_codelist_from_csv_missing_column(tmp_path):
-    csv_file = tmp_path / "codes.csv"
-    csv_file.write_text("CodeID,foo\nabc00,123\n,def00,456\n ghi00 ,789")
-    with pytest.raises(CodelistError, match="no_col_here"):
-        codelist_from_csv(csv_file, "no_col_here", "ctv3")
+    assert codelist.codes == {CTV3Code("abc00"), CTV3Code("def00")}
 
 
 def test_codelist_from_csv_missing_file(tmp_path):
@@ -40,24 +32,49 @@ def test_codelist_from_csv_missing_file(tmp_path):
         codelist_from_csv(tmp_path / "no_file_here.csv", "CodeID", "ctv3")
 
 
-def test_codelist_from_csv_unknown_system(tmp_path):
-    csv_file = tmp_path / "codes.csv"
-    csv_file.touch()
+def test_codelist_from_csv_lines():
+    csv_lines = [
+        "CodeID,foo",
+        "abc00,",
+        "def00,",
+        # Check codes are trimmed
+        "ghi00 ,",
+        # Check blanks are ignored
+        "  ,"
+        # Check duplicates are ignored
+        " def00,",
+    ]
+    codelist = codelist_from_csv_lines(csv_lines, "CodeID", "ctv3")
+    assert codelist.codes == {CTV3Code("abc00"), CTV3Code("def00"), CTV3Code("ghi00")}
+
+
+def test_codelist_from_csv_lines_missing_column():
+    csv_lines = [
+        "CodeID",
+        "abc00",
+    ]
+    with pytest.raises(CodelistError, match="no_col_here"):
+        codelist_from_csv_lines(csv_lines, "no_col_here", "ctv3")
+
+
+def test_codelist_from_csv_lines_unknown_system():
+    csv_lines = [
+        "CodeID",
+        "abc00",
+    ]
     with pytest.raises(CodelistError, match="not_a_real_system"):
-        codelist_from_csv(csv_file, "CodeID", "not_a_real_system")
+        codelist_from_csv_lines(csv_lines, "CodeID", "not_a_real_system")
 
 
-def test_codelist_from_csv_with_categories(tmp_path):
-    csv_file = tmp_path / "codes.csv"
-    csv_text = """
-        CodeID,cat1,__str__
-        abc00,123,foo
-        def00,456,bar,
-        ghi00 ,789
-        ,
-        """
-    csv_file.write_text(textwrap.dedent(csv_text.strip()))
-    codelist = codelist_from_csv(csv_file, "CodeID", "ctv3")
+def test_codelist_from_csv_lines_with_categories():
+    csv_lines = [
+        "CodeID,cat1,__str__",
+        "abc00,123,foo",
+        "def00,456,bar,",
+        "ghi00 ,789",
+        ",",
+    ]
+    codelist = codelist_from_csv_lines(csv_lines, "CodeID", "ctv3")
     # Sensibly named category is accessible as an attribute
     assert codelist.cat1 == {
         CTV3Code("abc00"): "123",

--- a/tests/unit/test_codes.py
+++ b/tests/unit/test_codes.py
@@ -125,6 +125,52 @@ def test_codelist_from_csv_lines_without_system():
     assert codelist == ["abc00", "def00", "ghi00"]
 
 
+def test_codelist_from_csv_lines_with_category_column():
+    csv_lines = [
+        "CodeID,Cat1",
+        "abc00,foo",
+        "def00,bar",
+        "ghi00,",
+    ]
+    codelist = codelist_from_csv_lines(
+        csv_lines,
+        column="CodeID",
+        category_column="Cat1",
+    )
+    assert codelist == {
+        "abc00": "foo",
+        "def00": "bar",
+        "ghi00": "",
+    }
+
+
+def test_codelist_from_csv_lines_with_missing_category_column():
+    csv_lines = [
+        "CodeID,Cat1",
+        "abc00,foo",
+    ]
+    with pytest.raises(CodelistError, match="no_col_here"):
+        codelist_from_csv_lines(
+            csv_lines,
+            column="CodeID",
+            category_column="no_col_here",
+        )
+
+
+def test_codelist_from_csv_lines_combining_system_and_category_column():
+    csv_lines = [
+        "CodeID,Cat1",
+        "abc00,foo",
+    ]
+    with pytest.raises(CodelistError, match="cannot be supplied together"):
+        codelist_from_csv_lines(
+            csv_lines,
+            column="CodeID",
+            system="ctv3",
+            category_column="Cat1",
+        )
+
+
 @pytest.mark.parametrize(
     "cls,value",
     [

--- a/tests/unit/test_codes.py
+++ b/tests/unit/test_codes.py
@@ -109,6 +109,22 @@ def test_codelist_from_csv_lines_with_categories():
     }
 
 
+def test_codelist_from_csv_lines_without_system():
+    csv_lines = [
+        "CodeID,foo",
+        "abc00,",
+        "def00,",
+        # Check codes are trimmed
+        "ghi00 ,",
+        # Check blanks are ignored
+        "  ,"
+        # Check duplicates are ignored
+        " def00,",
+    ]
+    codelist = codelist_from_csv_lines(csv_lines, column="CodeID")
+    assert codelist == ["abc00", "def00", "ghi00"]
+
+
 @pytest.mark.parametrize(
     "cls,value",
     [

--- a/tests/unit/test_codes.py
+++ b/tests/unit/test_codes.py
@@ -23,13 +23,17 @@ def test_codelist_from_csv(tmp_path):
         def00,
         """
     csv_file.write_text(textwrap.dedent(csv_text.strip()))
-    codelist = codelist_from_csv(csv_file, "CodeID", "ctv3")
+    codelist = codelist_from_csv(csv_file, column="CodeID", system="ctv3")
     assert codelist.codes == {CTV3Code("abc00"), CTV3Code("def00")}
 
 
 def test_codelist_from_csv_missing_file(tmp_path):
     with pytest.raises(CodelistError, match="no_file_here.csv"):
-        codelist_from_csv(tmp_path / "no_file_here.csv", "CodeID", "ctv3")
+        codelist_from_csv(
+            tmp_path / "no_file_here.csv",
+            column="CodeID",
+            system="ctv3",
+        )
 
 
 def test_codelist_from_csv_lines():
@@ -44,7 +48,11 @@ def test_codelist_from_csv_lines():
         # Check duplicates are ignored
         " def00,",
     ]
-    codelist = codelist_from_csv_lines(csv_lines, "CodeID", "ctv3")
+    codelist = codelist_from_csv_lines(
+        csv_lines,
+        column="CodeID",
+        system="ctv3",
+    )
     assert codelist.codes == {CTV3Code("abc00"), CTV3Code("def00"), CTV3Code("ghi00")}
 
 
@@ -54,7 +62,11 @@ def test_codelist_from_csv_lines_missing_column():
         "abc00",
     ]
     with pytest.raises(CodelistError, match="no_col_here"):
-        codelist_from_csv_lines(csv_lines, "no_col_here", "ctv3")
+        codelist_from_csv_lines(
+            csv_lines,
+            column="no_col_here",
+            system="ctv3",
+        )
 
 
 def test_codelist_from_csv_lines_unknown_system():
@@ -63,7 +75,11 @@ def test_codelist_from_csv_lines_unknown_system():
         "abc00",
     ]
     with pytest.raises(CodelistError, match="not_a_real_system"):
-        codelist_from_csv_lines(csv_lines, "CodeID", "not_a_real_system")
+        codelist_from_csv_lines(
+            csv_lines,
+            column="CodeID",
+            system="not_a_real_system",
+        )
 
 
 def test_codelist_from_csv_lines_with_categories():
@@ -74,7 +90,11 @@ def test_codelist_from_csv_lines_with_categories():
         "ghi00 ,789",
         ",",
     ]
-    codelist = codelist_from_csv_lines(csv_lines, "CodeID", "ctv3")
+    codelist = codelist_from_csv_lines(
+        csv_lines,
+        column="CodeID",
+        system="ctv3",
+    )
     # Sensibly named category is accessible as an attribute
     assert codelist.cat1 == {
         CTV3Code("abc00"): "123",


### PR DESCRIPTION
This is a "make things worse before making them better" PR: it adds some conditional behaviour to `codelist_from_csv()` to change the return type based on the arguments supplied.

The end goal is to remove both the `system` argument and the `Codelist` type entirely and replace them with lists and dicts containing strings. But to facilitate a smooth transition we first support both lists/dicts and `Codelist`. Then, once we've updated all extant ehrQL projects, we can remove the old code and simplify.

The aim here is both to simplify things for end users and to reduce the API surface of ehrQL. Now that we can [validate](https://github.com/opensafely-core/databuilder/pull/1081) strings against the coding system they're being used with we no longer need users to specify the system for each codelist. Of course, ideally we'd get metadata from OpenCodelists which tells us the system automatically. But until we have this, making the user specify it doesn't add any meaningful validation and complicates the API.

As for removing the `Codelist` class, I think the more we can use standard Python types the better. If we later find a use for a specialised container type for codes we can add one, but driven by concrete needs rather than speculatively.

One final thought: conceptually codelists should probably be represented by `set` rather than `list`. But I couldn't really think of any concrete advantages to this, and using `list` felt  like a simpler and more friendly type for Python newbies.