### PR TITLE
Assert `patient_id` not in `InlinePatientTable`

### DIFF
--- a/databuilder/query_model/nodes.py
+++ b/databuilder/query_model/nodes.py
@@ -199,6 +199,12 @@ class InlinePatientTable(OneRowPerPatientFrame):
     rows: Iterable[tuple]
     schema: TableSchema
 
+    def __post_init__(self):
+        assert (
+            "patient_id" not in self.schema.column_names
+        ), "patient_id is implicitly included and must not be explicitly specified"
+        return super().__post_init__()
+
 
 class SelectColumn(Series):
     source: Frame

--- a/tests/unit/query_model/test_nodes.py
+++ b/tests/unit/query_model/test_nodes.py
@@ -153,6 +153,17 @@ def test_inline_patient_table():
     i = SelectColumn(inline_table, "i")
     assert get_series_type(i) == int
 
+    # Check that attempting to construct an InlinePatientTable with an explicit definition
+    # for patient_id throws an error
+    with pytest.raises(
+        AssertionError,
+        match="patient_id is implicitly included and must not be explicitly specified",
+    ):
+        InlinePatientTable(
+            rows=IterWrapper([(1)]),
+            schema=TableSchema(patient_id=int),
+        )
+
 
 # TEST DOMAIN VALIDATION
 #


### PR DESCRIPTION
Ensure `InlinePatientTable`s cannot be defined (e.g via
`@table_from_file`) with a `patient_id` in their schema as this would
conflict with implicit `patient_id` field