### PR TITLE
Ensure MSSQL engine treats all float-like values as float, not decimal

### DIFF
--- a/tests/integration/query_engines/test_mssql_dialect.py
+++ b/tests/integration/query_engines/test_mssql_dialect.py
@@ -33,3 +33,11 @@ def test_enforces_minimum_server_version(mssql_engine, monkeypatch):
     monkeypatch.setattr(MSSQLDialect, "minimum_server_version", (999999,))
     with pytest.raises(RuntimeError, match=r"we require at least \(999999,\)"):
         mssql_engine.sqlalchemy_engine().connect()
+
+
+def test_float_literals_have_correct_type(mssql_engine):
+    sum_literal = sqlalchemy.func.sum(0.5)
+    query = sqlalchemy.select(sum_literal + 0.25)
+    with mssql_engine.sqlalchemy_engine().connect() as conn:
+        results = list(conn.execute(query))
+    assert results[0][0] == 0.75

--- a/tests/unit/query_engines/test_mssql_dialect.py
+++ b/tests/unit/query_engines/test_mssql_dialect.py
@@ -74,3 +74,14 @@ def _str(expression):
         compile_kwargs={"literal_binds": True},
     )
     return str(compiled).strip()
+
+
+def test_mssql_float_type():
+    float_col = sqlalchemy.Column("float_col", sqlalchemy_types.Float())
+    # explicitly casts floats
+    assert _str(float_col == 0.75) == "float_col = CAST(0.75 AS FLOAT)"
+    assert _str(float_col == None) == "float_col IS NULL"  # noqa: E711
+    assert (
+        _str(sqlalchemy.sql.case((float_col > 0.5, 0.1), else_=0.75))
+        == "CASE WHEN (float_col > CAST(0.5 AS FLOAT)) THEN CAST(0.1 AS FLOAT) ELSE CAST(0.75 AS FLOAT) END"
+    )


### PR DESCRIPTION
Fixes #1065 

Adds a custom Float type for the mssql engine, which ensures that all bound parameters are cast to float.

I haven't added the spec test that fails in #1065, because it doesn't seem like a useful test to be included in the documentation, but I have verified that it passes with this change.