### PR TITLE
Jongmassey/table_from_file_docs

### DIFF
--- a/databuilder/docs/specs.py
+++ b/databuilder/docs/specs.py
@@ -94,10 +94,12 @@ def build_paragraph(paragraph_id, test_fn):
     source_lines = inspect.getsource(test_fn).splitlines()
 
     # Find the line the source where spec_test is called.
-    ix = source_lines.index("    spec_test(")
+    for ix, l in enumerate(source_lines):
+        if re.match(r"\s+spec_test\(", l):
+            break
 
     # Check that the next line is as expected.
-    assert source_lines[ix + 1] == "        table_data,"
+    assert re.match(r"\s+table_data", source_lines[ix + 1])
 
     series = get_series_code(source_lines, ix + 2, capturer.define_population)
 

--- a/databuilder/docs/specs.py
+++ b/databuilder/docs/specs.py
@@ -94,9 +94,10 @@ def build_paragraph(paragraph_id, test_fn):
     source_lines = inspect.getsource(test_fn).splitlines()
 
     # Find the line the source where spec_test is called.
-    for ix, l in enumerate(source_lines):
+    ix = 0
+    for i, l in enumerate(source_lines):
         if re.match(r"\s+spec_test\(", l):
-            break
+            ix = i
 
     # Check that the next line is as expected.
     assert re.match(r"\s+table_data", source_lines[ix + 1])

--- a/docs/includes/generated_docs/specs.md
+++ b/docs/includes/generated_docs/specs.md
@@ -2689,13 +2689,88 @@ returns the following patient series:
 
 
 
