### PR TITLE
Jongmassey/table from rows

### DIFF
--- a/databuilder/main.py
+++ b/databuilder/main.py
@@ -154,14 +154,18 @@ def get_sql_strings(query_engine, variable_definitions):
     dialect = query_engine.sqlalchemy_dialect()
     sql_strings = []
 
-    for n, query in enumerate(setup_queries, start=1):
+    for i, query in enumerate(setup_queries, start=1):
         sql = clause_as_str(query, dialect)
-        sql_strings.append(f"-- Setup query {n:03} / {len(setup_queries):03}\n{sql}")
+        sql_strings.append(f"-- Setup query {i:03} / {len(setup_queries):03}\n{sql}")
 
     sql = clause_as_str(results_query, dialect)
     sql_strings.append(f"-- Results query\n{sql}")
 
-    assert not cleanup_queries, "Support these once tests exercise them"
+    for i, query in enumerate(cleanup_queries, start=1):
+        sql = clause_as_str(query, dialect)
+        sql_strings.append(
+            f"-- Cleanup query {i:03} / {len(cleanup_queries):03}\n{sql}"
+        )
 
     return sql_strings
 

--- a/databuilder/query_engines/in_memory.py
+++ b/databuilder/query_engines/in_memory.py
@@ -304,6 +304,13 @@ class InMemoryQueryEngine(BaseQueryEngine):
         arguments = [default, *[i for pair in cases for i in pair]]
         return apply_function(case_flattened, *arguments)
 
