### PR TITLE
Ignore warnings from external test code

### DIFF
--- a/tests/acceptance/test_external_studies.py
+++ b/tests/acceptance/test_external_studies.py
@@ -1,5 +1,6 @@
 import contextlib
 import sys
+import warnings
 from pathlib import Path
 
 import pytest
@@ -146,6 +147,9 @@ def test_external_study(study_name, dataset_def):
         # variables_lib.py) Ensure that we clean up the module namespace after each
         # external study test.
         stack.enter_context(reset_module_namespace())
+        # Usually we treat warnings as errors, but we want to ignore them in user code
+        stack.enter_context(warnings.catch_warnings())
+        warnings.simplefilter("ignore")
         # Import the dataset (most of the validation work happens here)
         dataset = load_dataset_definition(dataset_def_path, user_args=())
     # Test that we can compile the dataset definition to a valid query model graph. I

--- a/tests/acceptance/test_external_studies.py
+++ b/tests/acceptance/test_external_studies.py
@@ -125,17 +125,22 @@ def reset_module_namespace():
         del sys.modules[key]
 
 
-@pytest.mark.parametrize("name", EXTERNAL_STUDIES.keys())
-def test_external_study(name, monkeypatch, reset_module_namespace):
-    # clear_module_namespace()
-    study_path = STUDY_DIR / name
-    for dataset_def in EXTERNAL_STUDIES[name]["dataset_definitions"]:
-        dataset_def_path = study_path / dataset_def
-        monkeypatch.chdir(study_path)
-        # Test that we can compile the dataset definition to a valid query model graph. I
-        # think this is sufficient for these tests which are intended to ensure we don't
-        # accidentally break the API. If we're unable to execute a valid query, that's a
-        # separate class of problem for which we need separate tests.
-        dataset = load_dataset_definition(dataset_def_path, user_args=())
-        variable_definitions = compile(dataset)
-        assert variable_definitions
+@pytest.mark.parametrize(
+    "study_name,dataset_def",
+    [
+        (study_name, dataset_def)
+        for (study_name, config) in EXTERNAL_STUDIES.items()
+        for dataset_def in config["dataset_definitions"]
+    ],
+)
+def test_external_study(study_name, dataset_def, monkeypatch, reset_module_namespace):
+    study_path = STUDY_DIR / study_name
+    dataset_def_path = study_path / dataset_def
+    monkeypatch.chdir(study_path)
+    # Test that we can compile the dataset definition to a valid query model graph. I
+    # think this is sufficient for these tests which are intended to ensure we don't
+    # accidentally break the API. If we're unable to execute a valid query, that's a
+    # separate class of problem for which we need separate tests.
+    dataset = load_dataset_definition(dataset_def_path, user_args=())
+    variable_definitions = compile(dataset)
+    assert variable_definitions


### PR DESCRIPTION
In our own code we take a zero-tolerance approach to these, but we shouldn't fail the acceptance tests if external code triggers them.