### PR TITLE
fix: Remove deprecated ehrQL methods

### DIFF
--- a/databuilder/query_language.py
+++ b/databuilder/query_language.py
@@ -2,7 +2,6 @@ import dataclasses
 import datetime
 import enum
 import functools
-import warnings
 from collections import ChainMap
 from typing import Union
 
@@ -35,14 +34,6 @@ class _DictArg(list):
 class Dataset:
     def __init__(self):
         object.__setattr__(self, "variables", {})
-
-    def set_population(self, population):  # pragma: no cover
-        warnings.warn(
-            "Use `define_population` instead of `set_population`",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.define_population(population)
 
     def define_population(self, population):
         validate_population_definition(population.qm_node)
@@ -623,10 +614,6 @@ class PatientFrame(BaseFrame):
 
 
 class EventFrame(BaseFrame):
-    def take(self, series):  # pragma: no cover
-        warnings.warn("Use `where` instead of `take`", DeprecationWarning, stacklevel=2)
-        return self.where(series)
-
     def where(self, series):
         return self.__class__(
             qm.Filter(
@@ -634,12 +621,6 @@ class EventFrame(BaseFrame):
                 condition=_convert(series),
             )
         )
-
-    def drop(self, series):  # pragma: no cover
-        warnings.warn(
-            "Use `except_where` instead of `drop`", DeprecationWarning, stacklevel=2
-        )
-        return self.except_where(series)
 
     def except_where(self, series):
         return self.__class__(

--- a/tests/acceptance/external_studies/ons-mental-health/analysis/dataset_definition_ons_cis_new.py
+++ b/tests/acceptance/external_studies/ons-mental-health/analysis/dataset_definition_ons_cis_new.py
@@ -13,14 +13,14 @@ n_visits = 26
 dataset = Dataset()
 
 #######################################################################################
-# Set population
+# Define population
 # Filter ONS CIS table to visit dates between the study start and end dates (inclusive) 
 # and set the population to only patients who have at least one visit date in study date
 # range
 #######################################################################################
 
-ons_cis = schema.ons_cis.take(schema.ons_cis.visit_date.is_on_or_between(start_date, end_date))
-dataset.set_population(ons_cis.exists_for_patient())
+ons_cis = schema.ons_cis.where(schema.ons_cis.visit_date.is_on_or_between(start_date, end_date))
+dataset.define_population(ons_cis.exists_for_patient())
 
 #######################################################################################
 # Define variables
@@ -41,7 +41,7 @@ def get_sequential_events(events, num_events, column_name):
         # One each iteration through this loop, we first filter the events to only those
         # LATER than the previous_date found
         if previous_date is not None:
-            later_events = events.take(sort_column > previous_date)
+            later_events = events.where(sort_column > previous_date)
         else:
             later_events = events
         # Now we sort the events and get the first one

--- a/tests/acceptance/external_studies/openprompt-long-covid-economics/analysis/codelists.py
+++ b/tests/acceptance/external_studies/openprompt-long-covid-economics/analysis/codelists.py
@@ -117,3 +117,58 @@ ra_sle_psoriasis_code = codelist_from_csv(
     "codelists/opensafely-ra-sle-psoriasis.csv",
     column = "CTV3ID",
 )
+
+asplenia_code = codelist_from_csv(
+    "codelists/opensafely-asplenia.csv",
+    column = "CTV3ID",
+)
+
+hiv_code = codelist_from_csv(
+    "codelists/opensafely-hiv.csv",
+    column = "CTV3ID",
+)
+
+aplastic_anemia_code = codelist_from_csv(
+    "codelists/opensafely-aplastic-anaemia.csv",
+    column = "CTV3ID",
+)
+
+permanent_immune_suppress_code = codelist_from_csv(
+    "codelists/opensafely-permanent-immunosuppression.csv",
+    column="CTV3ID",
+)
+
+temporary_immune_suppress_code = codelist_from_csv(
+    "codelists/opensafely-temporary-immunosuppression.csv",
+        column="CTV3ID",
+)
+
+# adminstered vaccine codes
+vac_adm_1 = codelist_from_csv(
+  "codelists/primis-covid19-vacc-uptake-covadm1.csv",
+  column="code"
+)
+vac_adm_2 = codelist_from_csv(
+  "codelists/primis-covid19-vacc-uptake-covadm2.csv",
+  column="code"
+)
+vac_adm_3 = codelist_from_csv(
+  "codelists/primis-covid19-vacc-uptake-covadm3_cod.csv",
+  column="code"
+)
+vac_adm_4 = codelist_from_csv(
+  "codelists/primis-covid19-vacc-uptake-covadm4_cod.csv",
+  column="code"
+)
+vac_adm_5 = codelist_from_csv(
+  "codelists/primis-covid19-vacc-uptake-covadm5_cod.csv",
+  column="code"
+)
+
+vac_adm_combine_code = (
+    vac_adm_1
+    + vac_adm_2
+    + vac_adm_3
+    + vac_adm_4
+    + vac_adm_5
+)

--- a/tests/acceptance/external_studies/openprompt-long-covid-economics/analysis/dataset_definition_unmatched_comparator.py
+++ b/tests/acceptance/external_studies/openprompt-long-covid-economics/analysis/dataset_definition_unmatched_comparator.py
@@ -1,0 +1,65 @@
+from datetime import date
+
+from databuilder.ehrql import Dataset, days, years, months
+from databuilder.tables.beta.tpp import (
+    patients, addresses, appointments,
+    practice_registrations, clinical_events,
+    sgss_covid_all_tests, ons_deaths, 
+)
+from codelists import lc_codelists_combined
+
+import codelists
+import csv 
+
+# study start date
+study_start_date = date(2020, 11, 1)
+
+# age 
+age = (study_start_date - patients.date_of_birth).years
+
+
+# Import the filtered GP list to exclude GP that was not using the long COVID codes
+with open("output/dataset_lc_gp_list.csv") as csv_file:
+    reader = csv.DictReader(csv_file)
+    lc_gp = [int(row["gp_practice"]) for row in reader]
+
+target_practices = practice_registrations.where(practice_registrations.practice_pseudo_id.is_in(lc_gp))
+
+
+# current registration
+registration = practice_registrations \
+    .except_where(practice_registrations.start_date > (study_start_date - months(3))) \
+    .except_where(practice_registrations.end_date <= study_start_date) \
+    .sort_by(practice_registrations.start_date).last_for_patient()
+
+# # historical registration
+# historical_registration = practice_registrations \
+#     .except_where(practice_registrations.start_date > date(2018, 11, 1)) \
+#     .except_where(practice_registrations.end_date < date(2019, 11, 1))
+
+# # covid tests
+# latest_test_before_diagnosis = sgss_covid_all_tests \
+#     .where(sgss_covid_all_tests.is_positive) \
+#     .sort_by(sgss_covid_all_tests.specimen_taken_date).last_for_patient()
+
+# Potential end of follow-up before matching
+death_date = ons_deaths.sort_by(ons_deaths.date) \
+    .last_for_patient().date
+end_reg_date = registration.end_date
+lc_dx_date = clinical_events.where(clinical_events.snomedct_code.is_in(lc_codelists_combined)) \
+    .sort_by(clinical_events.date) \
+    .first_for_patient().date # LC dx dates
+
+dataset = Dataset()
+dataset.define_population((age >= 18) & registration.exists_for_patient() & target_practices.exists_for_patient())
+dataset.age = age
+dataset.sex = patients.sex
+dataset.region = registration.practice_stp
+dataset.gp_practice = registration.practice_pseudo_id
+dataset.registration_date = registration.start_date
+# dataset.historical_comparison_group = historical_registration.exists_for_patient()
+# dataset.comp_positive_covid_test = latest_test_before_diagnosis.exists_for_patient()
+# dataset.date_of_latest_positive_test_before_diagnosis = latest_test_before_diagnosis.specimen_taken_date.to_first_of_month() # only need the month 
+dataset.end_death = death_date
+dataset.end_deregist = end_reg_date
+dataset.long_covid_dx_date = lc_dx_date

--- a/tests/acceptance/external_studies/openprompt-long-covid-economics/analysis/dataset_definition_unmatched_exp_lc.py
+++ b/tests/acceptance/external_studies/openprompt-long-covid-economics/analysis/dataset_definition_unmatched_exp_lc.py
@@ -2,15 +2,15 @@ from datetime import date
 
 from databuilder.ehrql import Dataset, days, years
 from databuilder.tables.beta.tpp import (
-    patients, addresses, appointments,
+    patients, addresses, ons_deaths,
     practice_registrations, clinical_events,
-    sgss_covid_all_tests, ons_deaths, hospital_admissions,
 )
 from databuilder.codes import SNOMEDCTCode
 from codelists import lc_codelists_combined
 import codelists
-from variables import add_visits
+# from variables import add_visits
 
+# study start date 
 study_start_date = date(2020, 11, 1)
 
 # age 
@@ -27,23 +27,23 @@ lc_dx = clinical_events.where(clinical_events.snomedct_code.is_in(lc_codelists_c
     .sort_by(clinical_events.date) \
     .first_for_patient() # had lc dx and dx dates
 
-# covid tests month
-latest_test_before_diagnosis = sgss_covid_all_tests \
-    .where(sgss_covid_all_tests.is_positive) \
-    .except_where(sgss_covid_all_tests.specimen_taken_date >= lc_dx.date - days(30)) \
-    .sort_by(sgss_covid_all_tests.specimen_taken_date) \
-    .last_for_patient()
-# # only need the diagnostic month for sensitivity analysis matching
+# # covid tests month
+# latest_test_before_diagnosis = sgss_covid_all_tests \
+#     .where(sgss_covid_all_tests.is_positive) \
+#     .except_where(sgss_covid_all_tests.specimen_taken_date >= lc_dx.date - days(30)) \
+#     .sort_by(sgss_covid_all_tests.specimen_taken_date) \
+#     .last_for_patient()
+# # # only need the diagnostic month for sensitivity analysis matching
 
 # define end date: lc dx date +12 | death | derigistration | post COVID-19 syndrome resolved
-one_year_after_start = lc_dx.date + days(365) 
+# one_year_after_start = lc_dx.date + days(365) 
 death_date = ons_deaths.sort_by(ons_deaths.date) \
     .last_for_patient().date
 end_reg_date = registration.end_date
-lc_cure = clinical_events.where(clinical_events.snomedct_code ==  SNOMEDCTCode("1326351000000108")) \
-    .sort_by(clinical_events.date) \
-    .first_for_patient()
-# #first recorded lc cure date
+# lc_cure = clinical_events.where(clinical_events.snomedct_code ==  SNOMEDCTCode("1326351000000108")) \
+#     .sort_by(clinical_events.date) \
+#     .first_for_patient()
+#first recorded lc cure date
 
 
 dataset = Dataset()
@@ -53,27 +53,27 @@ dataset.sex = patients.sex
 dataset.region = registration.practice_stp
 dataset.gp_practice = registration.practice_pseudo_id
 dataset.registration_date = registration.start_date
-dataset.covid_positive = latest_test_before_diagnosis.exists_for_patient()
-dataset.covid_dx_month = latest_test_before_diagnosis.specimen_taken_date.to_first_of_month() # only need dx month
+# dataset.covid_positive = latest_test_before_diagnosis.exists_for_patient()
+# dataset.covid_dx_month = latest_test_before_diagnosis.specimen_taken_date.to_first_of_month() # only need dx month
 dataset.long_covid_dx = lc_dx.exists_for_patient()
 dataset.long_covid_dx_date = lc_dx.date
 dataset.index_date = lc_dx.date
-dataset.end_1y_after_index = one_year_after_start
+# dataset.end_1y_after_index = one_year_after_start
 dataset.end_death = death_date
 dataset.end_deregist = end_reg_date
-dataset.end_lc_cure = lc_cure.date
+# dataset.end_lc_cure = lc_cure.date
 
-add_visits(dataset, lc_dx.date, num_months=1)
-add_visits(dataset, lc_dx.date, num_months=2)
-add_visits(dataset, lc_dx.date, num_months=3)
-add_visits(dataset, lc_dx.date, num_months=4)
-add_visits(dataset, lc_dx.date, num_months=5)
-add_visits(dataset, lc_dx.date, num_months=6)
-add_visits(dataset, lc_dx.date, num_months=7)
-add_visits(dataset, lc_dx.date, num_months=8)
-add_visits(dataset, lc_dx.date, num_months=9)
-add_visits(dataset, lc_dx.date, num_months=10)
-add_visits(dataset, lc_dx.date, num_months=11)
-add_visits(dataset, lc_dx.date, num_months=12)
+# add_visits(dataset, lc_dx.date, num_months=1)
+# add_visits(dataset, lc_dx.date, num_months=2)
+# add_visits(dataset, lc_dx.date, num_months=3)
+# add_visits(dataset, lc_dx.date, num_months=4)
+# add_visits(dataset, lc_dx.date, num_months=5)
+# add_visits(dataset, lc_dx.date, num_months=6)
+# add_visits(dataset, lc_dx.date, num_months=7)
+# add_visits(dataset, lc_dx.date, num_months=8)
+# add_visits(dataset, lc_dx.date, num_months=9)
+# add_visits(dataset, lc_dx.date, num_months=10)
+# add_visits(dataset, lc_dx.date, num_months=11)
+# add_visits(dataset, lc_dx.date, num_months=12)
 
 

--- a/tests/acceptance/external_studies/openprompt-long-covid-economics/analysis/outcomes_health_use.py
+++ b/tests/acceptance/external_studies/openprompt-long-covid-economics/analysis/outcomes_health_use.py
@@ -1,0 +1,16 @@
+# local variables for defining covariates
+from datetime import date
+from databuilder.ehrql import Dataset, days, years,  case, when
+from databuilder.tables.beta.tpp import (
+    patients, addresses, appointments,
+    practice_registrations, clinical_events,
+    sgss_covid_all_tests, ons_deaths, hospital_admissions,
+)
+from databuilder.codes import CTV3Code, DMDCode, ICD10Code, SNOMEDCTCode
+import codelists
+
+from variables import (
+    add_visits, 
+    hospitalisation_diagnosis_matches,
+    clinical_ctv3_matches, 
+)

--- a/tests/acceptance/external_studies/openprompt-long-covid-economics/analysis/variables.py
+++ b/tests/acceptance/external_studies/openprompt-long-covid-economics/analysis/variables.py
@@ -84,3 +84,16 @@ def clinical_ctv3_matches(gpevent, codelist):
       .sort_by(gpevent.date).last_for_patient()
     )
     return gp_dx
+
+# Create sequential variables for COVID-19 vaccine
+def create_sequential_variables(
+    dataset, variable_name_template, events, column, num_variables, sort_column=None
+):
+    sort_column = sort_column or column
+    for index in range(num_variables):
+        next_event = events.sort_by(getattr(events, sort_column)).first_for_patient()
+        events = events.where(
+            getattr(events, sort_column) > getattr(next_event, sort_column)
+        )
+        variable_name = variable_name_template.format(n=index + 1)
+        setattr(dataset, variable_name, getattr(next_event, column))

--- a/tests/acceptance/external_studies/openprompt-long-covid-economics/codelists/opensafely-aplastic-anaemia.csv
+++ b/tests/acceptance/external_studies/openprompt-long-covid-economics/codelists/opensafely-aplastic-anaemia.csv
@@ -1,0 +1,42 @@
+CTV3ID,CTV3PreferredTermDesc,CTV3Source
+D2...,Aplastic and other anaemias,CTV3Map_Code_And_Term
+D20..,Aplastic anaemia,CTV3Map_Code_And_Term
+D200.,(Anaem:[const aplas][fam hypopl])(pancytop+malf)(Black-Diam),CTV3_Children
+D2000,"Anaemia: [congen hypoplastic]/[constit aplastic, no malform]",CTV3_Children
+D2001,Fanconi's anaemia,CTV3Map_Code_And_Term
+D2001,Fanconi's anaemia,CTV3Map_Code_Only
+D2003,(RBC aplas/hypoplas: [named variants]) or (Blackf-Diam synd),CTV3_Children
+D200y,Other specified constitutional aplastic anaemia,CTV3Map_Code_And_Term
+D200z,Constitutional aplastic anaemia NOS,CTV3_Children
+D201.,Anaemia: [acquired aplastic] or [normocytic due to aplasia],CTV3_Children
+D2010,Aplastic anaemia due to chronic disease,CTV3Map_Code_And_Term
+D2011,Anaemia: [aplast due drug][hypoplast due drug or chem subst],CTV3_Children
+D2012,Aplastic anaemia due to infection,CTV3Map_Code_And_Term
+D2012,Aplastic anaemia due to infection,CTV3Map_Code_Only
+D2013,Aplastic anaemia due to radiation,CTV3Map_Code_And_Term
+D2013,Aplastic anaemia due to radiation,CTV3Map_Code_Only
+D2014,Aplastic anaemia due to toxic cause,CTV3Map_Code_And_Term
+D2014,Aplastic anaemia due to toxic cause,CTV3Map_Code_Only
+D2017,Transient hypoplastic anaemia,CTV3_Children
+D204.,Idiopathic aplastic anaemia,CTV3Map_Code_And_Term
+D20z.,Aplastic anaemia NOS,CTV3Map_Code_And_Term
+Dyu21,[X]Other specified aplastic anaemias,CTV3_Children
+X20CO,Pancytopenia with pancreatitis,CTV3Map_Code_Only
+X20CP,Constitutional aplastic anaemia without malformation,CTV3Map_Code_And_Term
+X20CP,Constitutional aplastic anaemia without malformation,CTV3Map_Code_Only
+X30Jq,Congenital Fanconi syndrome,CTV3Map_Code_And_Term
+X30Jr,Acquired Fanconi syndrome,CTV3Map_Code_And_Term
+X30Jr,Acquired Fanconi syndrome,CTV3Map_Code_Only
+X30Js,Adult Fanconi syndrome,CTV3Map_Code_And_Term
+X70Jk,Parvoviral aplastic crisis,QOF
+XE13q,Constitutional aplastic anaemia,CTV3Map_Code_And_Term
+XE13q,Constitutional aplastic anaemia,CTV3Map_Code_Only
+XE13r,Constitutional aplastic anaemia with malformation,CTV3Map_Code_And_Term
+XE13r,Constitutional aplastic anaemia with malformation,CTV3Map_Code_Only
+XE13t,Acquired aplastic anaemia,CTV3Map_Code_And_Term
+XE13u,Aplastic anaemia due to drugs,CTV3Map_Code_And_Term
+XE13u,Aplastic anaemia due to drugs,CTV3Map_Code_Only
+XE13w,Acquired aplastic anaemia NOS,CTV3Map_Code_And_Term
+XE14g,Anaemia: [aplastic and other] or [aplastic] or [hypoblastic],High_Level_SNOMED
+XM1Qy,Pancytopenia-dysmelia,CTV3Map_Code_And_Term
+XM1Qy,Pancytopenia-dysmelia,CTV3Map_Code_Only

--- a/tests/acceptance/external_studies/openprompt-long-covid-economics/codelists/opensafely-asplenia.csv
+++ b/tests/acceptance/external_studies/openprompt-long-covid-economics/codelists/opensafely-asplenia.csv
@@ -1,0 +1,51 @@
+CTV3ID,CTV3PreferredTermDesc,CTV3Source
+14N7.,H/O splenectomy,CTV3Map_Code_And_Term
+7840.,Total splenectomy,CTV3Map_Code_And_Term
+7840.,Total splenectomy,CTV3Map_Code_Only
+7840.,Total splenectomy,QOF
+78400,Total splenectomy and reimplantation of fragments,CTV3Map_Code_And_Term
+78401,Total splenectomy,High_Level_SNOMED
+78403,Splenectomy NEC,CTV3Map_Code_And_Term
+78403,Splenectomy NEC,QOF
+7840y,Other specified total excision of spleen,CTV3Map_Code_And_Term
+7840y,Other specified total excision of spleen,QOF
+7840z,Total excision of spleen NOS,CTV3Map_Code_And_Term
+7840z,Total excision of spleen NOS,QOF
+7841.,Other excision of spleen,CTV3Map_Code_And_Term
+7841.,Other excision of spleen,QOF
+78410,Partial splenectomy,CTV3Map_Code_And_Term
+7841y,Other specified other excision of spleen,CTV3Map_Code_And_Term
+7841y,Other specified other excision of spleen,QOF
+7841z,Other excision of spleen NOS,CTV3Map_Code_And_Term
+7841z,Other excision of spleen NOS,QOF
+78421,Embolisation of spleen,CTV3Map_Code_And_Term
+A8410,Plasmodium vivax malaria with rupture of spleen,QOF
+D4154,Atrophy of spleen,CTV3Map_Code_And_Term
+D4154,Atrophy of spleen,QOF
+D4156,Splenic fibrosis,CTV3Map_Code_And_Term
+D4156,Splenic fibrosis,QOF
+D4157,Infarction of spleen,CTV3Map_Code_And_Term
+D4157,Infarction of spleen,QOF
+G74y6,Embolism and thrombosis of the splenic artery,CTV3Map_Code_And_Term
+PK01.,(Absent spleen) or (asplenia),High_Level_SNOMED
+PK06.,Hypoplasia of spleen,CTV3Map_Code_And_Term
+PK06.,Hypoplasia of spleen,QOF
+Ua1JD,Subtotal splenectomy,CTV3_Children
+X205i,Splenic vein thrombosis,QOF
+X20BK,Splenectomy,QOF
+X20Fp,Post-splenectomy leucocytosis,QOF
+XA07k,Avulsion of spleen,QOF
+XE1Mi,Congenital absence of spleen,CTV3Map_Code_And_Term
+XE1Mi,Congenital absence of spleen,CTV3Map_Code_Only
+XE1Mi,Congenital absence of spleen,QOF
+XM1OF,Congenital syphilitic splenomegaly,CTV3Map_Code_And_Term
+Xa0hO,Hyposplenism,CTV3Map_Code_And_Term
+Xa0hO,Hyposplenism,QOF
+Xa7Ya,Spleen absent,CTV3Map_Code_And_Term
+Xa7Ya,Spleen absent,CTV3Map_Code_Only
+Xa7Ya,Spleen absent,QOF
+Xa9D7,Hereditary splenic hypoplasia,QOF
+XaEXw,Laparoscopic total splenectomy,CTV3Map_Code_And_Term
+XaEXw,Laparoscopic total splenectomy,QOF
+XaZvR,Acquired absence of spleen,CTV3_Children
+XaZvR,Acquired absence of spleen,QOF

--- a/tests/acceptance/external_studies/openprompt-long-covid-economics/codelists/opensafely-permanent-immunosuppression.csv
+++ b/tests/acceptance/external_studies/openprompt-long-covid-economics/codelists/opensafely-permanent-immunosuppression.csv
@@ -1,0 +1,192 @@
+CTV3ID,CTV3PreferredTermDesc
+C390y,Other specified deficiency of humoral immunity
+C390z,Deficiency of humoral immunity NOS
+C391.,Deficiencies of cell-mediated immunity
+C391z,Deficiency of cell-mediated immunity NOS
+C393.,Unspecified immunity deficiency
+Cyu00,[X]Other immunodeficiencies+predominantly antibody defects
+Cyu05,[X]Other specified immunodeficiency disorders
+D401z,Polymorphonuclear neutrophil disorder NOS
+X20GZ,Immunodeficiency disorder
+X20HE,T-lymphocyte deficiency
+XaYgn,Immune reconstitution syndrome
+XE11u,Deficiencies of humoral immunity
+XE11w,Predominantly T-cell immuno-deficiency NOS
+C30yy,(Adenosine deamin def) or (oth sp disturb amino acid metab)
+C3760,C1 esterase inhibitor deficiency
+C390.,(Deficiencies of humoral immunity) or (agammaglobulinaemia)
+C3901,Selective immunoglobulin A deficiency
+C3902,Selective immunoglobulin M deficiency
+C3903,Selective immunoglobulin G deficiency
+C3904,Other selective immunoglobulin deficiency
+C3905,Hypogammaglob:[cong][agammaglob:(Brut)(cong sex-link & [X])]
+C3906,Hyperimmunoglobulin M syndrome
+C3907,Common variable immunodeficiency
+C3909,Agammaglobulinaemia NEC
+C390A,Dysimmunoglobulinaemia NEC
+C3910,Cellular immunity syndr (& T-lymphocyte deficiency [& NOS])
+C3911,DiGeorge syndrome
+C3912,Wiskott-Aldrich syndrome
+C3913,Nezelof's syndrome
+C392.,Combined T-cell and B-cell immunodeficiency
+C3920,Autosomal recessive severe combined immunodeficiency
+C3921,(Severe combined immunodefic) or (Swiss agammaglobulinaemia)
+C3922,Thymic aplasia or dysplasia with immunodeficiency
+C3923,Severe combined immunodefiency with reticular dysgenesis
+C3924,Severe combined immunodef with low T- and B-cell numbers
+C3925,Severe combined immunodef with low or normal B-cell numbers
+C3928,Major histocompatibility complex class I deficiency
+C3929,Major histocompatibility complex class II deficiency
+C392z,Combined immunity deficiency NOS
+C396.,Immunodef follow hereditary defect respon Epstein-Barr vir
+C3980,Com var immunodef with predom abn B-cell numbers and functns
+C3981,Common var immunodef predom immunoregulatory T-cell disorder
+C3982,Common variable immunodef wth autoantibod to B- or T-cells
+C39y0,Lymphocyte function antigen-1 defect
+Cyu01,[X]Other combined immunodeficiency disorders
+Cyu02,[X]Immunodeficiency associatd+other specified major defects
+Cyu03,"[X]Immunodeficiency associated+major defect, unspecified"
+Cyu04,[X]Other common variable immunodeficiencies
+D2016,Pancytopenia: [with malformation]/[with pancreatitis]/[NOS]
+D4001,Primary splenic neutropenia
+D4005,Congenital: [neutropenia] or [agranulocytosis NEC]
+D4009,Cyclical neutropenia
+D401.,(Funct dis polymorph neutroph)(Job's)(fam lipochr histiocyt)
+D4010,Congenital dysphagocytosis
+D402.,(Anomaly: [genet leucocyt][epon vars]) or (Ched-Higash synd)
+F14y0,Ataxia telangiectasia
+M15y3,Complement 5 dysfunction
+X20CO,Pancytopenia with pancreatitis
+X20Da,Congenital agranulocytosis NEC
+X20Db,X-linked hypogammaglobulinaemia
+X20De,Chronic idiopathic neutropenia
+X20Df,Severe congenital neutropenia
+X20Dk,Myelokathexis
+X20Dl,Metabolic neutropenia
+X20Dn,Autoimmune neutropenia
+X20Dv,Chediak-Higashi syndrome
+X20Dw,Hyperimmunoglobulin E syndrome
+X20Dx,CR3-receptor deficiency
+X20Dy,Specific granule deficiency
+X20E0,Chronic granulomatous disease
+X20E1,Myeloperoxidase deficiency
+X20E4,Hereditary hypersegmentation
+X20Ga,Primary immunodeficiency
+X20Gb,Agammaglobulinaemia
+X20Gc,X-linked agammaglobulinaemia
+X20Gd,X-linked agammaglobulinaemia with growth hormone deficiency
+X20Ge,Autosomal agammaglobulinaemia with absent B-cells
+X20Gf,Selective immunoglobulin dysfunction
+X20Gg,X-linked hyperimmunoglobulin M syndrome
+X20Gh,Autosomal recessive hyperimmunoglobulin M syndrome
+X20Gj,Hyperimmunoglobulin D with periodic fever
+X20Gk,Immunoglobulin heavy chain deficiency
+X20Gn,Selective immunoglobulin M and immunoglobulin A deficiency
+X20Go,Immunoglobulin light chain deficiency
+X20Gp,Kappa light chain deficiency
+X20Gq,Lambda light chain deficiency
+X20Gr,Immunoglobulin subclass deficiency
+X20Gt,Immunoglobulin G2 deficiency
+X20Gu,Combined immunoglobulin G2 and G4 deficiency
+X20Gv,Immunoglobulin G3 deficiency
+X20Gw,Immunoglobulin G4 deficiency
+X20Gx,Immunoglobulin G1 deficiency
+X20Gy,Immunoglobulin A1 deficiency
+X20Gz,Immunoglobulin A2 deficiency
+X20H0,Immunoglobulin-associated molecule deficiency
+X20H1,Secretory piece deficiency
+X20H2,Defective immunoglobulin glycosylation
+X20Ha,Schwachman's syndrome
+X20Hb,Defective phagocytic cell adhesion
+X20Hc,Leucocyte adhesion deficiency - type 1
+X20Hd,Leucocyte adhesion deficiency - type 2
+X20Hf,Tuftsin deficiency
+X20HF,Chronic mucocutaneous candidiasis
+X20Hg,Defective phagocytic cell killing
+X20HH,Combined immunodeficiency with maturation pathway defect
+X20HI,Reticular dysgenesis
+X20Hi,Leucocyte glucose-6-phosphate dehydrogenase deficiency
+X20HJ,X-linked severe combined immunodeficiency
+X20HK,Severe combined immunodeficiency with short-limbed dwarfism
+X20Hk,Neutrophil lactoferrin deficiency
+X20HL,Bare lymphocyte syndrome
+X20Hl,Neutrophil secondary granule deficiency
+X20HM,Familial erythrophagocytic lymphohistiocytosis
+X20Hm,Gluthathione synthetase deficiency
+X20HN,Severe comb immunodeficiency with maternofetal engraftment
+X20Hn,Gluthathione peroxidase deficiency
+X20HO,"Warts, hypogammaglobulinaemia, infections, and myelokathexis"
+X20Hp,Combined phagocytic defect
+X20Ht,Classical complement pathway abnormality
+X20HU,Chronic familial neutropaenia
+X20Hu,Complement 1q deficiency
+X20HV,Lipochrome histiocytosis - familial
+X20Hv,Complement 1q beta chain deficiency
+X20HW,Defective phagocytic cell opsonisation
+X20Hw,Complement 1q dysfunction
+X20HX,Mannan-binding protein deficiency
+X20Hx,Complement 1r deficiency
+X20HY,Defective phagocytic cell chemotaxis
+X20Hy,Complement 1s deficiency
+X20HZ,Lazy leucocyte syndrome
+X20Hz,Complement 2 deficiency
+X20I0,Complement 4 deficiency
+X20I1,Complement 4A deficiency
+X20I2,Complement 4B deficiency
+X20I3,Complement 3 deficiency
+X20I4,Alternative pathway deficiency
+X20I5,Properdin deficiency
+X20I6,Factor B deficiency
+X20I7,Factor D deficiency
+X20I8,Terminal component deficiency
+X20I9,Complement 5 deficiency
+X20Ia,Chromosome 18 syndromes and antibody deficiency
+X20IB,Complement 6 deficiency
+X20Ib,Chromosome 22 abnormalities with hypogammaglobulinaemia
+X20IC,Complement 7 deficiency
+X20Ic,Monosomy 22 and absence of immunoglobulin A
+X20ID,Combined complement 6 and 7 deficiencies
+X20Id,Deletion of X-chromosome and hypogammaglobulinaemia
+X20IE,Complement 8 beta chain deficiency
+X20Ie,"Microcephaly, normal intelligence and immunodeficiency"
+X20IF,Complement 8 beta chain dysfunction
+X20If,"Triple X syndrome, epilepsy, and hypogammaglobulinaemia"
+X20IG,Complement 8 alpha-gamma deficiency
+X20Ig,18-p syndrome with associated immunodeficiency
+X20IH,Complement 9 deficiency
+X20Ih,Immunodeficiency with multiple organ system abnormalities
+X20II,Complement regulatory factor defect
+X20IJ,Hereditary C1 esterase inhibitor defic - deficient factor
+X20Ij,Partial albinism with immunodeficiency
+X20IK,Hereditary C1 esterase inhib defic - dysfunctional factor
+X20Ik,X-linked lymphoproliferative syndrome
+X20IL,Factor I deficiency
+X20IM,Factor H deficiency
+X20IN,Complement 4 binding protein deficiency
+X20IO,Decay accelerating factor deficiency
+X20IP,Homologous restriction factor deficiency
+X20IQ,Complement 5a inhibitor deficiency
+X20IR,Anaphylotoxin inactivator deficiency
+X20IS,Complement receptor deficiency
+X20IT,Complement receptor 1 deficiency
+X20IU,Complement receptor 3 deficiency
+X20IV,Immunodeficiency with major anomalies
+X20IW,Immunodeficiency associated with chromosomal abnormality
+X20IY,Bloom syndrome
+X20IZ,"Centromeric instability of chromosomes 1,9+16 + immunodefic"
+X20RX,Familial chronic mucocutaneous candidiasis
+X40Ua,Adenosine deaminase deficiency
+X40Uc,Purine nucleoside phosphorylase deficiency
+X70Qz,Familial chronic mucocutaneous candidiasis - late onset type
+X70R0,Chronic localised mucocutaneous candidiasis
+X70R1,Chronic diffuse mucocutaneous candidiasis
+X789w,Immuno-osseous dysplasia
+Xa9Az,Phagocytic cell dysfunction
+XaA0r,"Metaphys chondrodysplas, McKusick type with assoc immunodef"
+XE11v,Congenital hypogammaglobulinaemia
+XE13a,Agammaglobulinaemia &/or hypo-gammaglobulinaemia
+XE14B,Chronic idiopathic neutropaenia
+XE14F,Congenital neutropenia
+XE14H,Functional disorders of polymorphonuclear neutrophils
+8C31.,Transplant immunosuppression
+PK281,Congenital absence of thymus

--- a/tests/acceptance/external_studies/openprompt-long-covid-economics/codelists/opensafely-temporary-immunosuppression.csv
+++ b/tests/acceptance/external_studies/openprompt-long-covid-economics/codelists/opensafely-temporary-immunosuppression.csv
@@ -1,0 +1,41 @@
+CTV3ID,CTV3PreferredTermDesc
+42H4.,Agranulocytosis
+D2015,Pancytopenia - acquired
+D400.,(Agranulocytosis) or (Kostmann's syndrome) or (neutropenia)
+D4000,Idiopathic: [agranulocytosis] or [neutropenia]
+D4002,Drug induced: [agranulocytosis] or [neutropenia]
+D4003,Radiation: [agranulocytosis] or [neutropenia]
+D4004,Infection: [agranulocytosis] or [neutropenia]
+D4006,Drug-associated neutropenia
+D4008,Acquired: [neutropenia NEC] or [agranulocytosis NEC]
+D400y,Other specified agranulocytosis
+D400z,Agranulocytosis NOS
+F1001,Schultz disease
+Ua14c,Patient immunocompromised
+Ua19z,Patient immunosuppressed
+X20CN,Pancytopenia
+X20Dp,Corticosteroid-induced neutrophilia
+X20HQ,Phagocytic cell defect
+X20HR,Disorder of phagocytic cell number
+X20Hs,Complement deficiency
+X20Il,Secondary immunodeficiency
+X20Ip,Drug-induced immunodeficiency
+Xa09u,Chloramphenicol-induced neutropenia
+Xa97S,Immunosuppressive therapy
+Xa9E8,Neutropenic disorder
+XaXUJ,Immunosuppressant drug therapy
+XE13v,Pancytopenia NOS
+XE14A,Agranulocytopenic disorder
+XE14C,Drug-associated neutropenia
+XE14D,Neutropenia due to irradiation
+XE14E,Infective neutropenia
+XE14G,Acquired neutropenia NEC
+XM0BV,Predominantly B-cell defect
+XM0BW,Predominantly T-cell defect
+XM1WJ,Preventing infection of immunocompromised patient
+XM1WL,Reverse barrier nursing
+X20HB,Primary immunoglobulin catabolism abnormality
+X20HC,Immunoglobulin hypercatabolism
+X20HD,Familial immunoglobulin hypercatabolism
+X20HP,Benign combined immunodeficiency
+BBmC.,[M] T-gamma lymphoproliferative disease

--- a/tests/acceptance/external_studies/openprompt-long-covid-economics/codelists/primis-covid19-vacc-uptake-covadm1.csv
+++ b/tests/acceptance/external_studies/openprompt-long-covid-economics/codelists/primis-covid19-vacc-uptake-covadm1.csv
@@ -1,0 +1,3 @@
+code,term
+1324681000000101,Administration of first dose of severe acute respiratory syndrome coronavirus 2 vaccine
+840534001,Administration of vaccine product containing only Severe acute respiratory syndrome coronavirus 2 antigen

--- a/tests/acceptance/external_studies/openprompt-long-covid-economics/codelists/primis-covid19-vacc-uptake-covadm2.csv
+++ b/tests/acceptance/external_studies/openprompt-long-covid-economics/codelists/primis-covid19-vacc-uptake-covadm2.csv
@@ -1,0 +1,3 @@
+code,term
+1324691000000104,Administration of second dose of severe acute respiratory syndrome coronavirus 2 vaccine
+840534001,Administration of vaccine product containing only Severe acute respiratory syndrome coronavirus 2 antigen

--- a/tests/acceptance/external_studies/openprompt-long-covid-economics/codelists/primis-covid19-vacc-uptake-covadm3_cod.csv
+++ b/tests/acceptance/external_studies/openprompt-long-covid-economics/codelists/primis-covid19-vacc-uptake-covadm3_cod.csv
@@ -1,0 +1,3 @@
+code,term
+1363861000000103,Administration of third dose of severe acute respiratory syndrome coronavirus 2 vaccine
+840534001,Administration of vaccine product containing only Severe acute respiratory syndrome coronavirus 2 antigen

--- a/tests/acceptance/external_studies/openprompt-long-covid-economics/codelists/primis-covid19-vacc-uptake-covadm4_cod.csv
+++ b/tests/acceptance/external_studies/openprompt-long-covid-economics/codelists/primis-covid19-vacc-uptake-covadm4_cod.csv
@@ -1,0 +1,3 @@
+code,term
+1363791000000101,Administration of fourth dose of severe acute respiratory syndrome coronavirus 2 vaccine
+840534001,Administration of vaccine product containing only Severe acute respiratory syndrome coronavirus 2 antigen

--- a/tests/acceptance/external_studies/openprompt-long-covid-economics/codelists/primis-covid19-vacc-uptake-covadm5_cod.csv
+++ b/tests/acceptance/external_studies/openprompt-long-covid-economics/codelists/primis-covid19-vacc-uptake-covadm5_cod.csv
@@ -1,0 +1,3 @@
+code,term
+1363831000000108,Administration of fifth dose of severe acute respiratory syndrome coronavirus 2 vaccine
+840534001,Administration of vaccine product containing only Severe acute respiratory syndrome coronavirus 2 antigen

--- a/tests/acceptance/external_studies/test-age-distribution/analysis/dataset_definition.py
+++ b/tests/acceptance/external_studies/test-age-distribution/analysis/dataset_definition.py
@@ -9,5 +9,5 @@ year_of_birth = patients.date_of_birth.year
 age = index_year - year_of_birth
 
 dataset = Dataset()
-dataset.set_population((age >= min_age) & (age <= max_age))
+dataset.define_population((age >= min_age) & (age <= max_age))
 dataset.age = age

--- a/tests/acceptance/test_external_studies.py
+++ b/tests/acceptance/test_external_studies.py
@@ -100,13 +100,18 @@ EXTERNAL_STUDIES = {
         file_globs=[
             "analysis/dataset_definition_*.py",
             "analysis/codelists.py",
+            "analysis/outcomes_health_use.py",
             "analysis/variables.py",
             "codelists/*.csv",
         ],
+        dummy_files=[
+            "output/dataset_lc_gp_list.csv",
+        ],
         dataset_definitions=[
             "analysis/dataset_definition_lc_gp_list.py",
-            "analysis/dataset_definition_exp_lc.py",
+            "analysis/dataset_definition_unmatched_exp_lc.py",
             "analysis/dataset_definition_comparator_large.py",
+            "analysis/dataset_definition_unmatched_comparator.py",
         ],
     ),
 }

--- a/tests/acceptance/update_external_studies.py
+++ b/tests/acceptance/update_external_studies.py
@@ -5,6 +5,7 @@ supports but which isn't actually executed by the test suite — hence the "no c
 import shutil  # pragma: no cover
 import tarfile  # pragma: no cover
 from fnmatch import fnmatch  # pragma: no cover
+from pathlib import Path  # pragma: no cover
 from urllib.request import urlopen  # pragma: no cover
 
 from .test_external_studies import EXTERNAL_STUDIES, STUDY_DIR  # pragma: no cover
@@ -17,6 +18,7 @@ def update_external_studies():  # pragma: no cover
         target_dir = STUDY_DIR / name
         tarball_url = f"https://github.com/{config['repo']}/tarball/{config['branch']}"
         download_files(target_dir, tarball_url, config["file_globs"])
+        create_dummy_files(target_dir, config.get("dummy_files", []))
 
 
 def download_files(target_dir, tarball_url, file_globs):  # pragma: no cover
@@ -35,6 +37,17 @@ def get_files_from_remote_tarball(url):  # pragma: no cover
             while tar_info := tarobj.next():
                 if tar_info.isfile():
                     yield tar_info.name, lambda: tarobj.extractfile(tar_info).read()
+
+
+def create_dummy_files(target_dir, dummy_files):  # pragma: no cover
+    """
+    Ensure any necessary filepaths exist (e.g. output files that are referenced in a
+    dataset definition
+    """
+    for dummy_file in dummy_files:
+        dummy_filepath = Path(target_dir) / dummy_file
+        dummy_filepath.parent.mkdir(exist_ok=True, parents=True)
+        dummy_filepath.touch(exist_ok=True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Remove the take, drop and set_population aliases now that all external studies have been updated.

Also required the external studies to be updated, and some changes to the update_external_studies script to accommodate them.