### PR TITLE
Replace and deprecate `take`, `drop` and `set_population`

### DIFF
--- a/databuilder/docs/specs.py
+++ b/databuilder/docs/specs.py
@@ -99,7 +99,7 @@ def build_paragraph(paragraph_id, test_fn):
     # Check that the next line is as expected.
     assert source_lines[ix + 1] == "        table_data,"
 
-    series = get_series_code(source_lines, ix + 2, capturer.set_population)
+    series = get_series_code(source_lines, ix + 2, capturer.define_population)
 
     # Extract descriptive docstring if any
     text = inspect.getdoc(test_fn)
@@ -116,7 +116,7 @@ def build_paragraph(paragraph_id, test_fn):
     )
 
 
-def get_series_code(source_lines, series_index, set_population=False):
+def get_series_code(source_lines, series_index, define_population=False):
     """
     Extract the definition of the series from the test function.
     """
@@ -143,7 +143,7 @@ def get_series_code(source_lines, series_index, set_population=False):
                 break
     series = "\n".join(series_lines).strip().removesuffix(",")
 
-    if set_population:
+    if define_population:
         # If this test set a custom population, we need to parse the rest of the lines for
         # the population definition
         population_lines = []
@@ -163,10 +163,10 @@ def get_series_code(source_lines, series_index, set_population=False):
         if len(population_lines) > 1:
             indent = " " * 4
             population = f"\n{indent}".join(population_lines).strip().removesuffix(",")
-            population = f"set_population(\n{indent}{population}\n)"
+            population = f"define_population(\n{indent}{population}\n)"
         else:
             population = (
-                f"set_population({population_lines[0].strip().removesuffix(',')})"
+                f"define_population({population_lines[0].strip().removesuffix(',')})"
             )
         series = f"{series}\n{population}"
     return series
@@ -246,4 +246,4 @@ class ArgCapturer:
         self.table_data = table_data
         self.series = series
         self.expected_output = expected_output
-        self.set_population = population is not None
+        self.define_population = population is not None

--- a/databuilder/query_language.py
+++ b/databuilder/query_language.py
@@ -34,14 +34,22 @@ class Dataset:
     def __init__(self):
         object.__setattr__(self, "variables", {})
 
