### PR TITLE
feat: Add a workflow to deploy the main docs site

### DIFF
--- a/.github/workflows/deploy-documentation.yml
+++ b/.github/workflows/deploy-documentation.yml
@@ -1,0 +1,29 @@
+---
+name: "Trigger a deploy of opensafely documentation site"
+
+on:
+  workflow_run:
+    workflows:
+      - CI
+    branches:
+      - main
+    types:
+      - completed
+
+jobs:
+  build-docs:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+
+    steps:
+      - name: Trigger documentation deploy
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.DOCS_WRITE_TOKEN }}
+          script: |
+            github.rest.actions.createWorkflowDispatch({
+              owner: 'opensafely',
+              repo: 'documentation',
+              workflow_id: 'pages-deployment.yml',
+              ref: 'main'
+            });


### PR DESCRIPTION
This will trigger a build and deploy of docs.opensafely.org after a successful CI run on databuilder's main branch.

As a test, a previous temporary commit ran this workflow on pushes to this branch:
https://github.com/opensafely-core/databuilder/actions/runs/4342201787

The above action triggered this run on the docs site:
https://github.com/opensafely/documentation/actions/runs/4342203683

Fixes https://github.com/opensafely/documentation/issues/1108