### PR TITLE
Fix IGNORED_ERROR handling in generative tests

### DIFF
--- a/tests/generative/test_query_model.py
+++ b/tests/generative/test_query_model.py
@@ -236,8 +236,9 @@ IGNORED_ERRORS = [
         re.compile(".+Adding a value to a 'date' column caused an overflow.+"),
     ),  # DateAddMonths, resulting in an invalid date
     # sqlite
-    # Note the leading `-` below: ISO format doesn't handle BC dates
-    (ValueError, re.compile(r"Invalid isoformat string: '-\d\d\d\d-\d\d-\d\d'")),
+    # Note the leading `-` below: ISO format doesn't handle BC dates, and BC dates don't
+    # always have four year digits
+    (ValueError, re.compile(r"Invalid isoformat string: '-\d+-\d\d-\d\d'")),
     # in-memory engine
     (
         ValueError,


### PR DESCRIPTION
This fixes two issues:
 * an overly prescriptive error regex which caused us not to ignore some errors which we wanted to ignore;
 * a failure to clean up nicely after an error which caused subsequent queries to fail and confused the merry hell out of Hypothesis (see [commment](https://github.com/opensafely-core/databuilder/issues/1180#issuecomment-1496152092) for more of the detail).

Closes #1180 