+    def visit_InlinePatientTable(self, node):
+        col_names = node.schema.column_names
+        return PatientTable.from_records(
+            col_names=["patient_id"] + col_names,
+            row_records=node.rows,
+        )
+
 
 def case_flattened(default, *cases):
     """

--- a/databuilder/query_engines/sqlite.py
+++ b/databuilder/query_engines/sqlite.py
@@ -1,4 +1,5 @@
 import sqlalchemy
+from sqlalchemy.schema import CreateIndex
 from sqlalchemy.sql.functions import Function as SQLFunction
 
 from databuilder.query_engines.base_sql import BaseSQLQueryEngine
@@ -77,3 +78,15 @@ class SQLiteQueryEngine(BaseSQLQueryEngine):
 
     def to_first_of_month(self, date):
         return SQLFunction("DATE", date, "start of month", type_=sqlalchemy.Date)
+
+    def get_temporary_table_setup_and_cleanup_queries(self, table):
+        (
+            setup_queries,
+            cleanup_queries,
+        ) = super().get_temporary_table_setup_and_cleanup_queries(table)
+
+        setup_queries.append(
+            CreateIndex(sqlalchemy.Index(None, table.c["patient_id"])),
+        )
+
+        return (setup_queries, cleanup_queries)

--- a/databuilder/query_language.py
+++ b/databuilder/query_language.py
@@ -755,6 +755,14 @@ def get_table_schema_from_class(cls):
     return qm.TableSchema(**schema)
 
 
+def _inline_patient_table_from_rows(cls, rows):
+    return qm.InlinePatientTable(
+        rows=qm.IterWrapper(rows),
+        schema=get_table_schema_from_class(cls),
+        name=cls.__name__,
+    )
+
+
 # Defines a PatientFrame along with the data it contains. Takes a list (or
 # any iterable) of row tuples of the form:
 #
@@ -764,11 +772,7 @@ def table_from_rows(rows):
     def decorator(cls):
         if cls.__bases__ != (PatientFrame,):
             raise SchemaError("`@table_from_rows` can only be used with `PatientFrame`")
-        qm_node = qm.InlinePatientTable(
-            rows=qm.IterWrapper(rows),
-            schema=get_table_schema_from_class(cls),
-            name=cls.__name__,
-        )
+        qm_node = _inline_patient_table_from_rows(cls, rows)
         return cls(qm_node)
 
     return decorator

--- a/databuilder/query_language.py
+++ b/databuilder/query_language.py
@@ -767,6 +767,7 @@ def table_from_rows(rows):
         qm_node = qm.InlinePatientTable(
             rows=qm.IterWrapper(rows),
             schema=get_table_schema_from_class(cls),
+            name=cls.__name__,
         )
         return cls(qm_node)
 

--- a/databuilder/query_model/nodes.py
+++ b/databuilder/query_model/nodes.py
@@ -196,6 +196,7 @@ class InlinePatientTable(OneRowPerPatientFrame):
     #
     rows: Iterable[tuple]
     schema: TableSchema
+    name: str
 
 
 class SelectColumn(Series):

--- a/tests/spec/table_from_rows/test_table_from_rows.py
+++ b/tests/spec/table_from_rows/test_table_from_rows.py
@@ -1,5 +1,3 @@
-import pytest
-
 from databuilder.tables import PatientFrame, Series, table_from_rows
 
 from ..tables import p
@@ -17,7 +15,6 @@ table_data = {
 }
 
 
-@pytest.mark.xfail
 def test_table_from_rows(spec_test):
     inline_data = [
         (1, 100),

--- a/tests/unit/query_model/test_nodes.py
+++ b/tests/unit/query_model/test_nodes.py
@@ -136,6 +136,7 @@ def test_inline_patient_table():
             ]
         ),
         schema=TableSchema(i=Column(int)),
+        name="t",
     )
     # Check that the table node is still hashable even though the iterable hidden by the
     # `IterWrapper` is mutable

--- a/tests/unit/test_query_language.py
+++ b/tests/unit/test_query_language.py
@@ -198,7 +198,8 @@ class TestIntEventSeries:
 class TestDateSeries:
     def test_year(self):
         assert_produces(
-            DateEventSeries(qm_date_series).year, Function.YearFromDate(qm_date_series)
+            DateEventSeries(qm_date_series).year,
+            Function.YearFromDate(qm_date_series),
         )
 
 
@@ -231,7 +232,8 @@ def test_automatic_cast(lhs, op, rhs, expected_type):
 def test_is_in():
     int_series = IntEventSeries(qm_int_series)
     assert_produces(
-        int_series.is_in([1, 2]), Function.In(qm_int_series, Value(frozenset([1, 2])))
+        int_series.is_in([1, 2]),
+        Function.In(qm_int_series, Value(frozenset([1, 2]))),
     )
 
 
@@ -312,7 +314,8 @@ def test_table_from_rows():
 
 def test_table_from_rows_only_accepts_patient_frame():
     with pytest.raises(
-        SchemaError, match="`@table_from_rows` can only be used with `PatientFrame`"
+        SchemaError,
+        match="`@table_from_rows` can only be used with `PatientFrame`",
     ):
 
         @table_from_rows([])
@@ -415,10 +418,30 @@ def test_static_date_operations(lhs, op, rhs, expected):
         ("2020-01-01", "-", patients.date_of_birth, DateDifference),
         (date(2020, 1, 1), "-", patients.date_of_birth, DateDifference),
         # DateDifference attributes
-        ((patients.date_of_birth - "2020-01-01").days, "+", 1, IntPatientSeries),
-        ((patients.date_of_birth - "2020-01-01").weeks, "+", 1, IntPatientSeries),
-        ((patients.date_of_birth - "2020-01-01").months, "+", 1, IntPatientSeries),
-        ((patients.date_of_birth - "2020-01-01").years, "+", 1, IntPatientSeries),
+        (
+            (patients.date_of_birth - "2020-01-01").days,
+            "+",
+            1,
+            IntPatientSeries,
+        ),
+        (
+            (patients.date_of_birth - "2020-01-01").weeks,
+            "+",
+            1,
+            IntPatientSeries,
+        ),
+        (
+            (patients.date_of_birth - "2020-01-01").months,
+            "+",
+            1,
+            IntPatientSeries,
+        ),
+        (
+            (patients.date_of_birth - "2020-01-01").years,
+            "+",
+            1,
+            IntPatientSeries,
+        ),
         # Test with a "dynamic" duration
         (patients.date_of_birth, "+", days(patients.i), DatePatientSeries),
         (patients.date_of_birth, "+", weeks(patients.i), DatePatientSeries),


### PR DESCRIPTION
Groundwork for #793 commits cherry-picked from #1076 and rebased accordingly due to effects of changes in `main`.

This PR now includes the re-introduction of code for setup and cleanup queries removed in #1136 