-## 14 Defining a table using inline data
+## 14 Defining a table from a file
 
 
-### 14.1 Defining a table using inline data
+### 14.1 Defining a table from a file
 
 
-#### 14.1.1 Table from rows
+#### 14.1.1 Table from csv file
+
+This example makes use of a patient-level table named `p` containing the following data:
+
+| patient|i1 |
+| - | - |
+| 1|10 |
+| 2|20 |
+| 3|30 |
+
+```
+p.i1 + t.n
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|110 |
+| 2| |
+| 3|330 |
+
+
+
+#### 14.1.2 Table from csv gz file
+
+This example makes use of a patient-level table named `p` containing the following data:
+
+| patient|i1 |
+| - | - |
+| 1|10 |
+| 2|20 |
+| 3|30 |
+
+```
+p.i1 + t.n
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|110 |
+| 2| |
+| 3|330 |
+
+
+
+#### 14.1.3 Table from arrow file
+
+This example makes use of a patient-level table named `p` containing the following data:
+
+| patient|i1 |
+| - | - |
+| 1|10 |
+| 2|20 |
+| 3|30 |
+
+```
+p.i1 + t.n
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|110 |
+| 2| |
+| 3|330 |
+
+
+
+## 15 Defining a table using inline data
+
+
+### 15.1 Defining a table using inline data
+
+
+#### 15.1.1 Table from rows
 
 This example makes use of a patient-level table named `p` containing the following data:
 

--- a/tests/spec/table_from_file/test_table_from_file.py
+++ b/tests/spec/table_from_file/test_table_from_file.py
@@ -1,5 +1,7 @@
 import csv
 import gzip
+from pathlib import Path
+from tempfile import TemporaryDirectory
 
 import pyarrow
 from pyarrow.feather import write_feather
@@ -27,67 +29,73 @@ file_data = [
 ]
 
 
-def test_table_from_file_csv(spec_test, tmp_path):
-    path = tmp_path / "test_table_from_file.csv"
-    with path.open("w") as f:
-        writer = csv.writer(f)
-        writer.writerow(["patient_id", "n"])
-        writer.writerows(file_data)
+def test_table_from_csv_file(spec_test):
+    with TemporaryDirectory() as td:
+        tmp_path = Path(td)
+        path = tmp_path / "test_table_from_file.csv"
+        with path.open("w") as f:
+            writer = csv.writer(f)
+            writer.writerow(["patient_id", "n"])
+            writer.writerows(file_data)
 
-    @table_from_file(path)
-    class t(PatientFrame):
-        n = Series(int)
+        @table_from_file(path)
+        class t(PatientFrame):
+            n = Series(int)
 
-    spec_test(
-        table_data,
-        p.i1 + t.n,
-        {
-            1: 10 + 100,
-            2: None,
-            3: 30 + 300,
-        },
-    )
-
-
-def test_table_from_file_csv_gz(spec_test, tmp_path):
-    path = tmp_path / "test_table_from_file.csv.gz"
-    with gzip.open(path, "wt", newline="", compresslevel=6) as f:
-        writer = csv.writer(f)
-        writer.writerow(["patient_id", "n"])
-        writer.writerows(file_data)
-
-    @table_from_file(path)
-    class t(PatientFrame):
-        n = Series(int)
-
-    spec_test(
-        table_data,
-        p.i1 + t.n,
-        {
-            1: 10 + 100,
-            2: None,
-            3: 30 + 300,
-        },
-    )
+        spec_test(
+            table_data,
+            p.i1 + t.n,
+            {
+                1: 10 + 100,
+                2: None,
+                3: 30 + 300,
+            },
+        )
 
 
-def test_table_from_file_feather(spec_test, tmp_path):
-    path = tmp_path / "test_table_from_file.arrow"
+def test_table_from_csv_gz_file(spec_test):
+    with TemporaryDirectory() as td:
+        tmp_path = Path(td)
+        path = tmp_path / "test_table_from_file.csv.gz"
+        with gzip.open(path, "wt", newline="", compresslevel=6) as f:
+            writer = csv.writer(f)
+            writer.writerow(["patient_id", "n"])
+            writer.writerows(file_data)
 
-    columns = ["patient_id", "n"]
-    table = pyarrow.Table.from_pylist([dict(zip(columns, f)) for f in file_data])
-    write_feather(table, str(path), compression="zstd")
+        @table_from_file(path)
+        class t(PatientFrame):
+            n = Series(int)
 
-    @table_from_file(path)
-    class t(PatientFrame):
-        n = Series(int)
+        spec_test(
+            table_data,
+            p.i1 + t.n,
+            {
+                1: 10 + 100,
+                2: None,
+                3: 30 + 300,
+            },
+        )
 
-    spec_test(
-        table_data,
-        p.i1 + t.n,
-        {
-            1: 10 + 100,
-            2: None,
-            3: 30 + 300,
-        },
-    )
+
+def test_table_from_arrow_file(spec_test):
+    with TemporaryDirectory() as td:
+        tmp_path = Path(td)
+        path = tmp_path / "test_table_from_file.arrow"
+
+        columns = ["patient_id", "n"]
+        table = pyarrow.Table.from_pylist([dict(zip(columns, f)) for f in file_data])
+        write_feather(table, str(path), compression="zstd")
+
+        @table_from_file(path)
+        class t(PatientFrame):
+            n = Series(int)
+
+        spec_test(
+            table_data,
+            p.i1 + t.n,
+            {
+                1: 10 + 100,
+                2: None,
+                3: 30 + 300,
+            },
+        )

--- a/tests/spec/table_from_file/test_table_from_file.py
+++ b/tests/spec/table_from_file/test_table_from_file.py
@@ -34,7 +34,7 @@ def test_table_from_file_csv(spec_test, tmp_path):
         writer.writerow(["patient_id", "n"])
         writer.writerows(file_data)
 
-    @table_from_file(str(path))
+    @table_from_file(path)
     class t(PatientFrame):
         n = Series(int)
 

--- a/tests/spec/toc.py
+++ b/tests/spec/toc.py
@@ -58,6 +58,9 @@ contents = {
     "population": [
         "test_population",
     ],
+    "table_from_file": [
+        "test_table_from_file",
+    ],
     "table_from_rows": [
         "test_table_from_rows",
     ],


### PR DESCRIPTION
Include previously-omitted `@table_from_file` in table of contents,
and make supporting changes to its tests and the doc generation.

The argument capturing used to generate docs from spec tests
is incompatible with the pytest `tmp_file` fixture as used previously.
Instead, a `TemporaryDirectory` from `tempfile` is used.

`build_paragraph()` changed to use regexes to handle variable levels
on indentation from the required `with` clause of this context manager.

Spec tests for `@table_from_file` renamed to look better in docs