### PR TITLE
Make databuilder docs look more like the main docs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,6 +38,8 @@ repos:
     - id: check-json
     - id: check-toml
     - id: check-yaml
+      # --unsafe is a workaround for the use of !! in mkdocs.yml.
+      args: [--unsafe]
     - id: detect-private-key
 
   - repo: local

--- a/docs/includes/data-builder-danger-header.md
+++ b/docs/includes/data-builder-danger-header.md
@@ -1,0 +1,13 @@
+!!! danger
+
+    This page discusses the new [OpenSAFELY Data
+    Builder](https://github.com/opensafely-core/databuilder) for
+    accessing OpenSAFELY data sources.
+
+    **Use OpenSAFELY [cohort-extractor](https://github.com/opensafely-core/cohort-extractor), unless you are
+    specifically involved in the development or testing of Data
+    Builder.**
+
+    OpenSAFELY Data Builder and its documentation are still undergoing
+    extensive development. We will announce when Data Builder is ready
+    for general use on the [Platform News](https://www.opensafely.org/changelog/) page.

--- a/docs/index.md
+++ b/docs/index.md
@@ -47,8 +47,8 @@ Data Builder allows researchers to provide their own dummy data to
 use to develop their analytical code against.
 
 !!! Note
-There is work in progress to add the functionality to generate dummy data
-from the dataset definition. This is currently in development.
+    There is work in progress to add the functionality to generate dummy data
+    from the dataset definition. This is currently in development.
 
 ## Why Data Builder was created
 For researchers familiar with OpenSAFELY, there is naturally a question as

--- a/hooks/parent_snippets.py
+++ b/hooks/parent_snippets.py
@@ -1,0 +1,32 @@
+import re
+
+
+def on_page_markdown(markdown, page, **kwargs):
+    """
+    parent_snippet markers are snippets that are intended to be replaced in the parent
+    site with appropriate snippet notation.  The snippets themselves do not live in
+    this repo.
+
+    on_page_* methods are called for each Page in a mkdocs site and can modify the
+    markdown they are given as input.  We're using this method to look for the
+    parent_includes markers and replace them with a note box that indicates in the
+    built docs that this snippet will be replaced in the full docs build.
+
+    For example:
+        !!! parent_snippet:'includes/glossary.md'
+
+    will be replaced with:
+        !!! note "TO BE REPLACED IN FULL DOCS BUILD
+            This snippet will be replaced in the main docs with the parent file 'includes/glossary.md'
+
+    This allows docs imported from other repos (e.g. databuilder) to reference snippets
+    in the parent docs, such as the glossary.
+    """
+    parent_snippets = set(re.findall(r"!!! parent_snippet:.+$", markdown))
+    for parent_snippet in parent_snippets:
+        markdown = markdown.replace(
+            parent_snippet,
+            '\n\n!!! note "TO BE REPLACED IN FULL DOCS BUILD"\n\n\tThis snippet will be replaced in the main docs '
+            f'with the parent file {parent_snippet.lstrip("!!! parent_snippet:")}',
+        )
+    return markdown

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,8 +3,8 @@ repo_url: https://github.com/opensafely-core/databuilder
 docs_dir: docs
 
 nav:
-  - Home: toc.md
-  - Quick Start: quick-start.md
+  - Home: index.md
+  - Table of Contents: toc.md
 
 
 theme:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,3 +1,11 @@
+# NOTE: This mkdocs.yml contains the minimum config required to run
+# databuilder's docs locally.  These docs do not run in isolation in production.
+#
+# In production, the databuilder docs are pulled into and built with the main docs at
+# https://github.com/opensafely/documentation
+#
+# The contents of this mkdocs.yml are ignore in the production build.
+#
 site_name: OpenSAFELY Data Builder documentation
 repo_url: https://github.com/opensafely-core/databuilder
 docs_dir: docs
@@ -6,20 +14,22 @@ nav:
   - Home: index.md
   - Table of Contents: toc.md
 
-
 theme:
   name: material
 
-
 watch:
   - docs
-
 
 plugins:
   - table-reader:
       base_path: "docs_dir"
 
 
+# WARNING!
+# This markdown_extensions config (with the exception of the snippets base_path) is duplicated
+# from the mkdocs.yml in the parent repo (https://github.com/opensafely/documentation) in order
+# to build local docs with similar styling. If any changes/additions are needed, ensure they are
+# made in the parent repo also.
 markdown_extensions:
   - pymdownx.details
   - pymdownx.snippets:
@@ -41,5 +51,7 @@ markdown_extensions:
   - abbr
   - md_in_html
 
+# This hook adds some clarifying studying around snippets that will be incorporated
+# from the parent repo, and is relevant for local development only.
 hooks:
   - hooks/parent_snippets.py

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -40,3 +40,6 @@ markdown_extensions:
   - footnotes
   - abbr
   - md_in_html
+
+hooks:
+  - hooks/parent_snippets.py

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,5 +21,22 @@ plugins:
 
 
 markdown_extensions:
+  - pymdownx.details
   - pymdownx.snippets:
       base_path: docs
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
+  - toc:
+      permalink: "🔗"
+  - pymdownx.highlight
+  - pymdownx.superfences
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.keys
+  - admonition
+  - footnotes
+  - abbr
+  - md_in_html


### PR DESCRIPTION
This does some minimal styling improvements to make the local docs (run with `just docs-serve`) look a bit more like the main docs.

It doesn't use the [mkdocs-multirepo-plugin feature](https://github.com/jdoiro3/mkdocs-multirepo-plugin#%CE%B2-development-in-imported-repos-beta), for [reasons mentioned here](https://github.com/opensafely-core/databuilder/issues/978#issuecomment-1423033126).  Having had another attempt at getting that feature to work, I've come to the conclusion that our docs may just be a bit too complex for it, and it's intended more for a skeleton parent repo that pulls in docs from other repos, so doing the reverse for a single imported repo doesn't involve pulling in a lot of complicated files.

Mainly, this PR adds the same markdown extensions as the main repo (with the exception of the configuration of the snippets paths).  This gets us, amongst other things, the nice formatting of notes and warnings:
![Screenshot from 2023-03-07 15-24-09](https://user-images.githubusercontent.com/6770950/223469685-bebcff38-5fb6-42f1-bdeb-42b2e5a67635.png)

In addition, there's a small hook to replace the parent_snippet notation with a "note" box to make it clear that these snippets will be replaced in the main build:
![Screenshot from 2023-03-07 15-24-20](https://user-images.githubusercontent.com/6770950/223471085-c8f6c378-3801-49ba-b2ce-275a7bf1429f.png)

There are also a few minor fixes to the docs themselves:
1) Fix the indentation for a `!!! note` block
2) Add a missing snippet (which I'll remove from the main docs repo once this PR is merged)
3) Update the navigation for local docs to include the index page (the page at /data-builder on the main docs site) and the toc
