### PR TITLE
Use local just commands in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
 
     - id: check-docs
       name: check-docs
-      entry: just generate-docs
+      entry: just precommit-generate-docs
       language: system
       types: [python]
       always_run: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,29 +4,22 @@ default_language_version:
 exclude: tests/acceptance/external_studies/
 
 repos:
-  - repo: https://github.com/psf/black
-    rev: 23.1.0
+  - repo: local
     hooks:
-    - id: black
+    - id: check
+      name: check
+      entry: just check
+      language: system
+      types: [python]
+      require_serial: true
 
-  - repo: https://github.com/PyCQA/flake8
-    rev: 6.0.0
-    hooks:
-    - id: flake8
-      additional_dependencies:
-        - "flake8-builtins"
-        - "flake8-implicit-str-concat"
-        - "flake8-no-pep420"
-
-  - repo: https://github.com/PyCQA/isort
-    rev: 5.12.0
-    hooks:
-    - id: isort
-
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v3.3.0
-    hooks:
-    -   id: pyupgrade
+    - id: check-docs
+      name: check-docs
+      entry: just generate-docs
+      language: system
+      types: [python]
+      always_run: true
+      require_serial: true
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.3.0
@@ -41,12 +34,3 @@ repos:
       # --unsafe is a workaround for the use of !! in mkdocs.yml.
       args: [--unsafe]
     - id: detect-private-key
-
-  - repo: local
-    hooks:
-    - id: check-docs
-      name: check-docs
-      entry: scripts/check-docs.sh
-      language: script
-      types: [python]
-      always_run: true

--- a/Justfile
+++ b/Justfile
@@ -198,9 +198,11 @@ test-generative *ARGS: devenv
     $BIN/python -m pytest --doctest-modules databuilder
     [[ -v CI ]]  && echo "::endgroup::" || echo ""
 
-generate-docs *args="docs/includes/generated_docs": devenv
-    $BIN/python -m databuilder.docs {{ args }}
-    echo "Generated data for documentation in {{ args }}"
+generate-docs OUTPUT_DIR="docs/includes/generated_docs": devenv
+    $BIN/python -m databuilder.docs {{ OUTPUT_DIR }}
+    echo "Generated data for documentation in {{ OUTPUT_DIR }}"
+
+precommit-generate-docs *args: generate-docs
 
 update-external-studies: devenv
     $BIN/python -m tests.acceptance.update_external_studies

--- a/Justfile
+++ b/Justfile
@@ -92,7 +92,7 @@ upgrade env package="": _virtualenv
 
 
 # runs the format (black), sort (isort) and lint (flake8) checks but does not change any files
-check: devenv
+check *args: devenv
     $BIN/black --check .
     $BIN/isort --check-only --diff .
     $BIN/flake8
@@ -198,9 +198,9 @@ test-generative *ARGS: devenv
     $BIN/python -m pytest --doctest-modules databuilder
     [[ -v CI ]]  && echo "::endgroup::" || echo ""
 
-generate-docs OUTPUT_DIR="docs/includes/generated_docs": devenv
-    $BIN/python -m databuilder.docs {{ OUTPUT_DIR }}
-    echo "Generated data for documentation in {{ OUTPUT_DIR }}"
+generate-docs *args="docs/includes/generated_docs": devenv
+    $BIN/python -m databuilder.docs {{ args }}
+    echo "Generated data for documentation in {{ args }}"
 
 update-external-studies: devenv
     $BIN/python -m tests.acceptance.update_external_studies

--- a/databuilder/query_language.py
+++ b/databuilder/query_language.py
@@ -4,7 +4,6 @@ import enum
 import functools
 from collections import ChainMap
 from pathlib import Path
-from typing import Union
 
 from databuilder.codes import BaseCode
 from databuilder.file_formats import read_dataset, validate_dataset
@@ -428,8 +427,8 @@ class DatePatientSeries(DateFunctions, PatientSeries):
 
 @dataclasses.dataclass
 class DateDifference:
-    lhs: Union[datetime.date, DateEventSeries, DatePatientSeries]
-    rhs: Union[datetime.date, DateEventSeries, DatePatientSeries]
+    lhs: datetime.date | DateEventSeries | DatePatientSeries
+    rhs: datetime.date | DateEventSeries | DatePatientSeries
 
     @property
     def days(self):
