### PR TITLE
Ensure all QM nodes are covered by generative tests in CI

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -194,8 +194,9 @@ test-generative *ARGS: devenv
     #!/usr/bin/env bash
     set -euo pipefail
 
+    examples=${GENTEST_EXAMPLES:-200}
     [[ -v CI ]] && echo "::group::Run tests (click to view)" || echo "Run tests"
-    $BIN/python -m pytest \
+    GENTEST_EXAMPLES=$examples GENTEST_COMPREHENSIVE=t $BIN/python -m pytest \
         --cov=databuilder \
         --cov=tests \
         --cov-report=html \

--- a/tests/generative/recording.py
+++ b/tests/generative/recording.py
@@ -47,7 +47,7 @@ class Recorder:
         return tuple(copy.values())
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def recorder(request):  # pragma: no cover
     recorder_ = Recorder()
 

--- a/tests/generative/test_query_model.py
+++ b/tests/generative/test_query_model.py
@@ -66,7 +66,7 @@ data_strategy = data_strategies.data(
     value_strategies,
 )
 settings = dict(
-    max_examples=(int(os.environ.get("GENTEST_EXAMPLES", 100))),
+    max_examples=(int(os.environ.get("GENTEST_EXAMPLES", 10))),
     deadline=None,
 )
 

--- a/tests/generative/test_query_model.py
+++ b/tests/generative/test_query_model.py
@@ -107,7 +107,7 @@ def test_query_model(query_engines, variable, data, recorder):
         ),  # triggers python overflow error with timedelta
     ],
 )
-def test_handle_date_errors(query_engines, operation, rhs, recorder):
+def test_handle_date_errors(query_engines, operation, rhs):
     data = [
         {
             "type": data_setup.P0,


### PR DESCRIPTION
Fixes #1055 

- Sets the default generative tests examples to 10, which means they take a couple of seconds to run.
- Makes `just test-all` use GENTEST_COMPREHENSIVE=t GENTEST_EXAMPLES=200 (which is sufficient to cover all the QM nodes).  GENTEST_EXAMPLES can still be defined as something else by doing e.g. `GENTEST_EXAMPLES=500 just test-all`
- Updates the recording fixture scope so that comprehensive check failures are reported at a more logical point in the test run (after the generative tests, rather than at the end of the entire run)
