### PR TITLE
Fix dummy data generation for InlinePatientTables

### DIFF
--- a/databuilder/dummy_data/generator.py
+++ b/databuilder/dummy_data/generator.py
@@ -24,16 +24,19 @@ get_regex_generator = functools.cache(create_regex_generator)
 
 
 class DummyDataGenerator:
-    # TODO: Make these user configurable. We're deliberately not doing this right now
-    # because we want to keep the API surface to zero in the early stages while we
-    # iterate on things.
-    population_size = 500
-    batch_size = 5000
-    random_seed = "BwRV3spP"
-    timeout = 60
-
-    def __init__(self, variable_definitions):
+    def __init__(
+        self,
+        variable_definitions,
+        population_size=500,
+        batch_size=5000,
+        random_seed="BwRV3spP",
+        timeout=60,
+    ):
         self.variable_definitions = variable_definitions
+        self.population_size = population_size
+        self.batch_size = batch_size
+        self.random_seed = random_seed
+        self.timeout = timeout
         self.patient_generator = DummyPatientGenerator(
             self.variable_definitions, self.random_seed
         )

--- a/databuilder/dummy_data/query_info.py
+++ b/databuilder/dummy_data/query_info.py
@@ -6,6 +6,7 @@ from databuilder.query_model.nodes import (
     Column,
     Constraint,
     Function,
+    InlinePatientTable,
     SelectColumn,
     SelectPatientTable,
     SelectTable,
@@ -118,6 +119,13 @@ class QueryInfo:
         # For every column used in the query (sorted for consistency) …
         for column in sort_by_name(by_type[SelectColumn]):
             table = get_root_frame(column.source)
+            # We're only interested in "standard" tables here
+            if isinstance(table, InlinePatientTable):
+                continue
+            elif isinstance(table, SelectTable | SelectPatientTable):
+                pass
+            else:
+                assert False
             name = column.name
             table_info = tables[table.name]
             column_info = table_info.columns.get(name)

--- a/tests/generative/test_query_model.py
+++ b/tests/generative/test_query_model.py
@@ -8,6 +8,7 @@ import hypothesis.strategies as st
 import pytest
 import sqlalchemy.exc
 
+from databuilder.dummy_data import DummyDataGenerator
 from databuilder.query_model.nodes import (
     Column,
     Function,
@@ -134,6 +135,12 @@ def setup_test(data, variable):
 
 def run_test(query_engines, data, variable, recorder):
     instances, variables = setup_test(data, variable)
+
+    # Test that we can successfully generate a minimal amount of dummy data
+    dummy_data_generator = DummyDataGenerator(
+        variables, population_size=1, batch_size=1, timeout=-1
+    )
+    assert len(dummy_data_generator.get_data()) > 0
 
     results = [
         (name, run_with(engine, instances, variables))

--- a/tests/unit/dummy_data/test_query_info.py
+++ b/tests/unit/dummy_data/test_query_info.py
@@ -4,7 +4,14 @@ from databuilder.codes import CTV3Code
 from databuilder.dummy_data.query_info import ColumnInfo, QueryInfo, TableInfo
 from databuilder.ehrql import Dataset, days
 from databuilder.query_language import compile
-from databuilder.tables import Constraint, EventFrame, PatientFrame, Series, table
+from databuilder.tables import (
+    Constraint,
+    EventFrame,
+    PatientFrame,
+    Series,
+    table,
+    table_from_rows,
+)
 
 
 @table
@@ -26,13 +33,21 @@ class events(EventFrame):
     code = Series(CTV3Code)
 
 
+@table_from_rows([])
+class inline_table(PatientFrame):
+    value = Series(int)
+
+
 def test_query_info_from_variable_definitions():
     dataset = Dataset()
     dataset.define_population(events.exists_for_patient())
     dataset.date_of_birth = patients.date_of_birth
     dataset.sex = patients.sex
-    variable_definitions = compile(dataset)
+    # We include this inline table in the dataset just to confirm that it is ignored by
+    # the query info inspection
+    dataset.value = inline_table.value
 
+    variable_definitions = compile(dataset)
     query_info = QueryInfo.from_variable_definitions(variable_definitions)
 
     assert query_info == QueryInfo(


### PR DESCRIPTION
As well as fixing the specific issue here this PR extends the generative tests so that they attempt to generate a minimal amount of dummy data for each query. As CI ensures that these tests produce at least one instance of every node type this gives us some assurance that the `QueryInfo` class which drives the dummy data generation can handle every node type. 