### PR TITLE
Tutorial workflow triggers

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -6,7 +6,6 @@ on:
   workflow_run:
     workflows:
       - CI
-      - Check documentation
     branches:
       - main
     types:

--- a/.github/workflows/update-tutorial-databuilder-version.yml
+++ b/.github/workflows/update-tutorial-databuilder-version.yml
@@ -1,12 +1,10 @@
 ---
-name: "Create PR to update databuilder image version in ehrql tutorial"
+name: "Update and test ehrql tutorial"
 
 on:
   workflow_dispatch:
   workflow_run:
     workflows:
-      - CI
-      - Check documentation
       - Build and publish image
     branches:
       - main
@@ -15,6 +13,7 @@ on:
 
 jobs:
   create_tutorial_version_pr:
+    if: ${{ (github.event.workflow_run.conclusion == 'success') || (github.event_name == 'workflow_dispatch') }}
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Some small updates to the workflow that updates the databuilder image in the ehrql tutorial and tests the tutorial dataset definitions.

- Rename the workflow since the test part is important (now that the tutorial only uses the major `v0` etc version, we shouldn't need to actually update the image very often, but we still need to re-run the step to check that the outputs build and make a PR if any changed **after** a new image has been built
- fix the workflow trigger so it only runs after the `Build and publish image` workflow has completed (multiple workflows in the `workflow_runs` mean that the workflow will be triggered when [any one of them complete
](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#running-a-workflow-based-on-the-conclusion-of-another-workflow)
- Only run if the triggering workflow completed successfully.  Triggering on completion happens[ whether the completed workflow succeeded or failed](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#running-a-workflow-based-on-the-conclusion-of-another-workflow).