### PR TITLE
Check links in databuilder docs

### DIFF
--- a/.github/workflows/check-docs-links.yml
+++ b/.github/workflows/check-docs-links.yml
@@ -43,3 +43,13 @@ jobs:
           fail: true
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+      - name: "Notify Slack on Failure"
+        if: failure()
+        uses: voxmedia/github-action-slack-notify-build@3665186a8c1a022b28a1dbe0954e73aa9081ea9e # v1.6.0
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+        with:
+          channel_id: C03FB777L1M
+          status: "Databuilder Check Docs Links Failure"
+          color: danger

--- a/.github/workflows/check-docs-links.yml
+++ b/.github/workflows/check-docs-links.yml
@@ -1,0 +1,45 @@
+---
+name: 'Check docs links'
+
+# yamllint disable-line rule:truthy
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '14 4 * * *'
+
+permissions:
+  contents: read
+
+jobs:
+  check_docs_links:
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Checkout docs repo
+        uses: actions/checkout@v3
+        with:
+          repository: opensafely/documentation
+          submodules: true
+
+      - name: Install Python and just
+        uses: opensafely-core/setup-action@v1
+        with:
+          install-just: true
+          python-version: '3.9'
+
+      - name: Build docs site
+        env:
+          AccessToken: ${{ secrets.GITHUB_TOKEN }}
+          MKDOCS_SITE_URL: https://docs.opensafely.org
+          MKDOCS_MULTIREPO_CLEANUP: true
+          DATABUILDER_BRANCH: main
+        run: just build
+
+      - name: Check links in built databuilder docs
+        uses: lycheeverse/lychee-action@9ace499fe66cee282a29eaa628fdac2c72fa087f  # v1.6.1
+        with:
+          args: "--exclude-all-private --exclude-mail --include-verbatim --require-https --verbose --no-progress
+          './**/data-builder/*.md' './**/data-builder/*.html'"
+          fail: true
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/docs/ehrql-tutorial-examples/README.md
+++ b/docs/ehrql-tutorial-examples/README.md
@@ -16,7 +16,7 @@ The current process for adding a new example is:
 
 1. Create a new dataset and add it to the [`example-data`](example-data/) directory,
 2. Write the dataset definition and add it to this directory.
-   See the [ehrQL tutorial introduction](../../docs/data-builder/ehrql/tutorial/index.md#using-data-builders-command-line-interface)
+   See the [ehrQL tutorial introduction](../ehrql/tutorial/index.md#using-data-builders-command-line-interface)
    for an explanation of the filename convention.
 3. Build the dataset definition outputs
    (see below),


### PR DESCRIPTION
Adds a workflow that checks out the documentation repo, builds it, checks the links in the built databuilder docs only, and posts to slack if any failures are found.

This does duplicate the checks on the main docs repo (which run on all the docs, including the imported databuilder ones), but allows us to notify slack specifically for databuilder links, which are trickier to check locally (any references to the main docs are relative links which work when the main site is built, but not when running just the local docs).  Broken links in databuilder docs will need to be fixed here in this repo.

Closes #1123 