### PR TITLE
Fix shebang for portability

### DIFF
--- a/scripts/check-docs.sh
+++ b/scripts/check-docs.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 
 # This script is run as a pre-commit hook to ensure generated docs files are
 # up to date


### PR DESCRIPTION
Different OSs put bash in different places, so run the first bash found on on the `PATH`.