@@ -452,7 +451,7 @@ class DateDifference:
 class Duration:
     Units = enum.Enum("Units", ["DAYS", "MONTHS", "YEARS"])
 
-    value: Union[int, IntEventSeries, IntPatientSeries]
+    value: int | IntEventSeries | IntPatientSeries
     units: Units
 
     def __add__(self, other):

--- a/databuilder/query_model/column_specs.py
+++ b/databuilder/query_model/column_specs.py
@@ -1,6 +1,6 @@
 import dataclasses
 from functools import singledispatch
-from typing import Optional, TypeVar
+from typing import TypeVar
 
 from databuilder.query_model.nodes import (
     AggregateByPatient,
@@ -18,9 +18,9 @@ T = TypeVar("T")
 class ColumnSpec:
     type: type[T]  # noqa: A003
     nullable: bool = True
-    categories: Optional[tuple[T]] = None
-    min_value: Optional[T] = None
-    max_value: Optional[T] = None
+    categories: tuple[T] | None = None
+    min_value: T | None = None
+    max_value: T | None = None
 
 
 def get_column_specs(variable_definitions):

--- a/databuilder/query_model/nodes.py
+++ b/databuilder/query_model/nodes.py
@@ -5,7 +5,7 @@ from datetime import date
 from enum import Enum
 from functools import cache, singledispatch
 from types import GenericAlias
-from typing import Any, Optional, TypeVar
+from typing import Any, TypeVar
 
 from databuilder.codes import BaseCode
 from databuilder.query_model.table_schema import Column, Constraint, TableSchema
@@ -386,7 +386,7 @@ class Function:
 
 class Case(Series[T]):
     cases: Mapping[Series[bool], Series[T]]
-    default: Optional[Series[T]] = None
+    default: Series[T] | None = None
 
     def __hash__(self):
         # `cases` is a dict and so not naturally hashable, but we treat it as immutable.

--- a/databuilder/utils/typing_utils.py
+++ b/databuilder/utils/typing_utils.py
@@ -88,7 +88,7 @@ def type_matches(spec, target_spec, typevar_context):
             # operations very much harder since it allows operations like True + True => 2.
             return False
         return spec is not None and issubclass(spec, target_spec)
-    elif target_spec_origin is typing.Union:
+    elif target_spec_origin is typing.types.UnionType:
         # For union types we just need to match one of the arguments
         return any(
             type_matches(spec, arg, typevar_context)

--- a/scripts/check-docs.sh
+++ b/scripts/check-docs.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-
-# This script is run as a pre-commit hook to ensure generated docs files are
-# up to date
-
-just generate-docs

--- a/tests/unit/utils/test_typing_utils.py
+++ b/tests/unit/utils/test_typing_utils.py
@@ -1,4 +1,4 @@
-from typing import Any, TypeVar, Union
+from typing import Any, TypeVar
 
 import pytest
 
@@ -39,7 +39,7 @@ def test_get_typespec_errors_on_unhandled_container_type():
 
 
 def test_type_matches():
-    assert type_matches(list[str], list[Union[int, str]], {})
+    assert type_matches(list[str], list[int | str], {})
     assert type_matches(dict[str, FileNotFoundError], dict[Any, OSError], {})
 
 
@@ -85,7 +85,7 @@ def test_type_matches_rejects_mismatch():
     assert not type_matches(list[str], list[int], {})
     assert not type_matches(tuple[int], list[int], {})
     assert not type_matches(list[str], list[Numeric], {})
-    assert not type_matches(list[float], list[Union[int, str]], {})
+    assert not type_matches(list[float], list[int | str], {})
     assert not type_matches(list, list[int], {})
     assert not type_matches(bool, Numeric, {})
 


### PR DESCRIPTION
Update pre-commit to use local just commands.
As a result, pyupgrade insisted on changing `Union` and `Optional` types to `|` (because of the upgrade to python 3.11, and [PEP 604](https://peps.python.org/pep-0604/); not sure why it didn't do this before), and the custom type checking needed to change to check for `typing.types.UnionType` instead of `typing.Union`.