-    def set_population(self, population):
+    def set_population(self, population):  # pragma: no cover
+        warnings.warn(
+            "Use `define_population` instead of `set_population`",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.define_population(population)
+
+    def define_population(self, population):
         validate_population_definition(population.qm_node)
         self.variables["population"] = population
 
     def __setattr__(self, name, value):
         if name == "population":
             raise AttributeError(
-                "Cannot set variable 'population'; use set_population() instead"
+                "Cannot set variable 'population'; use define_population() instead"
             )
         if name in self.variables:
             raise AttributeError(f"'{name}' is already set and cannot be reassigned")

--- a/databuilder/query_language.py
+++ b/databuilder/query_language.py
@@ -1,6 +1,7 @@
 import dataclasses
 import datetime
 import enum
+import warnings
 from typing import Union
 
 from databuilder.codes import BaseCode
@@ -618,7 +619,11 @@ class PatientFrame(BaseFrame):
 
 
 class EventFrame(BaseFrame):
-    def take(self, series):
+    def take(self, series):  # pragma: no cover
+        warnings.warn("Use `where` instead of `take`", DeprecationWarning, stacklevel=2)
+        return self.where(series)
+
+    def where(self, series):
         return EventFrame(
             qm.Filter(
                 source=self.qm_node,
@@ -626,7 +631,13 @@ class EventFrame(BaseFrame):
             )
         )
 
-    def drop(self, series):
+    def drop(self, series):  # pragma: no cover
+        warnings.warn(
+            "Use `except_where` instead of `drop`", DeprecationWarning, stacklevel=2
+        )
+        return self.except_where(series)
+
+    def except_where(self, series):
         return EventFrame(
             qm.Filter(
                 source=self.qm_node,

--- a/databuilder/query_model/nodes.py
+++ b/databuilder/query_model/nodes.py
@@ -482,7 +482,7 @@ def validate_input_domains(node):
     #    As an example, we reject this erhQL construction because the per-patient
     #    cardinality of the first argument to `+` may be lower than that of the second:
     #
-    #        e.take(e.b).i + e.i
+    #        e.where(e.b).i + e.i
     #
     # * Many-rows-per-patient frames can be combined with many-rows-per-patient series
     #   derived from the same underlying table, as long as any filters applied to each
@@ -494,7 +494,7 @@ def validate_input_domains(node):
     #
     #   That means that filters and sorts can be expressed tersely in ehrQL, like this:
     #
-    #       events.filter(events.code == "foo").filter(events.date >= start_date)
+    #       events.where(events.code == "foo").where(events.date >= start_date)
     #
     # We enforce this by modelling domains as a hierarchy. At the root is the patient
     # domain, each table has an unique domain descending from this, and each filter

--- a/databuilder/tables/beta/tpp.py
+++ b/databuilder/tables/beta/tpp.py
@@ -68,7 +68,9 @@ class practice_registrations(EventFrame):
         duration. If there's stil an exact tie we choose arbitrarily based on the
         practice ID.
         """
-        spanning_regs = self.take(self.start_date <= date).drop(self.end_date < date)
+        spanning_regs = self.where(self.start_date <= date).except_where(
+            self.end_date < date
+        )
         ordered_regs = spanning_regs.sort_by(
             self.start_date,
             self.end_date,
@@ -146,7 +148,9 @@ class addresses(EventFrame):
         and then, if there are multiple of these, the one with the longest duration. If
         there's stil an exact tie we choose arbitrarily based on the address ID.
         """
-        spanning_addrs = self.take(self.start_date <= date).drop(self.end_date < date)
+        spanning_addrs = self.where(self.start_date <= date).except_where(
+            self.end_date < date
+        )
         ordered_addrs = spanning_addrs.sort_by(
             case(when(self.has_postcode).then(1), default=0),
             self.start_date,

--- a/docs/ehrql-tutorial-examples/1a_minimal_dataset_definition.py
+++ b/docs/ehrql-tutorial-examples/1a_minimal_dataset_definition.py
@@ -4,4 +4,4 @@ from databuilder.tables.examples.tutorial import patients
 dataset = Dataset()
 
 year_of_birth = patients.date_of_birth.year
-dataset.set_population(year_of_birth >= 2000)
+dataset.define_population(year_of_birth >= 2000)

--- a/docs/ehrql-tutorial-examples/1b_minimal_dataset_definition.py
+++ b/docs/ehrql-tutorial-examples/1b_minimal_dataset_definition.py
@@ -4,6 +4,6 @@ from databuilder.tables.examples.tutorial import patients
 dataset = Dataset()
 
 year_of_birth = patients.date_of_birth.year
-dataset.set_population(year_of_birth >= 2000)
+dataset.define_population(year_of_birth >= 2000)
 
 dataset.sex = patients.sex

--- a/docs/ehrql-tutorial-examples/2a_multiple_dataset_definition.py
+++ b/docs/ehrql-tutorial-examples/2a_multiple_dataset_definition.py
@@ -4,7 +4,7 @@ from databuilder.tables.examples.tutorial import patients, prescriptions
 dataset = Dataset()
 
 year_of_birth = patients.date_of_birth.year
-dataset.set_population(year_of_birth >= 2000)
+dataset.define_population(year_of_birth >= 2000)
 
 dataset.sex = patients.sex
 dataset.most_recent_dmd_code = (

--- a/docs/ehrql-tutorial-examples/3a1_multiple2_dataset_definition.py
+++ b/docs/ehrql-tutorial-examples/3a1_multiple2_dataset_definition.py
@@ -12,6 +12,6 @@ earliest_imd = (
 
 # This population is set so that we always select all patients.
 population = patients.exists_for_patient()
-dataset.set_population(population)
+dataset.define_population(population)
 
 dataset.earliest_imd = earliest_imd

--- a/docs/ehrql-tutorial-examples/3a2_multiple2_dataset_definition.py
+++ b/docs/ehrql-tutorial-examples/3a2_multiple2_dataset_definition.py
@@ -17,6 +17,6 @@ imd_has_increased = latest_imd > earliest_imd
 
 # This population is set so that we always select all patients.
 population = patients.exists_for_patient()
-dataset.set_population(population)
+dataset.define_population(population)
 
 dataset.imd_has_increased = imd_has_increased

--- a/docs/ehrql-tutorial-examples/3a_multiple2_dataset_definition.py
+++ b/docs/ehrql-tutorial-examples/3a_multiple2_dataset_definition.py
@@ -20,7 +20,7 @@ latest_imd = (
 imd_has_increased = latest_imd > earliest_imd
 latest_imd_is_at_least_5000 = latest_imd >= 5000
 population = (year_of_birth < 2000) & (imd_has_increased | latest_imd_is_at_least_5000)
-dataset.set_population(population)
+dataset.define_population(population)
 
 dataset.sex = patients.sex
 dataset.was_hospitalised = hospitalisations.exists_for_patient()

--- a/docs/ehrql-tutorial-examples/4a_multiple2_dataset_definition.py
+++ b/docs/ehrql-tutorial-examples/4a_multiple2_dataset_definition.py
@@ -7,7 +7,7 @@ start_date = "2020-03-01"
 final_date = "2020-05-31"
 
 date_of_birth = patients.date_of_birth
-hospitalisations_in_range = hospitalisations.take(
+hospitalisations_in_range = hospitalisations.where(
     hospitalisations.date.is_on_or_after(start_date)
     & hospitalisations.date.is_before(final_date)
 )
@@ -15,7 +15,7 @@ hospitalisations_in_range = hospitalisations.take(
 population = (date_of_birth < "2000-01-01") & (
     hospitalisations_in_range.exists_for_patient()
 )
-dataset.set_population(population)
+dataset.define_population(population)
 
 dataset.sex = patients.sex
 dataset.year_of_birth = patients.date_of_birth.year

--- a/docs/ehrql-tutorial-examples/5a_multiple3_dataset_definition.py
+++ b/docs/ehrql-tutorial-examples/5a_multiple3_dataset_definition.py
@@ -12,7 +12,7 @@ lowest_imd_address = patient_address.sort_by(
 ).first_for_patient()
 
 population = most_recent_hospitalisation.exists_for_patient()
-dataset.set_population(population)
+dataset.define_population(population)
 
 dataset.most_recent_hospitalisation_code = most_recent_hospitalisation.code
 dataset.most_recent_hospitalisation_system = (

--- a/docs/ehrql-tutorial-examples/6a_multiple4_dataset_definition.py
+++ b/docs/ehrql-tutorial-examples/6a_multiple4_dataset_definition.py
@@ -3,15 +3,15 @@ from databuilder.tables.examples.tutorial import clinical_events, patients
 
 dataset = Dataset()
 
-tutorial_code_system_events = clinical_events.drop(
+tutorial_code_system_events = clinical_events.except_where(
     clinical_events.system == "AnotherCodeSystem"
-).take(clinical_events.system == "TutorialCodeSystem")
+).where(clinical_events.system == "TutorialCodeSystem")
 
 minimum_h1_threshold = 200.0
 start_date_of_interest = "2004-01-01"
 end_date_of_interest = "2005-12-31"
 
-high_code_h1_events = tutorial_code_system_events.take(
+high_code_h1_events = tutorial_code_system_events.where(
     (tutorial_code_system_events.code == "h1")
     & (tutorial_code_system_events.numeric_value > minimum_h1_threshold)
     & (tutorial_code_system_events.date >= start_date_of_interest)
@@ -22,7 +22,7 @@ count_of_high_code_h1_events = high_code_h1_events.count_for_patient()
 maximum_h1_value = high_code_h1_events.numeric_value.maximum_for_patient()
 
 population = high_code_h1_events.exists_for_patient()
-dataset.set_population(population)
+dataset.define_population(population)
 
 dataset.date_of_birth = patients.date_of_birth
 dataset.h1_count = count_of_high_code_h1_events

--- a/docs/ehrql/define-population-explanation.md
+++ b/docs/ehrql/define-population-explanation.md
@@ -1,0 +1,5 @@
+If you accidentally include multiple calls to `define_population()`, it is the call that appears closest to the end of the dataset definition
+that takes effect.
+
+In future, calling `define_population()` more than once will cause a dataset definition to fail;
+see the associated [Data Builder](https://github.com/opensafely-core/databuilder/issues/775) issue.

--- a/docs/ehrql/set-population-explanation.md
+++ b/docs/ehrql/set-population-explanation.md
@@ -1,5 +1,0 @@
-If you accidentally include multiple calls to `set_population()`, it is the call that appears closest to the end of the dataset definition
-that takes effect.
-
-In future, calling `set_population()` more than once will cause a dataset definition to fail;
-see the associated [Data Builder](https://github.com/opensafely-core/databuilder/issues/775) issue.

--- a/docs/ehrql/tutorial/1a.md
+++ b/docs/ehrql/tutorial/1a.md
@@ -54,8 +54,8 @@ that we wish to add to the dataset.
 ### Find year of birth
 Next we define a year of birth. `date_of_birth` is in the patient table and therefore we can assign it to this new variable. We want to only capture the `year` of birth so we add the `.year` to the end of this variable assignment.
 
-### Set population
-Finally we set the population of the dataset. We use the special method called `set_population()` and pass in the definition of the population. In this case, we want to use our previously created `year_of_birth` and say, if year of birth is equal to or greater than 2000, include in this dataset.
+### Define population
+Finally we define the population of the dataset. We use the special method called `define_population()` and pass in the definition of the population. In this case, we want to use our previously created `year_of_birth` and say, if year of birth is equal to or greater than 2000, include in this dataset.
 
 ## Your turn
 Run the dataset definition by:

--- a/docs/ehrql/tutorial/3a.md
+++ b/docs/ehrql/tutorial/3a.md
@@ -184,10 +184,10 @@ In this dataset definition, we use:
 
 The value of this variable is True or False as patients either meet the criteria or they do not.
 
-### Set population
+### Define population
 
 Now we take the `population` variable created above
-and pass this into `set_population()`.
+and pass this into `define_population()`.
 This restricts the entire population to those patients
 who have the value `True` in the variable `population`.
 

--- a/docs/ehrql/tutorial/4a.md
+++ b/docs/ehrql/tutorial/4a.md
@@ -10,7 +10,7 @@ By the end of this tutorial, you should be able to:
 
 * specify dates in dataset definitions
 * explain date operations
-* use the key word `take` in dataset definitions
+* use the key word `where` in dataset definitions
 
 ### Full Example
 
@@ -74,9 +74,9 @@ to restrict the population to those with hospitalisations inclusive of this date
 ### Hospitalisations within a range
 
 We select the hospitalisation rows that match a condition
-with the `take` method.
+with the `where` method.
 
-This restricts the hospitalisation data to data that matches the condition passed into the `take()` function.
+This restricts the hospitalisation data to data that matches the condition passed into the `where()` function.
 We are passing in a condition
 that the date column in the hospitalisation table is on or after the start date created above,
 and is before the end date created above.
@@ -89,7 +89,7 @@ This creates a subset of the hospitalisation data.
     it helps to both explain what the value means
     and allow the value to be reused.
 
-### Set the population
+### Define the population
 
 Now we have the hospitalisation subset of data,
 we can use this to create our dataset.

--- a/docs/ehrql/tutorial/5a.md
+++ b/docs/ehrql/tutorial/5a.md
@@ -81,7 +81,7 @@ This is similar to what we have done before.
 In this case we sort rows by `index_of_multiple_deprivation_rounded`,
 and take the first row for the patient.
 
-### Set population
+### Define population
 
 We are trying to capture patients who have a recent hospitalisation.
 For this, we check if a patient has row in the `most_recent_hospitalisation` subset (created above).
@@ -135,11 +135,11 @@ In both cases, the result is a Boolean `True` or `False` for each row.
 !!! question
     1. Can you modify the dataset definition
        to eliminate the IMD value nulls?
-       (Hint: you may find `drop()` useful to filter out unwanted rows.)
+       (Hint: you may find `except_where()` useful to filter out unwanted rows.)
     2. Even with that modification,
        we still get a null IMD value in the dataset?
        Why?
        (Hint: look at the patient ID values.)
     3. Can you further modify the dataset definition
-       to add an extra criterion in `set_population()` to remove this row entirely?
+       to add an extra criterion in `define_population()` to remove this row entirely?
        (Hint: you may find the table operators covered earlier useful.)

--- a/docs/ehrql/tutorial/6a.md
+++ b/docs/ehrql/tutorial/6a.md
@@ -62,17 +62,17 @@ We create a variable called `tutorial_code_system_events`.
 This filters the clinical events table to include only events
 that belong to a coding system called `TutorialCodesystem`.
 
-The `take()` and `drop()` methods allow filtering of table rows:
+The `where()` and `except_where()` methods allow filtering of table rows:
 
-* `take()` specifies rows that you wish to *include*
-* `drop()` specifies rows that you wish to *exclude*
+* `where()` specifies rows that you wish to *include*
+* `except_where()` specifies rows that you wish to *exclude*
 
-Both `take()` and `drop()` require an expression inside their parentheses
+Both `where()` and `except_where()` require an expression inside their parentheses
 that evaluates to a Boolean `True` or `False` for each row.
 
-In previous tutorials, we have used `take()`.
+In previous tutorials, we have used `where()`.
 In this example,
-we are going to use `drop` to drop rows for `AnotherCodingSystem`.
+we are going to use `except_where` to exclude rows for `AnotherCodingSystem`.
 Rows that result in a `True` value for this expression then have the filter applied in the result.
 
 ### Filter by h1 events
@@ -104,16 +104,16 @@ by using `maximum_for_patient()`.
 !!! question
     1. In this dataset definition,
        we initially filtered all of the clinical events to those using the `TutorialCodeSystem` code system.
-       How would we rewrite that same selection to use a single `drop()`?
+       How would we rewrite that same selection to use a single `except_where()`?
     2. How would we find the *sum* of the numeric values of the `m1` clinical events
        for each patient within the same date range already specified?
        Refer to the [ehrQL reference](../reference.md).
     2. As the dataset definition shows,
-       we can use combine multiple filters using `take()` and `drop()`
+       we can use combine multiple filters using `where()` and `except_where()`
        in different ways.
-       Either we can specify multiple conditions to a single `take()` or
-       `drop()`.
-       Or we can *chain* multiple `take()` and `drop()` methods.
+       Either we can specify multiple conditions to a single `where()` or
+       `except_where()`.
+       Or we can *chain* multiple `where()` and `except_where()` methods.
        The output of each method is a frame.
 
         !!! todo
@@ -124,7 +124,7 @@ by using `maximum_for_patient()`.
          it may make your dataset definition either clearer
          or more consise to read.
 
-         Can you rewrite the `take()` with multiple conditions to be a series of chained `take()` methods?
+         Can you rewrite the `where()` with multiple conditions to be a series of chained `where()` methods?
          Refer to the [ehrQL reference](../reference.md).
 
         !!! todo

--- a/docs/ehrql/tutorial/7a.md
+++ b/docs/ehrql/tutorial/7a.md
@@ -74,11 +74,11 @@ You can use `isin` and `isnotin` to check for specific codes.
     a1_code = SNOMEDCTCode("a1")
     a2_code = SNOMEDCTCode("a2")
 
-    codelist_filtered_events = clinical_events.take(clinical_events.system == "snomed").code.is_in(codelist))
-    code_filtered_events = clinical_events.take(clinical.events.system == "snomed").code.is_in([a1_code, a2_code])
+    codelist_filtered_events = clinical_events.where(clinical_events.system == "snomed").code.is_in(codelist))
+    code_filtered_events = clinical_events.where(clinical.events.system == "snomed").code.is_in([a1_code, a2_code])
 
     dataset = Dataset()
-    dataset.set_population(codelist_filtered_events.exists_for_patient() | code_filtered_events.exists_for_patient())
+    dataset.define_population(codelist_filtered_events.exists_for_patient() | code_filtered_events.exists_for_patient())
     ```
 
 !!! todo

--- a/docs/ehrql/tutorial/conclusion.md
+++ b/docs/ehrql/tutorial/conclusion.md
@@ -146,7 +146,7 @@ Some ideas for inspiration:
   Try modifying `2a_multiple_dataset_definition.py`:
     * Can you use `count_for_patient()`
       to include the number of prescriptions for each patient?
-    * Can you use `take()` along with `count_for_patient()`
+    * Can you use `where()` along with `count_for_patient()`
       to count the number of prescriptions for one particular code of your choice?
 * …
 

--- a/docs/includes/generated_docs/specs.md
+++ b/docs/includes/generated_docs/specs.md
@@ -2546,7 +2546,7 @@ returns the following patient series:
 
 ### 13.1 Defining a population
 
-`set_population` is used to limit the population from which data is extracted.
+`define_population` is used to limit the population from which data is extracted.
 
 
 
@@ -2563,7 +2563,7 @@ This example makes use of a patient-level table named `p` containing the followi
 
 ```
 p.i1
-set_population(~p.b1)
+define_population(~p.b1)
 ```
 returns the following patient series:
 
@@ -2595,7 +2595,7 @@ This example makes use of a patient-level table named `p` and an event-level tab
 
 ```
 e.exists_for_patient()
-set_population(p.i1 > 0)
+define_population(p.i1 > 0)
 ```
 returns the following patient series:
 
@@ -2620,7 +2620,7 @@ This example makes use of a patient-level table named `p` containing the followi
 
 ```
 p.i1
-set_population(
+define_population(
     case(
         when(p.i1 <= 8).then(True),
         when(p.i1 > 8).then(False),

--- a/docs/includes/generated_docs/specs.md
+++ b/docs/includes/generated_docs/specs.md
@@ -4,7 +4,7 @@
 ### 1.1 Including rows
 
 
-#### 1.1.1 Take with column
+#### 1.1.1 Where with column
 
 This example makes use of an event-level table named `e` containing the following data:
 
@@ -20,7 +20,7 @@ This example makes use of an event-level table named `e` containing the followin
 | 3|302|F |
 
 ```
-e.take(e.b1).i1.sum_for_patient()
+e.where(e.b1).i1.sum_for_patient()
 ```
 returns the following patient series:
 
@@ -32,7 +32,7 @@ returns the following patient series:
 
 
 
-#### 1.1.2 Take with expr
+#### 1.1.2 Where with expr
 
 This example makes use of an event-level table named `e` containing the following data:
 
@@ -47,7 +47,7 @@ This example makes use of an event-level table named `e` containing the followin
 | 3|301| |
 
 ```
-e.take((e.i1 + e.i2) < 413).i1.sum_for_patient()
+e.where((e.i1 + e.i2) < 413).i1.sum_for_patient()
 ```
 returns the following patient series:
 
@@ -59,7 +59,7 @@ returns the following patient series:
 
 
 
-#### 1.1.3 Take with constant true
+#### 1.1.3 Where with constant true
 
 This example makes use of an event-level table named `e` containing the following data:
 
@@ -70,7 +70,7 @@ This example makes use of an event-level table named `e` containing the followin
 | 2|201 |
 
 ```
-e.take(True).count_for_patient()
+e.where(True).count_for_patient()
 ```
 returns the following patient series:
 
@@ -81,7 +81,7 @@ returns the following patient series:
 
 
 
-#### 1.1.4 Take with constant false
+#### 1.1.4 Where with constant false
 
 This example makes use of an event-level table named `e` containing the following data:
 
@@ -92,7 +92,7 @@ This example makes use of an event-level table named `e` containing the followin
 | 2|201 |
 
 ```
-e.take(False).count_for_patient()
+e.where(False).count_for_patient()
 ```
 returns the following patient series:
 
@@ -103,7 +103,7 @@ returns the following patient series:
 
 
 
-#### 1.1.5 Chain multiple takes
+#### 1.1.5 Chain multiple wheres
 
 This example makes use of an event-level table named `e` containing the following data:
 
@@ -114,7 +114,7 @@ This example makes use of an event-level table named `e` containing the followin
 | 1|3|F |
 
 ```
-e.take(e.i1 >= 2).take(e.b1).i1.sum_for_patient()
+e.where(e.i1 >= 2).where(e.b1).i1.sum_for_patient()
 ```
 returns the following patient series:
 
@@ -127,7 +127,7 @@ returns the following patient series:
 ### 1.2 Excluding rows
 
 
-#### 1.2.1 Drop with column
+#### 1.2.1 Except where with column
 
 This example makes use of an event-level table named `e` containing the following data:
 
@@ -143,7 +143,7 @@ This example makes use of an event-level table named `e` containing the followin
 | 3|302|T |
 
 ```
-e.drop(e.b1).i1.sum_for_patient()
+e.except_where(e.b1).i1.sum_for_patient()
 ```
 returns the following patient series:
 
@@ -155,7 +155,7 @@ returns the following patient series:
 
 
 
-#### 1.2.2 Drop with expr
+#### 1.2.2 Except where with expr
 
 This example makes use of an event-level table named `e` containing the following data:
 
@@ -170,7 +170,7 @@ This example makes use of an event-level table named `e` containing the followin
 | 3|301| |
 
 ```
-e.drop((e.i1 + e.i2) < 413).i1.sum_for_patient()
+e.except_where((e.i1 + e.i2) < 413).i1.sum_for_patient()
 ```
 returns the following patient series:
 
@@ -182,7 +182,7 @@ returns the following patient series:
 
 
 
-#### 1.2.3 Drop with constant true
+#### 1.2.3 Except where with constant true
 
 This example makes use of an event-level table named `e` containing the following data:
 
@@ -193,7 +193,7 @@ This example makes use of an event-level table named `e` containing the followin
 | 2|201 |
 
 ```
-e.drop(True).count_for_patient()
+e.except_where(True).count_for_patient()
 ```
 returns the following patient series:
 
@@ -204,7 +204,7 @@ returns the following patient series:
 
 
 
-#### 1.2.4 Drop with constant false
+#### 1.2.4 Except where with constant false
 
 This example makes use of an event-level table named `e` containing the following data:
 
@@ -215,7 +215,7 @@ This example makes use of an event-level table named `e` containing the followin
 | 2|201 |
 
 ```
-e.drop(False).count_for_patient()
+e.except_where(False).count_for_patient()
 ```
 returns the following patient series:
 

--- a/docs/patient-event-tables-explanation.md
+++ b/docs/patient-event-tables-explanation.md
@@ -8,7 +8,7 @@ When working with ehrQL, there are two distinct kinds of tables:
     Do we continue to use "one row"/"many rows"
     or event-level/patient-level?
 
-The table passed to `set_population` must be a patient-level table with a single Boolean column.
+The table passed to `define_population` must be a patient-level table with a single Boolean column.
 This table then defines which patients are included in the final dataset.
 
 !!! todo

--- a/docs/snippets/dsl.py
+++ b/docs/snippets/dsl.py
@@ -16,7 +16,7 @@
 #     .filter(practice_registrations.date_end >= index_date)
 #     .exists_for_patient()
 # )
-# cohort.set_population(registered)
+# cohort.define_population(registered)
 
 # cohort.code = (
 #     clinical_events.sort_by(clinical_events.date)

--- a/docs/snippets/ehrql.py
+++ b/docs/snippets/ehrql.py
@@ -10,6 +10,6 @@ from databuilder.tables.beta.smoketest import patients
 
 year_of_birth = patients.date_of_birth.year
 dataset = Dataset()
-dataset.set_population(year_of_birth >= 2000)
+dataset.define_population(year_of_birth >= 2000)
 dataset.year_of_birth = year_of_birth
 # --8<-- [end:minimalehrql]

--- a/tests/integration/backends/test_base.py
+++ b/tests/integration/backends/test_base.py
@@ -100,7 +100,7 @@ def test_query_table(engine):
 
 def _extract(engine, series):
     dataset = Dataset()
-    dataset.set_population(
+    dataset.define_population(
         patients.exists_for_patient() | covid_tests.exists_for_patient()
     )
     dataset.v = series

--- a/tests/integration/backends/test_base.py
+++ b/tests/integration/backends/test_base.py
@@ -93,7 +93,7 @@ def test_query_table(engine):
         NegativeResult(patient_id=1, date=datetime.date(2020, 7, 1)),
     )
     results = _extract(
-        engine, covid_tests.take(covid_tests.positive == 1).date.maximum_for_patient()
+        engine, covid_tests.where(covid_tests.positive == 1).date.maximum_for_patient()
     )
     assert results == {1: datetime.date(2020, 6, 1)}
 

--- a/tests/integration/contracts/test_universal.py
+++ b/tests/integration/contracts/test_universal.py
@@ -17,7 +17,7 @@ def tests_patients_age_on(in_memory_engine):
     )
 
     dataset = Dataset()
-    dataset.set_population(patients.exists_for_patient())
+    dataset.define_population(patients.exists_for_patient())
     dataset.age_2010 = patients.age_on("2010-01-01")
     results = in_memory_engine.extract(dataset)
 

--- a/tests/integration/query_engines/test_csv.py
+++ b/tests/integration/query_engines/test_csv.py
@@ -44,7 +44,9 @@ def test_csv_query_engine(tmp_path):
     dataset.sex = patients.sex
     dataset.total_score = events.score.sum_for_patient()
     # Check that missing columns end up NULL
-    dataset.missing = events.take(events.expected_missing.is_null()).count_for_patient()
+    dataset.missing = events.where(
+        events.expected_missing.is_null()
+    ).count_for_patient()
 
     dataset.set_population(patients.exists_for_patient())
     variable_definitions = compile(dataset)

--- a/tests/integration/query_engines/test_csv.py
+++ b/tests/integration/query_engines/test_csv.py
@@ -48,7 +48,7 @@ def test_csv_query_engine(tmp_path):
         events.expected_missing.is_null()
     ).count_for_patient()
 
-    dataset.set_population(patients.exists_for_patient())
+    dataset.define_population(patients.exists_for_patient())
     variable_definitions = compile(dataset)
 
     query_engine = CSVQueryEngine(tmp_path)

--- a/tests/integration/tables/beta/test_tpp.py
+++ b/tests/integration/tables/beta/test_tpp.py
@@ -96,7 +96,7 @@ def test_practice_registrations_for_patient_on(in_memory_engine):
     reg = tpp.practice_registrations.for_patient_on("2010-01-01")
 
     dataset = Dataset()
-    dataset.set_population(tpp.practice_registrations.exists_for_patient())
+    dataset.define_population(tpp.practice_registrations.exists_for_patient())
     dataset.practice_pseudo_id = reg.practice_pseudo_id
     results = in_memory_engine.extract(dataset)
 
@@ -222,7 +222,7 @@ def test_addresses_for_patient_on(in_memory_engine):
     address = tpp.addresses.for_patient_on("2010-01-01")
 
     dataset = Dataset()
-    dataset.set_population(tpp.addresses.exists_for_patient())
+    dataset.define_population(tpp.addresses.exists_for_patient())
     dataset.address_id = address.address_id
     results = in_memory_engine.extract(dataset)
 

--- a/tests/lib/fixtures.py
+++ b/tests/lib/fixtures.py
@@ -4,7 +4,7 @@ from databuilder.tables.beta.tpp import patients
 
 dataset = Dataset()
 year = patients.date_of_birth.year
-dataset.set_population(year >= 1940)
+dataset.define_population(year >= 1940)
 dataset.year = year
 """
 
@@ -14,7 +14,7 @@ from databuilder.tables.beta.tpp import patients
 
 my_dataset = Dataset()
 year = patients.date_of_birth.year
-my_dataset.set_population(year >= 1900)
+my_dataset.define_population(year >= 1900)
 """
 
 invalid_dataset_attribute_dataset_definition = """
@@ -43,6 +43,6 @@ args = parser.parse_args()
 
 dataset = Dataset()
 year = patients.date_of_birth.year
-dataset.set_population(year >= args.year)
+dataset.define_population(year >= args.year)
 dataset.year = year
 """

--- a/tests/spec/README.md
+++ b/tests/spec/README.md
@@ -60,7 +60,7 @@ spec test uses the `spec_test` fixture, which has the following components:
 ```
 spec_test(
     table_data,                          # a dict (see below) defining the tables in the test database
-    e.take(e.b1).i1.sum_for_patient(),   # the ehrQL code being tested
+    e.where(e.b1).i1.sum_for_patient(),   # the ehrQL code being tested
     {                                    # expected results
         1: (101 + 102),
         2: 201,
@@ -112,7 +112,7 @@ expected to return a Series.
 
 e.g. in the table data above, to get the sum of the `i1` column where `b1` is True:
 
-```e.take(e.b1).i1.sum_for_patient()```
+```e.where(e.b1).i1.sum_for_patient()```
 
 ### Expected results
 

--- a/tests/spec/conftest.py
+++ b/tests/spec/conftest.py
@@ -71,7 +71,7 @@ def make_dataset(table_data, population=None):
         for table in table_data.keys():
             population = table.exists_for_patient() | population
     dataset = Dataset()
-    dataset.set_population(population)
+    dataset.define_population(population)
     return dataset
 
 

--- a/tests/spec/filter/test_except_where.py
+++ b/tests/spec/filter/test_except_where.py
@@ -3,7 +3,7 @@ from ..tables import e
 title = "Excluding rows"
 
 
-def test_drop_with_column(spec_test):
+def test_except_where_with_column(spec_test):
     table_data = {
         e: """
               |  i1 |  b1
@@ -21,7 +21,7 @@ def test_drop_with_column(spec_test):
 
     spec_test(
         table_data,
-        e.drop(e.b1).i1.sum_for_patient(),
+        e.except_where(e.b1).i1.sum_for_patient(),
         {
             1: 103,
             2: (202 + 203),
@@ -30,7 +30,7 @@ def test_drop_with_column(spec_test):
     )
 
 
-def test_drop_with_expr(spec_test):
+def test_except_where_with_expr(spec_test):
     table_data = {
         e: """
               |  i1 |  i2
@@ -47,7 +47,7 @@ def test_drop_with_expr(spec_test):
 
     spec_test(
         table_data,
-        e.drop((e.i1 + e.i2) < 413).i1.sum_for_patient(),
+        e.except_where((e.i1 + e.i2) < 413).i1.sum_for_patient(),
         {
             1: None,
             2: (202 + 203),
@@ -56,7 +56,7 @@ def test_drop_with_expr(spec_test):
     )
 
 
-def test_drop_with_constant_true(spec_test):
+def test_except_where_with_constant_true(spec_test):
     table_data = {
         e: """
               |  i1
@@ -69,7 +69,7 @@ def test_drop_with_constant_true(spec_test):
 
     spec_test(
         table_data,
-        e.drop(True).count_for_patient(),
+        e.except_where(True).count_for_patient(),
         {
             1: 0,
             2: 0,
@@ -77,7 +77,7 @@ def test_drop_with_constant_true(spec_test):
     )
 
 
-def test_drop_with_constant_false(spec_test):
+def test_except_where_with_constant_false(spec_test):
     table_data = {
         e: """
               |  i1
@@ -90,7 +90,7 @@ def test_drop_with_constant_false(spec_test):
 
     spec_test(
         table_data,
-        e.drop(False).count_for_patient(),
+        e.except_where(False).count_for_patient(),
         {
             1: 2,
             2: 1,

--- a/tests/spec/filter/test_where.py
+++ b/tests/spec/filter/test_where.py
@@ -3,7 +3,7 @@ from ..tables import e
 title = "Including rows"
 
 
-def test_take_with_column(spec_test):
+def test_where_with_column(spec_test):
     table_data = {
         e: """
               |  i1 |  b1
@@ -21,7 +21,7 @@ def test_take_with_column(spec_test):
 
     spec_test(
         table_data,
-        e.take(e.b1).i1.sum_for_patient(),
+        e.where(e.b1).i1.sum_for_patient(),
         {
             1: (101 + 102),
             2: 201,
@@ -30,7 +30,7 @@ def test_take_with_column(spec_test):
     )
 
 
-def test_take_with_expr(spec_test):
+def test_where_with_expr(spec_test):
     table_data = {
         e: """
               |  i1 |  i2
@@ -47,7 +47,7 @@ def test_take_with_expr(spec_test):
 
     spec_test(
         table_data,
-        e.take((e.i1 + e.i2) < 413).i1.sum_for_patient(),
+        e.where((e.i1 + e.i2) < 413).i1.sum_for_patient(),
         {
             1: (101 + 102 + 103),
             2: 201,
@@ -56,7 +56,7 @@ def test_take_with_expr(spec_test):
     )
 
 
-def test_take_with_constant_true(spec_test):
+def test_where_with_constant_true(spec_test):
     table_data = {
         e: """
               |  i1
@@ -69,7 +69,7 @@ def test_take_with_constant_true(spec_test):
 
     spec_test(
         table_data,
-        e.take(True).count_for_patient(),
+        e.where(True).count_for_patient(),
         {
             1: 2,
             2: 1,
@@ -77,7 +77,7 @@ def test_take_with_constant_true(spec_test):
     )
 
 
-def test_take_with_constant_false(spec_test):
+def test_where_with_constant_false(spec_test):
     table_data = {
         e: """
               |  i1
@@ -90,7 +90,7 @@ def test_take_with_constant_false(spec_test):
 
     spec_test(
         table_data,
-        e.take(False).count_for_patient(),
+        e.where(False).count_for_patient(),
         {
             1: 0,
             2: 0,
@@ -98,7 +98,7 @@ def test_take_with_constant_false(spec_test):
     )
 
 
-def test_chain_multiple_takes(spec_test):
+def test_chain_multiple_wheres(spec_test):
     table_data = {
         e: """
               | i1 | b1
@@ -111,7 +111,7 @@ def test_chain_multiple_takes(spec_test):
 
     spec_test(
         table_data,
-        e.take(e.i1 >= 2).take(e.b1).i1.sum_for_patient(),
+        e.where(e.i1 >= 2).where(e.b1).i1.sum_for_patient(),
         {
             1: 2,
         },

--- a/tests/spec/population/test_population.py
+++ b/tests/spec/population/test_population.py
@@ -4,7 +4,7 @@ from ..tables import e, p
 
 title = "Defining a population"
 text = """
-`set_population` is used to limit the population from which data is extracted.
+`define_population` is used to limit the population from which data is extracted.
 """
 
 

--- a/tests/spec/test_specs.py
+++ b/tests/spec/test_specs.py
@@ -132,19 +132,21 @@ def test_get_title_for_test_fn(test_fn, title):
             ['p.d1.is_before("2000-01-20"),', "population=p.b1"],
             0,
             True,
-            'p.d1.is_before("2000-01-20")\nset_population(p.b1)',
+            'p.d1.is_before("2000-01-20")\ndefine_population(p.b1)',
         ),
         (
             # incomplete population definition; this should also never happen
             ['p.d1.is_before("2000-01-20"),', 'population=p.d2.is_before("2000-01-'],
             0,
             True,
-            'p.d1.is_before("2000-01-20")\nset_population(p.d2.is_before("2000-01-)',
+            'p.d1.is_before("2000-01-20")\ndefine_population(p.d2.is_before("2000-01-)',
         ),
     ],
 )
 def test_get_series_code(source_lines, source_index, includes_population, expected):
     assert (
-        get_series_code(source_lines, source_index, set_population=includes_population)
+        get_series_code(
+            source_lines, source_index, define_population=includes_population
+        )
         == expected
     )

--- a/tests/spec/test_specs.py
+++ b/tests/spec/test_specs.py
@@ -52,22 +52,22 @@ def test_build_section():
         assert False, "expected paragraph ids not found"
 
 
-def test_take_with_expr():
+def test_where_with_expr():
     pass
 
 
-test_take_with_expr.title = "Take rows that match an expression"
+test_where_with_expr.title = "Find rows where an expression is matched"
 
 
-def test_take_with_constant_true():
+def test_where_with_constant_true():
     pass
 
 
 @pytest.mark.parametrize(
     "test_fn,title",
     [
-        (test_take_with_expr, "Take rows that match an expression"),
-        (test_take_with_constant_true, "Take with constant true"),
+        (test_where_with_expr, "Find rows where an expression is matched"),
+        (test_where_with_constant_true, "Where with constant true"),
     ],
 )
 def test_get_title_for_test_fn(test_fn, title):

--- a/tests/spec/toc.py
+++ b/tests/spec/toc.py
@@ -2,8 +2,8 @@
 
 contents = {
     "filter": [
-        "test_take",
-        "test_drop",
+        "test_where",
+        "test_except_where",
     ],
     "sort_and_pick": [
         "test_sort_by_column_and_pick",

--- a/tests/unit/dummy_data/test_generator.py
+++ b/tests/unit/dummy_data/test_generator.py
@@ -36,7 +36,7 @@ class events(EventFrame):
 def test_dummy_data_generator():
     # Define a basic dataset
     dataset = Dataset()
-    dataset.set_population(practice_registrations.exists_for_patient())
+    dataset.define_population(practice_registrations.exists_for_patient())
     dataset.date_of_birth = patients.date_of_birth
     dataset.date_of_death = patients.date_of_death
     dataset.sex = patients.sex
@@ -74,7 +74,7 @@ def test_dummy_data_generator():
 @mock.patch("databuilder.dummy_data.generator.time")
 def test_dummy_data_generator_timeout_with_some_results(patched_time):
     dataset = Dataset()
-    dataset.set_population(patients.exists_for_patient())
+    dataset.define_population(patients.exists_for_patient())
 
     variable_definitions = compile(dataset)
     generator = DummyDataGenerator(variable_definitions)
@@ -94,7 +94,7 @@ def test_dummy_data_generator_timeout_with_some_results(patched_time):
 def test_dummy_data_generator_timeout_with_no_results(patched_time):
     # Define a dataset with a condition no patient can match
     dataset = Dataset()
-    dataset.set_population(patients.sex != patients.sex)
+    dataset.define_population(patients.sex != patients.sex)
 
     variable_definitions = compile(dataset)
     generator = DummyDataGenerator(variable_definitions)
@@ -171,7 +171,7 @@ def test_rows_for_patients_with_first_of_month_constraint(dummy_patient_generato
 @pytest.fixture(scope="module")
 def dummy_patient_generator():
     dataset = Dataset()
-    dataset.set_population(patients.exists_for_patient())
+    dataset.define_population(patients.exists_for_patient())
     variable_definitions = compile(dataset)
     generator = DummyPatientGenerator(variable_definitions, random_seed="abc")
     generator.generate_patient_facts()

--- a/tests/unit/dummy_data/test_generator.py
+++ b/tests/unit/dummy_data/test_generator.py
@@ -42,7 +42,7 @@ def test_dummy_data_generator():
     dataset.sex = patients.sex
 
     last_event = (
-        events.take(events.code.is_in(["abc", "def"]))
+        events.where(events.code.is_in(["abc", "def"]))
         .sort_by(events.date)
         .last_for_patient()
     )

--- a/tests/unit/dummy_data/test_query_info.py
+++ b/tests/unit/dummy_data/test_query_info.py
@@ -29,7 +29,7 @@ class events(EventFrame):
 
 def test_query_info_from_variable_definitions():
     dataset = Dataset()
-    dataset.set_population(events.exists_for_patient())
+    dataset.define_population(events.exists_for_patient())
     dataset.date_of_birth = patients.date_of_birth
     dataset.sex = patients.sex
     variable_definitions = compile(dataset)
@@ -70,7 +70,7 @@ def test_query_info_from_variable_definitions():
 
 def test_query_info_records_values():
     dataset = Dataset()
-    dataset.set_population(events.exists_for_patient())
+    dataset.define_population(events.exists_for_patient())
     # Simple equality comparison
     dataset.q1 = events.where(events.code == CTV3Code("abc00")).exists_for_patient()
     # String contains
@@ -97,7 +97,7 @@ def test_query_info_ignores_complex_comparisons():
     # selected column and a static value. We don't attempt to handle these, but we want
     # to make sure we don't blow up with an error, or misinterpret them.
     dataset = Dataset()
-    dataset.set_population(events.exists_for_patient())
+    dataset.define_population(events.exists_for_patient())
     dataset.q1 = patients.date_of_birth.year.is_in([2000, 2010, 2020])
     dataset.q2 = patients.date_of_birth + days(100) == "2021-10-20"
     dataset.q3 = patients.date_of_birth == "2022-10-05"

--- a/tests/unit/dummy_data/test_query_info.py
+++ b/tests/unit/dummy_data/test_query_info.py
@@ -72,15 +72,15 @@ def test_query_info_records_values():
     dataset = Dataset()
     dataset.set_population(events.exists_for_patient())
     # Simple equality comparison
-    dataset.q1 = events.take(events.code == CTV3Code("abc00")).exists_for_patient()
+    dataset.q1 = events.where(events.code == CTV3Code("abc00")).exists_for_patient()
     # String contains
     dataset.q2 = patients.sex.contains("ale")
     # Set contains
-    dataset.q3 = events.take(
+    dataset.q3 = events.where(
         events.code.is_in([CTV3Code("def00"), CTV3Code("ghi00")])
     ).exists_for_patient()
     # Equality comparison where the column is not selected directly from the table
-    old = events.take(events.date < "2000-01-01")
+    old = events.where(events.date < "2000-01-01")
     dataset.q4 = old.sort_by(old.date).first_for_patient().code == CTV3Code("jkl00")
 
     variable_definitions = compile(dataset)

--- a/tests/unit/test_docs.py
+++ b/tests/unit/test_docs.py
@@ -39,23 +39,23 @@ def test_generate_docs():
         for section in spec["sections"]
         for paragraph in section["paragraphs"]
     ]
-    # Split the series string into its series and set_population components, if necessary
+    # Split the series string into its series and define_population components, if necessary
     # assert that each component string has no leading whitespace for the first and last lines,
     # and other lines have a multiple of 4 spaces
     for series in all_series:
         series_lines = series.split("\n")
         population_lines = []
-        set_population_index = next(
+        define_population_index = next(
             (
                 i
                 for i, line in enumerate(series_lines)
-                if line.startswith("set_population")
+                if line.startswith("define_population")
             ),
             None,
         )
-        if set_population_index:
-            population_lines = series_lines[set_population_index:]
-            series_lines = series_lines[:set_population_index]
+        if define_population_index:
+            population_lines = series_lines[define_population_index:]
+            series_lines = series_lines[:define_population_index]
 
         for lines_list in [series_lines, population_lines]:
             for i, line in enumerate(lines_list):

--- a/tests/unit/test_docs.py
+++ b/tests/unit/test_docs.py
@@ -101,7 +101,7 @@ def test_render_specs():
                                     ["3", "302", "F"],
                                 ]
                             },
-                            "series": "e.take(e.b1).i1.sum_for_patient()",
+                            "series": "e.where(e.b1).i1.sum_for_patient()",
                             "output": [["1", "203"], ["2", "201"], ["3", ""]],
                         }
                     ],
@@ -128,7 +128,7 @@ This example makes use of an event-level table named `e` containing the followin
 | 3|302|F |
 
 ```
-e.take(e.b1).i1.sum_for_patient()
+e.where(e.b1).i1.sum_for_patient()
 ```
 returns the following patient series:
 
@@ -241,7 +241,7 @@ def test_specs_with_additional_text():
                                     ["3", "302", "F"],
                                 ]
                             },
-                            "series": "e.take(e.b1).i1.sum_for_patient()",
+                            "series": "e.where(e.b1).i1.sum_for_patient()",
                             "output": [["1", "203"], ["2", "201"], ["3", ""]],
                         }
                     ],
@@ -271,7 +271,7 @@ This example makes use of an event-level table named `e` containing the followin
 | 3|302|F |
 
 ```
-e.take(e.b1).i1.sum_for_patient()
+e.where(e.b1).i1.sum_for_patient()
 ```
 returns the following patient series:
 

--- a/tests/unit/test_query_language.py
+++ b/tests/unit/test_query_language.py
@@ -55,7 +55,7 @@ events = EventFrame(SelectTable("coded_events", events_schema))
 def test_dataset():
     year_of_birth = patients.date_of_birth.year
     dataset = Dataset()
-    dataset.set_population(year_of_birth <= 2000)
+    dataset.define_population(year_of_birth <= 2000)
     dataset.year_of_birth = year_of_birth
 
     assert dataset.year_of_birth is year_of_birth
@@ -81,7 +81,7 @@ def test_dataset():
 
 def test_dataset_preserves_variable_order():
     dataset = Dataset()
-    dataset.set_population(patients.exists_for_patient())
+    dataset.define_population(patients.exists_for_patient())
     dataset.foo = patients.date_of_birth.year
     dataset.baz = patients.date_of_birth.year + 100
     dataset.bar = patients.date_of_birth.year - 100


### PR DESCRIPTION
This is the first part of #1119, to replace and deprecate:
  -  `take` -> `where` 
  -  `drop` -> `except_where` 
  -  `set_population` -> `define_population` 