### PR TITLE
Fix region name categories

### DIFF
--- a/databuilder/backends/tpp.py
+++ b/databuilder/backends/tpp.py
@@ -53,8 +53,8 @@ class TPPBackend(BaseBackend):
                 CAST(reg.StartDate AS date) AS start_date,
                 CAST(reg.EndDate AS date) AS end_date,
                 org.Organisation_ID AS practice_pseudo_id,
-                org.STPCode AS practice_stp,
-                org.Region AS practice_nuts1_region_name
+                NULLIF(org.STPCode, '') AS practice_stp,
+                NULLIF(org.Region, '') AS practice_nuts1_region_name
             FROM RegistrationHistory AS reg
             LEFT OUTER JOIN Organisation AS org
             ON reg.Organisation_ID = org.Organisation_ID

--- a/databuilder/tables/beta/tpp.py
+++ b/databuilder/tables/beta/tpp.py
@@ -80,18 +80,23 @@ class practice_registrations(EventFrame):
         constraints=[
             Constraint.Categorical(
                 [
-                    "East Midlands",
-                    "East of England",
-                    "London",
                     "North East",
                     "North West",
+                    "Yorkshire and The Humber",
+                    "East Midlands",
+                    "West Midlands",
+                    "East",
+                    "London",
                     "South East",
                     "South West",
-                    "West Midlands",
-                    "Yorkshire and the Humber",
                 ]
             ),
         ],
+        description=(
+            "Name of the NUTS level 1 region of England to which the practice belongs.\n"
+            "For more information see:\n"
+            "https://www.ons.gov.uk/methodology/geography/ukgeographies/eurostat"
+        ),
     )
 
     def for_patient_on(self, date):

--- a/tests/integration/backends/test_tpp.py
+++ b/tests/integration/backends/test_tpp.py
@@ -177,11 +177,18 @@ def test_practice_registrations(select_all):
     results = select_all(
         Patient(Patient_ID=1),
         Organisation(Organisation_ID=2, STPCode="abc", Region="def"),
+        Organisation(Organisation_ID=3, STPCode="", Region=""),
         RegistrationHistory(
             Patient_ID=1,
             StartDate=date(2010, 1, 1),
             EndDate=date(2020, 1, 1),
             Organisation_ID=2,
+        ),
+        RegistrationHistory(
+            Patient_ID=1,
+            StartDate=date(2020, 1, 1),
+            EndDate=date(2030, 1, 1),
+            Organisation_ID=3,
         ),
     )
     assert results == [
@@ -192,7 +199,15 @@ def test_practice_registrations(select_all):
             "practice_pseudo_id": 2,
             "practice_stp": "abc",
             "practice_nuts1_region_name": "def",
-        }
+        },
+        {
+            "patient_id": 1,
+            "start_date": date(2020, 1, 1),
+            "end_date": date(2030, 1, 1),
+            "practice_pseudo_id": 3,
+            "practice_stp": None,
+            "practice_nuts1_region_name": None,
+        },
     ]
 
 


### PR DESCRIPTION
The previous values didn't match what's actually in the database. Specifically:

    East of England -> East
    Yorkshire and the Humber -> Yorkshire and The Humber

We also change the order to match the order in which the ONS list these regions (because we might as well) and add some minimal documentation.

The reason these incorrect names crept it was that although Eurostat and the ONS use the same regional divisions they have _very_ slightly different labelling. And I must have copied the Eurostat names in early in the development process without checking against the database.

For reference, here are the ONS names:
https://www.ons.gov.uk/methodology/geography/ukgeographies/eurostat

And here are the Eurostat ones:
https://ec.europa.eu/eurostat/documents/345175/7451602/nuts-map-UK.pdf

In addition, we now convert empty region/STP values to NULL. For the region variable this is important because it is typed as a categorical and the empty string is not one of the defined categories. This means a file format which is strict about categories (like Arrow) won't be able to store this value.

As STP is typed as a string this is less critical but we do it for consistency and also because the empty string does not match the regex which we define for the column.

These changes were prompted by a question in Slack here:
https://bennettoxford.slack.com/archives/C04DVD1UQC9/p1681398814141149