### PR TITLE
Fix column type for `practice_registrations`

### DIFF
--- a/databuilder/backends/tpp.py
+++ b/databuilder/backends/tpp.py
@@ -50,8 +50,8 @@ class TPPBackend(BaseBackend):
         """
             SELECT
                 reg.Patient_ID AS patient_id,
-                reg.StartDate AS start_date,
-                reg.EndDate AS end_date,
+                CAST(reg.StartDate AS date) AS start_date,
+                CAST(reg.EndDate AS date) AS end_date,
                 org.Organisation_ID AS practice_pseudo_id,
                 org.STPCode AS practice_stp,
                 org.Region AS practice_nuts1_region_name

--- a/tests/integration/backends/test_tpp.py
+++ b/tests/integration/backends/test_tpp.py
@@ -61,7 +61,13 @@ def select_all(request, mssql_database):
 
     qm_table = ql_table.qm_node
     sql_table = TPPBackend().get_table_expression(qm_table.name, qm_table.schema)
-    columns = [column.label(column.key) for column in sql_table.columns]
+    columns = [
+        # Using `type_coerce(..., None)` like this strips the type information from the
+        # SQLAlchemy column meaning we get back the type that the column actually is in
+        # database, not the type we've told SQLAlchemy it is.
+        sqlalchemy.type_coerce(column, None).label(column.key)
+        for column in sql_table.columns
+    ]
     select_all_query = sqlalchemy.select(*columns)
 
     def _select_all(*input_data):

--- a/tests/lib/tpp_schema.py
+++ b/tests/lib/tpp_schema.py
@@ -288,8 +288,8 @@ class RegistrationHistory(Base):
     Patient = relationship(
         "Patient", back_populates="RegistrationHistory", cascade="all, delete"
     )
-    StartDate = Column(Date)
-    EndDate = Column(Date)
+    StartDate = Column(DateTime)
+    EndDate = Column(DateTime)
 
 
 class Organisation(Base):


### PR DESCRIPTION
I discovered that the tests still passed when I changed the column type to `sqlalchemy.DateTime` in `tests/lib/tpp_schema.py`. This lead me to the first commit here which makes the test use the actual database type, rather than the type we've supplied to SQLAlchemy.

Addressing the issue of test/prod schema mismatch more systematically is covered in:
 * https://github.com/opensafely-core/databuilder/issues/1104

Closes #1183