### PR TITLE
Use `InMemoryQueryEngine` for population validation

### DIFF
--- a/databuilder/query_model/nodes.py
+++ b/databuilder/query_model/nodes.py
@@ -435,6 +435,11 @@ def get_series_type(series):
 
 
 def validate_node(node):
+    # Check that the node is hashable
+    try:
+        hash(node)
+    except TypeError as e:
+        raise TypeError("Node arguments must be hashable types") from e
     # Check that the types supplied match the types specified
     validate_types(node)
     # As well as types we need to validate the "domain constraint" which specifies how

--- a/databuilder/query_model/population_validation.py
+++ b/databuilder/query_model/population_validation.py
@@ -1,21 +1,11 @@
-import dataclasses
-import operator
-from functools import singledispatch
-
 from databuilder.query_engines.in_memory import InMemoryQueryEngine
 from databuilder.query_engines.in_memory_database import EventTable, PatientTable
 from databuilder.query_model.nodes import (
-    AggregateByPatient,
-    Case,
-    Function,
-    SelectColumn,
     Series,
     ValidationError,
-    Value,
     get_series_type,
     has_one_row_per_patient,
 )
-from databuilder.utils import date_utils, math_utils
 
 
 def validate_population_definition(population):
@@ -111,136 +101,3 @@ class EmptyQueryEngine(InMemoryQueryEngine):
     def visit_SelectPatientTable(self, node):
         column_names = ["patient_id", *node.schema.column_names]
         return PatientTable.from_records(column_names, row_records=[])
-
-
-@singledispatch
-def evaluate(node):
-    """
-    Given a Series node, return the value it would take if all its inputs were NULL
-    """
-    assert False, f"Unhandled node type: {type(node)}"
-
-
-@evaluate.register(Value)
-def evaluate_value(node):
-    return node.value
-
-
-@evaluate.register(SelectColumn)
-def evaluate_select_column(node):
-    return None
-
-
-@evaluate.register(AggregateByPatient.Exists)
-def evaluate_exists(node):
-    return False
-
-
-@evaluate.register(AggregateByPatient.Count)
-def evaluate_count(node):
-    return 0
-
-
-@evaluate.register(AggregateByPatient.CombineAsSet)
-def evaluate_combine_as_set(node):
-    return ()
-
-
-@evaluate.register(AggregateByPatient.Min)
-@evaluate.register(AggregateByPatient.Max)
-@evaluate.register(AggregateByPatient.Sum)
-@evaluate.register(AggregateByPatient.Mean)
-def evaluate_aggregation(node):
-    return None
-
-
-@evaluate.register(Function.IsNull)
-def evaluate_is_null(node):
-    return evaluate(node.source) is None
-
-
-@evaluate.register(Function.And)
-def evaluate_and(node):
-    lhs = evaluate(node.lhs)
-    rhs = evaluate(node.rhs)
-    if lhs is True and rhs is True:
-        return True
-    elif lhs is False or rhs is False:
-        return False
-    else:
-        return None
-
-
-@evaluate.register(Function.Or)
-def evaluate_or(node):
-    lhs = evaluate(node.lhs)
-    rhs = evaluate(node.rhs)
-    if lhs is True or rhs is True:
-        return True
-    elif lhs is False and rhs is False:
-        return False
-    else:
-        return None
-
-
-@evaluate.register(Case)
-def evaluate_case(node):
-    for condition, value in node.cases.items():
-        if evaluate(condition) is True:
-            return evaluate(value)
-    if node.default is not None:
-        return evaluate(node.default)
-
-
-def register_op(cls):
-    """
-    Handle registration for any operations with the default NULL behaviour, which is
-    that they return NULL if any of their arguments are NULL
-    """
-    getters = [operator.attrgetter(field.name) for field in dataclasses.fields(cls)]
-
-    def register(function):
-        @evaluate.register(cls)
-        def apply(node):
-            args = [evaluate(get_arg(node)) for get_arg in getters]
-            if any(arg is None for arg in args):
-                return None
-            return function(*args)
-
-        return apply
-
-    return register
-
-
-@register_op(Function.In)
-def in_(lhs, rhs):
-    return operator.contains(rhs, lhs)
-
-
-register_op(Function.YearFromDate)(date_utils.year_from_date)
-register_op(Function.MonthFromDate)(date_utils.month_from_date)
-register_op(Function.DayFromDate)(date_utils.day_from_date)
-register_op(Function.DateDifferenceInDays)(date_utils.date_difference_in_days)
-register_op(Function.DateDifferenceInMonths)(date_utils.date_difference_in_months)
-register_op(Function.DateDifferenceInYears)(date_utils.date_difference_in_years)
-register_op(Function.DateAddDays)(date_utils.date_add_days)
-register_op(Function.DateAddMonths)(date_utils.date_add_months)
-register_op(Function.DateAddYears)(date_utils.date_add_years)
-register_op(Function.ToFirstOfYear)(date_utils.to_first_of_year)
-register_op(Function.ToFirstOfMonth)(date_utils.to_first_of_month)
-register_op(Function.Not)(operator.not_)
-register_op(Function.Negate)(operator.neg)
-register_op(Function.EQ)(operator.eq)
-register_op(Function.NE)(operator.ne)
-register_op(Function.LT)(operator.lt)
-register_op(Function.LE)(operator.le)
-register_op(Function.GT)(operator.gt)
-register_op(Function.GE)(operator.ge)
-register_op(Function.Add)(operator.add)
-register_op(Function.Subtract)(operator.sub)
-register_op(Function.Multiply)(operator.mul)
-register_op(Function.TrueDivide)(math_utils.truediv)
-register_op(Function.FloorDivide)(math_utils.floordiv)
-register_op(Function.CastToInt)(int)
-register_op(Function.CastToFloat)(float)
-register_op(Function.StringContains)(operator.contains)

