### PR TITLE
Fix comprehensive gentests coverage check

### DIFF
--- a/databuilder/query_model/nodes.py
+++ b/databuilder/query_model/nodes.py
@@ -19,6 +19,7 @@ __all__ = [
     "Value",
     "SelectTable",
     "SelectPatientTable",
+    "InlinePatientTable",
     "SelectColumn",
     "Filter",
     "Sort",

--- a/tests/generative/variable_strategies.py
+++ b/tests/generative/variable_strategies.py
@@ -9,6 +9,7 @@ from databuilder.query_model.nodes import (
     Case,
     Filter,
     Function,
+    InlinePatientTable,
     PickOneRowPerPatient,
     Position,
     SelectColumn,
@@ -468,6 +469,7 @@ def variable(patient_tables, event_tables, schema, value_strategies):
 
 known_missing_operations = {
     AggregateByPatient.CombineAsSet,
+    InlinePatientTable,
 }
 
 

--- a/tests/lib/query_model_utils.py
+++ b/tests/lib/query_model_utils.py
@@ -25,7 +25,7 @@ def is_operation(cls):  # pragma: no cover
 
 
 def iterate_query_model_namespace():  # pragma: no cover
-    "Yield every public thing in the query_model module"
-    yield from [getattr(query_model, name) for name in query_model.__all__]
+    "Yield every value in the query_model module"
+    yield from vars(query_model).values()
     yield from vars(query_model.Function).values()
     yield from vars(query_model.AggregateByPatient).values()


### PR DESCRIPTION
Previously, we only picked up operations added to the module's `__all__` list. As an example, we forgot to add the new `InlinePatientTable` node to this list and as a result we didn't realise it wasn't covered by the generative tests.