### PR TITLE
Upgrade future manually via `pip-compile`

### DIFF
--- a/requirements.prod.txt
+++ b/requirements.prod.txt
@@ -8,8 +8,8 @@ databricks-sql-connector==2.0.2 \
     --hash=sha256:480f299d2a9f950da4f7a12a5a1dd51789af588c133f237a1878b7a4d506bad8 \
     --hash=sha256:b74bb176571ba6107c3610b04ec875bf52951c50e515bea8abb2ffb8fe4c90d7
     # via opensafely-databuilder (pyproject.toml)
-future==0.18.2 \
-    --hash=sha256:b1bead90b70cf6ec3f0710ae53a525360fa360d306a86583adc6bf83a4db537d
+future==0.18.3 \
+    --hash=sha256:34a17436ed1e96697a86f9de3d15a3b0be01d8bc8de9c1dffd59fb8234ed5307
     # via pyhive
 greenlet==1.1.2 \
     --hash=sha256:0051c6f1f27cb756ffc0ffbac7d2cd48cb0362ac1736871399a739b2885134d3 \


### PR DESCRIPTION
Dependabot keeps failing on this, for whatever reason, in the following way:

```
updater | INFO <job_621493460> Latest version is 0.18.3
updater | INFO <job_621493460> Requirements to unlock own
updater | INFO <job_621493460> Requirements update strategy bump_versions
updater | INFO <job_621493460> Updating future from 0.18.2 to 0.18.3
…
updater | ERROR <job_621493460> Error processing future (RuntimeError)
updater | ERROR <job_621493460> No files have changed!
```

Maybe this will unblock Dependabot from being able to upgrade production dependencies? (See #964.)