### PR TITLE
feat: Run generate-docs as a pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,3 +37,12 @@ repos:
     - id: check-toml
     - id: check-yaml
     - id: detect-private-key
+
+  - repo: local
+    hooks:
+    - id: check-docs
+      name: check-docs
+      entry: scripts/check-docs.sh
+      language: script
+      types: [python]
+      always_run: true

--- a/scripts/check-docs.sh
+++ b/scripts/check-docs.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/bash
+
+# This script is run as a pre-commit hook to ensure generated docs files are
+# up to date
+
+just generate-docs


### PR DESCRIPTION
fixes #967 

Runs the `just` command to generate the automated docs from the backends, contracts, schema and specs tests as a pre-commit hook.

This could also run the command to build the dataset definition outputs for the ehrql tutorial, but that takes a while and probably doesn't want to run on every commit.  If someone makes a change that needs to update those outputs, they should be aware of it, and it'll be picked up in CI if not.