### PR TITLE
fix: Fix the regex for finding parent snippets in docs

### DIFF
--- a/hooks/parent_snippets.py
+++ b/hooks/parent_snippets.py
@@ -22,7 +22,7 @@ def on_page_markdown(markdown, page, **kwargs):
     This allows docs imported from other repos (e.g. databuilder) to reference snippets
     in the parent docs, such as the glossary.
     """
-    parent_snippets = set(re.findall(r"!!! parent_snippet:.+$", markdown))
+    parent_snippets = set(re.findall(r"!!! parent_snippet:.+\n", markdown))
     for parent_snippet in parent_snippets:
         markdown = markdown.replace(
             parent_snippet,


### PR DESCRIPTION
This now matches all single lines with parent snippets, not just lines at the end of the file.