--- a/databuilder/utils/orm_utils.py
+++ b/databuilder/utils/orm_utils.py
@@ -6,7 +6,6 @@ from contextlib import ExitStack
 import sqlalchemy
 from sqlalchemy.orm import declarative_base
 
-from databuilder.query_language import BaseFrame
 from databuilder.query_model.nodes import has_one_row_per_patient
 from databuilder.sqlalchemy_types import Integer, type_from_python_type
 from databuilder.utils.sqlalchemy_query_utils import expr_has_type
@@ -73,7 +72,7 @@ def make_orm_models(*args):
             combined.setdefault(table, []).extend(rows)
     orm_classes = orm_classes_from_tables(combined.keys())
     for table, rows in combined.items():
-        table_name = table.qm_node.name if isinstance(table, BaseFrame) else table.name
+        table_name = table.qm_node.name if hasattr(table, "qm_node") else table.name
         orm_class = orm_classes[table_name]
         yield from (orm_class(**row) for row in rows)
 
@@ -84,7 +83,7 @@ def orm_classes_from_tables(tables):
     a dict mapping table names to ORM classes
     """
     qm_tables = frozenset(
-        table.qm_node if isinstance(table, BaseFrame) else table for table in tables
+        table.qm_node if hasattr(table, "qm_node") else table for table in tables
     )
     return _orm_classes_from_qm_tables(qm_tables)
 

--- a/tests/lib/query_model_utils.py
+++ b/tests/lib/query_model_utils.py
@@ -2,13 +2,16 @@ import dataclasses
 
 from databuilder.query_model import nodes as query_model
 
+# These are only exercised during the long-running generative tests when
+# GENTEST_COMPREHENSIVE is enabled
 
-def get_all_operations():
+
+def get_all_operations():  # pragma: no cover
     "Return every operation defined in the query model"
     return [cls for cls in iterate_query_model_namespace() if is_operation(cls)]
 
 
-def is_operation(cls):
+def is_operation(cls):  # pragma: no cover
     "Return whether an arbitrary value is a query model operation class"
     # We need to check this first or the `issubclass` check can fail
     if not isinstance(cls, type):
@@ -21,7 +24,7 @@ def is_operation(cls):
     return len(dataclasses.fields(cls)) > 0
 
 
-def iterate_query_model_namespace():
+def iterate_query_model_namespace():  # pragma: no cover
     "Yield every public thing in the query_model module"
     yield from [getattr(query_model, name) for name in query_model.__all__]
     yield from vars(query_model.Function).values()

--- a/tests/unit/query_model/test_nodes.py
+++ b/tests/unit/query_model/test_nodes.py
@@ -438,3 +438,8 @@ def test_comparisons_between_value_nodes_are_strict():
     assert Value(10) != Value(10.0)
     assert Value(1) != Value(True)
     assert Value(10) != 10
+
+
+def test_unhashable_arguments_are_rejected():
+    with pytest.raises(TypeError):
+        Value({1, 2, 3})

--- a/tests/unit/query_model/test_nodes.py
+++ b/tests/unit/query_model/test_nodes.py
@@ -416,7 +416,7 @@ def test_any_type_acts_as_an_escape_hatch():
     # them in the type checking system, which is already "cleverer" than anyone would
     # like. This test ensures that `Any` can be used as an escape hatch.
 
-    mixed_set = {1, 2.0, "three"}
+    mixed_set = frozenset({1, 2.0, "three"})
 
     # Confirm that we can't validate heterogeneous sets
     class SomePublicOperation(Series):

--- a/tests/unit/query_model/test_population_validation.py
+++ b/tests/unit/query_model/test_population_validation.py
@@ -8,17 +8,14 @@ from databuilder.query_model.nodes import (
     SelectColumn,
     SelectPatientTable,
     SelectTable,
-    Series,
     TableSchema,
     Value,
 )
 from databuilder.query_model.population_validation import (
     EmptyQueryEngine,
     ValidationError,
-    evaluate,
     validate_population_definition,
 )
-from tests.lib.query_model_utils import get_all_operations
 
 
 def test_rejects_non_series():
@@ -205,17 +202,3 @@ cases = [
 def test_series_evaluates_true(expected, query):
     result = EmptyQueryEngine(None).series_evaluates_true(query)
     assert result == expected, f"Expected {expected}, got {result} in:\n{query}"
-
-
-# TEST EVALUTE DEFINITION IS EXHAUSTIVE
-#
-# Test that the `evaluate()` single dispatch function is exhaustively defined so we
-# can't forget to update it if we add a new query model operation.
-#
-@pytest.mark.parametrize(
-    "operation", [op for op in get_all_operations() if issubclass(op, Series)]
-)
-def test_evaluate_function_defined_for(operation):
-    default = evaluate.dispatch(object)
-    function = evaluate.dispatch(operation)
-    assert function != default, f"No `evaluate()` implementation for {operation}"

--- a/tests/unit/query_model/test_population_validation.py
+++ b/tests/unit/query_model/test_population_validation.py
@@ -160,13 +160,6 @@ cases = [
         Function.In(Value(10), Value(frozenset([30, 20, 10]))),
     ),
     (
-        None,
-        Function.In(
-            patients_value,
-            AggregateByPatient.CombineAsSet(events_value),
-        ),
-    ),
-    (
         "bar",
         Case(
             {

--- a/tests/unit/query_model/test_population_validation.py
+++ b/tests/unit/query_model/test_population_validation.py
@@ -157,7 +157,7 @@ cases = [
     ),
     (
         True,
-        Function.In(Value(10), Value({30, 20, 10})),
+        Function.In(Value(10), Value(frozenset([30, 20, 10]))),
     ),
     (
         None,


### PR DESCRIPTION
The previous `population_validation` module ended up duplicating logic from the in-memory engine. The total amount of code wasn't huge, but it meant that anyone adding an operation to the query model had _yet another_ set of changes to worry about (alongside a Python implementation, three flavours of SQL and a generative test strategy). Re-using the in-memory engine avoids this.

Closes #1019