### PR TITLE
Keep databuilder image version in tutorial up to date

### DIFF
--- a/.github/workflows/update-tutorial-databuilder-version.yml
+++ b/.github/workflows/update-tutorial-databuilder-version.yml
@@ -1,0 +1,66 @@
+---
+name: "Create PR to update databuilder image version in ehrql tutorial"
+
+on:
+  workflow_dispatch:
+  workflow_run:
+    workflows:
+      - CI
+      - Check documentation
+      - Build and publish image
+    branches:
+      - main
+    types:
+      - completed
+
+jobs:
+  create_tutorial_version_pr:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: opensafely-core/setup-action@v1
+        with:
+          install-just: true
+          python-version: "3.9"
+
+      - name: Install opensafely
+        run: pip install opensafely
+
+      - name: Update databuilder image version in tutorial project.yaml
+        env:
+          TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: just docs-update-tutorial-databuilder-version
+
+      - name: Check dataset definitions outputs can be built with OpenSAFELY CLI project.yaml
+        run: just docs-build-dataset-definitions-outputs-docker-project
+
+      - name: Create a Pull Request if there are any changes
+        id: create_pr
+        uses: peter-evans/create-pull-request@2b011faafdcbc9ceb11414d64d0573f37c774b04 # v4.2.3
+        with:
+          add-paths: |
+            docs/ehrql-tutorial-examples/project.yaml
+            docs/ehrql-tutorial-examples/outputs/*
+          branch: bot/update-tutorial-version
+          base: main
+          commit-message: "chore: Update databuilder version in tutorial project.yaml"
+          title: "Update databuilder version in tutorial project.yaml"
+          body: |
+            To get tests to run on this PR there's an odd workflow:
+             - Approve it
+             - Close it
+             - Re-open it
+             - Re-enable automerge
+
+            You can read more on why this is needed in the `create-pull-request` [docs][1].
+
+            [1]: https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs
+
+      # The PR will still require manual approval, this just reduces it to a one-click process
+      - name: Enable automerge
+        if: steps.create_pr.outputs.pull-request-operation == 'created'
+        uses: peter-evans/enable-pull-request-automerge@60812ab1c2c6c6a8932b4d6e059becafaf386256 # v2.3.0
+        with:
+          pull-request-number: ${{ steps.create_pr.outputs.pull-request-number }}
+          merge-method: squash

--- a/.github/workflows/update-tutorial-databuilder-version.yml
+++ b/.github/workflows/update-tutorial-databuilder-version.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Update databuilder image version in tutorial project.yaml
         env:
-          TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: just docs-update-tutorial-databuilder-version
 
       - name: Check dataset definitions outputs can be built with OpenSAFELY CLI project.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,6 @@ cache/
 
 # MkDocs output
 site/
+
+# tutorial examples metadata (generated when running tutorial actions in docker)
+docs/ehrql-tutorial-examples/metadata/

--- a/Justfile
+++ b/Justfile
@@ -308,3 +308,22 @@ docs-check-generated-docs-are-current: generate-docs
       echo "Generated docs directory contains files/directories not in the repository."
       exit 1
     fi
+
+
+docs-update-tutorial-databuilder-version:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    if [ -z ${TOKEN+x}]
+    then
+      echo "TOKEN env variable is required (a PAT with the packages:read permission)"
+      exit 1
+    fi
+
+    # find latest major version
+    latest_version=$(curl -H "Authorization: Bearer $TOKEN" \
+    https://api.github.com/orgs/opensafely-core/packages/container/databuilder/versions?per_page=1 \
+    | jq -r '.[0].metadata.container.tags[-1]')
+
+    # replace latest version in tutorial project.yaml
+    sed -Ei "s/v[0-9]\b/${latest_version}/g" docs/ehrql-tutorial-examples/project.yaml

--- a/docs/ehrql-tutorial-examples/project.yaml
+++ b/docs/ehrql-tutorial-examples/project.yaml
@@ -5,55 +5,55 @@ expectations:
 
 actions:
   extract_1a_minimal_population:
-    run: databuilder:v0.67.0 generate-dataset "./1a_minimal_dataset_definition.py" --dummy-tables "example-data/minimal" --output "outputs/1a_minimal_dataset_definition.csv"
+    run: databuilder:v0 generate-dataset "./1a_minimal_dataset_definition.py" --dummy-tables "example-data/minimal" --output "outputs/1a_minimal_dataset_definition.csv"
     outputs:
       highly_sensitive:
         population: outputs/1a_minimal_dataset_definition.csv
 
   extract_1b_minimal_population:
-    run: databuilder:v0.67.0 generate-dataset "./1b_minimal_dataset_definition.py" --dummy-tables "example-data/minimal" --output "outputs/1b_minimal_dataset_definition.csv"
+    run: databuilder:v0 generate-dataset "./1b_minimal_dataset_definition.py" --dummy-tables "example-data/minimal" --output "outputs/1b_minimal_dataset_definition.csv"
     outputs:
       highly_sensitive:
         population: outputs/1b_minimal_dataset_definition.csv
 
   extract_2a_multiple_population:
-    run: databuilder:v0.67.0 generate-dataset "./2a_multiple_dataset_definition.py" --dummy-tables "example-data/multiple" --output "outputs/2a_multiple_dataset_definition.csv"
+    run: databuilder:v0 generate-dataset "./2a_multiple_dataset_definition.py" --dummy-tables "example-data/multiple" --output "outputs/2a_multiple_dataset_definition.csv"
     outputs:
       highly_sensitive:
         population: outputs/2a_multiple_dataset_definition.csv
 
   extract_3a_multiple2_population:
-    run: databuilder:v0.67.0 generate-dataset "./3a_multiple2_dataset_definition.py" --dummy-tables "example-data/multiple2" --output "outputs/3a_multiple2_dataset_definition.csv"
+    run: databuilder:v0 generate-dataset "./3a_multiple2_dataset_definition.py" --dummy-tables "example-data/multiple2" --output "outputs/3a_multiple2_dataset_definition.csv"
     outputs:
       highly_sensitive:
         population: outputs/3a_multiple2_dataset_definition.csv
 
   extract_3a1_multiple2_population:
-    run: databuilder:v0.67.0 generate-dataset "./3a1_multiple2_dataset_definition.py" --dummy-tables "example-data/multiple2" --output "outputs/3a1_multiple2_dataset_definition.csv"
+    run: databuilder:v0 generate-dataset "./3a1_multiple2_dataset_definition.py" --dummy-tables "example-data/multiple2" --output "outputs/3a1_multiple2_dataset_definition.csv"
     outputs:
       highly_sensitive:
         population: outputs/3a1_multiple2_dataset_definition.csv
 
   extract_3a2_multiple2_population:
-    run: databuilder:v0.67.0 generate-dataset "./3a2_multiple2_dataset_definition.py" --dummy-tables "example-data/multiple2" --output "outputs/3a2_multiple2_dataset_definition.csv"
+    run: databuilder:v0 generate-dataset "./3a2_multiple2_dataset_definition.py" --dummy-tables "example-data/multiple2" --output "outputs/3a2_multiple2_dataset_definition.csv"
     outputs:
       highly_sensitive:
         population: outputs/3a2_multiple2_dataset_definition.csv
 
   extract_4a_multiple2_population:
-    run: databuilder:v0.67.0 generate-dataset "./4a_multiple2_dataset_definition.py" --dummy-tables "example-data/multiple2" --output "outputs/4a_multiple2_dataset_definition.csv"
+    run: databuilder:v0 generate-dataset "./4a_multiple2_dataset_definition.py" --dummy-tables "example-data/multiple2" --output "outputs/4a_multiple2_dataset_definition.csv"
     outputs:
       highly_sensitive:
         population: outputs/4a_multiple2_dataset_definition.csv
 
   extract_5a_multiple3_population:
-    run: databuilder:v0.67.0 generate-dataset "./5a_multiple3_dataset_definition.py" --dummy-tables "example-data/multiple3" --output "outputs/5a_multiple3_dataset_definition.csv"
+    run: databuilder:v0 generate-dataset "./5a_multiple3_dataset_definition.py" --dummy-tables "example-data/multiple3" --output "outputs/5a_multiple3_dataset_definition.csv"
     outputs:
       highly_sensitive:
         population: outputs/5a_multiple3_dataset_definition.csv
 
   extract_6a_multiple4_population:
-    run: databuilder:v0.67.0 generate-dataset "./6a_multiple4_dataset_definition.py" --dummy-tables "example-data/multiple4" --output "outputs/6a_multiple4_dataset_definition.csv"
+    run: databuilder:v0 generate-dataset "./6a_multiple4_dataset_definition.py" --dummy-tables "example-data/multiple4" --output "outputs/6a_multiple4_dataset_definition.csv"
     outputs:
       highly_sensitive:
         population: outputs/6a_multiple4_dataset_definition.csv


### PR DESCRIPTION
Adds a just command to find the latest (major) databuilder image version and update it in the ehrql tutorial's project.yaml.

A new github action runs after merges to main to run the update command, build the tutorial dataset definitions with the OpenSAFELY CLI, which will pull in any new updates to the image after the merge to main, and create a PR if anything has changed. 

Fixes #966 