### PR TITLE
fix: Raise helpful error if backslash used in paths

### DIFF
--- a/databuilder/codes.py
+++ b/databuilder/codes.py
@@ -110,7 +110,18 @@ class DMDCode(BaseCode):
 def codelist_from_csv(filename, *, column, category_column=None):
     filename = Path(filename)
     if not filename.exists():
-        raise CodelistError(f"No CSV file at {filename}")
+        # If the character which comes after the backslash in the string literal happens
+        # to form a valid escape sequence then no backslash will appear in the compiled
+        # string. Checking the repr for backslashes has false positives (e.g. a tab
+        # character will trigger it) but that seems OK in this context.
+        if "\\" in repr(filename):
+            hint = (
+                "\n\n"
+                "HINT: Use forward slash (/) instead of backslash (\\) in file paths"
+            )
+        else:
+            hint = ""
+        raise CodelistError(f"No CSV file at {filename}{hint}")
     with filename.open("r") as f:
         return codelist_from_csv_lines(
             f, column=column, category_column=category_column

--- a/tests/unit/test_codes.py
+++ b/tests/unit/test_codes.py
@@ -1,4 +1,5 @@
 import textwrap
+from pathlib import Path
 
 import pytest
 
@@ -15,7 +16,14 @@ from databuilder.codes import (
 )
 
 
-def test_codelist_from_csv(tmp_path):
+# `codelist_from_csv` can take either a string or `pathlib.Path` and we want to check
+# that we handle both correctly
+@pytest.fixture(params=[str, Path])
+def path_type(request):
+    return request.param
+
+
+def test_codelist_from_csv(path_type, tmp_path):
     csv_file = tmp_path / "codes.csv"
     csv_text = """
         CodeID,foo
@@ -23,13 +31,13 @@ def test_codelist_from_csv(tmp_path):
         def00,
         """
     csv_file.write_text(textwrap.dedent(csv_text.strip()))
-    codelist = codelist_from_csv(csv_file, column="CodeID")
+    codelist = codelist_from_csv(path_type(csv_file), column="CodeID")
     assert codelist == ["abc00", "def00"]
 
 
-def test_codelist_from_csv_missing_file(tmp_path):
+def test_codelist_from_csv_missing_file(path_type, tmp_path):
     with pytest.raises(CodelistError, match="no_file_here.csv"):
-        codelist_from_csv(tmp_path / "no_file_here.csv", column="CodeID")
+        codelist_from_csv(path_type(tmp_path / "no_file_here.csv"), column="CodeID")
 
 
 def test_codelist_from_csv_lines():

--- a/tests/unit/test_codes.py
+++ b/tests/unit/test_codes.py
@@ -35,9 +35,10 @@ def test_codelist_from_csv(path_type, tmp_path):
     assert codelist == ["abc00", "def00"]
 
 
-def test_codelist_from_csv_missing_file(path_type, tmp_path):
+def test_codelist_from_csv_missing_file(path_type):
+    missing_file = Path(__file__) / "no_file_here.csv"
     with pytest.raises(CodelistError, match="no_file_here.csv"):
-        codelist_from_csv(path_type(tmp_path / "no_file_here.csv"), column="CodeID")
+        codelist_from_csv(path_type(missing_file), column="CodeID")
 
 
 def test_codelist_from_csv_lines():

--- a/tests/unit/test_codes.py
+++ b/tests/unit/test_codes.py
@@ -41,6 +41,12 @@ def test_codelist_from_csv_missing_file(path_type):
         codelist_from_csv(path_type(missing_file), column="CodeID")
 
 
+def test_codelist_from_csv_missing_file_hint(path_type):
+    bad_path = Path(__file__) / "bad\file.csv"
+    with pytest.raises(CodelistError, match="backslash"):
+        codelist_from_csv(path_type(bad_path), column="CodeID")
+
+
 def test_codelist_from_csv_lines():
     csv_lines = [
         "CodeID,foo",


### PR DESCRIPTION
A small UX improvement based on observed user errors.